### PR TITLE
Fix SimDeck action PR comment permissions

### DIFF
--- a/docs/guide/github-actions.md
+++ b/docs/guide/github-actions.md
@@ -62,7 +62,7 @@ permissions:
   actions: read
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: simdeck-ios-pr-${{ github.event.issue.number }}


### PR DESCRIPTION
The live downstream test showed GitHub returns 403 when the caller workflow only grants pull-requests: read. The session action posts PR issue comments, so the integration docs need pull-requests: write alongside issues: write.\n\nValidation:\n- Prettier check on docs/guide/github-actions.md\n- git diff --check