### PR TITLE
Improve Apple Watch chrome rendering and HID button coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ Private simulator behavior is implemented locally in:
 - Accessibility bridge: `cli/XCWAccessibilityBridge.*`
 
 The current repo uses the private boot path, private display bridge, and private accessibility translation bridge directly. The browser streams frames from that bridge, injects touch and keyboard events through the same native session layer, inspects accessibility through `AccessibilityPlatformTranslation`, and renders device chrome from `cli/XCWChromeRenderer.*`.
-Physical chrome button support uses DeviceKit `chrome.json` input geometry for browser hit targets. Volume, action, mute, Apple Watch digital crown, Watch side button, and Watch left-side button dispatch through `IndigoHIDMessageForHIDArbitrary` with consumer/telephony/vendor HID usage pairs from the device chrome metadata; home, lock, and app-switcher remain on the existing SimulatorKit button paths.
+Physical chrome button support uses DeviceKit `chrome.json` input geometry for browser hit targets. Volume, action, mute, Apple Watch digital crown, Watch side button, and Watch left-side button dispatch through `IndigoHIDMessageForHIDArbitrary` with consumer/telephony/vendor HID usage pairs from the device chrome metadata; home, lock, and app-switcher remain on the existing SimulatorKit button paths. Apple Watch Digital Crown rotation dispatches through `IndigoHIDMessageForScrollEvent` with the same digitizer target as touch input.
 WebKit inspection uses the simulator `webinspectord` Unix socket named `com.apple.webinspectord_sim.socket` and WebKit's binary-plist Remote Inspector selectors. It lists only WebKit content that the runtime exposes as inspectable. For app-owned `WKWebView` on iOS 16.4 and newer, the app must set `isInspectable = true`.
 
 ## Build and Run

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ Private simulator behavior is implemented locally in:
 - Accessibility bridge: `cli/XCWAccessibilityBridge.*`
 
 The current repo uses the private boot path, private display bridge, and private accessibility translation bridge directly. The browser streams frames from that bridge, injects touch and keyboard events through the same native session layer, inspects accessibility through `AccessibilityPlatformTranslation`, and renders device chrome from `cli/XCWChromeRenderer.*`.
-Physical chrome button support uses DeviceKit `chrome.json` input geometry for browser hit targets. Volume, action, and mute buttons dispatch through `IndigoHIDMessageForHIDArbitrary` with consumer/telephony HID usage pairs from the device chrome metadata; home, lock, and app-switcher remain on the existing SimulatorKit button paths.
+Physical chrome button support uses DeviceKit `chrome.json` input geometry for browser hit targets. Volume, action, mute, Apple Watch digital crown, Watch side button, and Watch left-side button dispatch through `IndigoHIDMessageForHIDArbitrary` with consumer/telephony/vendor HID usage pairs from the device chrome metadata; home, lock, and app-switcher remain on the existing SimulatorKit button paths.
 WebKit inspection uses the simulator `webinspectord` Unix socket named `com.apple.webinspectord_sim.socket` and WebKit's binary-plist Remote Inspector selectors. It lists only WebKit content that the runtime exposes as inspectable. For app-owned `WKWebView` on iOS 16.4 and newer, the app must set `isInspectable = true`.
 
 ## Build and Run

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ simdeck button <udid> lock --duration-ms 1000
 simdeck button <udid> volume-up
 simdeck button <udid> action --duration-ms 1000
 simdeck button <udid> digital-crown
+simdeck crown <udid> --delta 50
 simdeck button <udid> left-side-button
 simdeck batch <udid> --step "tap --label Continue" --step "type 'hello'" --step "wait-for --label hello"
 simdeck dismiss-keyboard <udid>

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ simdeck type <udid> --file message.txt
 simdeck button <udid> lock --duration-ms 1000
 simdeck button <udid> volume-up
 simdeck button <udid> action --duration-ms 1000
+simdeck button <udid> digital-crown
+simdeck button <udid> left-side-button
 simdeck batch <udid> --step "tap --label Continue" --step "type 'hello'" --step "wait-for --label hello"
 simdeck dismiss-keyboard <udid>
 simdeck home <udid>

--- a/cli/DFPrivateSimulatorDisplayBridge.h
+++ b/cli/DFPrivateSimulatorDisplayBridge.h
@@ -85,6 +85,8 @@ NS_SWIFT_NAME(PrivateSimulatorDisplayBridge)
                        usagePage:(nullable NSNumber *)usagePage
                            usage:(nullable NSNumber *)usage
                            error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(sendHardwareButton(named:pressed:usagePage:usage:));
+- (BOOL)rotateDigitalCrownByDelta:(double)delta
+                             error:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(rotateDigitalCrown(delta:));
 
 - (BOOL)rotateRight:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(rotateRight());
 - (BOOL)rotateLeft:(NSError * _Nullable * _Nullable)error NS_SWIFT_NAME(rotateLeft());

--- a/cli/DFPrivateSimulatorDisplayBridge.m
+++ b/cli/DFPrivateSimulatorDisplayBridge.m
@@ -38,6 +38,7 @@ typedef IndigoHIDMessage *(*DFIndigoHIDMessageForKeyboardArbitraryFn)(int keyCod
 typedef IndigoHIDMessage *(*DFIndigoHIDMessageForKeyboardNSEventFn)(NSEvent *event);
 typedef IndigoHIDMessage *(*DFIndigoHIDMessageForButtonFn)(uint32_t buttonCode, uint32_t operation, uint32_t target);
 typedef IndigoHIDMessage *(*DFIndigoHIDMessageForHIDArbitraryFn)(uint32_t target, uint32_t page, uint32_t usage, uint32_t operation);
+typedef IndigoHIDMessage *(*DFIndigoHIDMessageForScrollEventFn)(uint32_t target, double deltaX, double deltaY, double momentumPhase);
 typedef IndigoHIDMessage *(*DFIndigoHIDServiceMessageFn)(void);
 
 #pragma pack(push, 4)
@@ -1425,6 +1426,29 @@ static IndigoHIDMessage *DFCreateArbitraryHIDMessage(uint32_t target, uint32_t p
         *error = DFMakeError(
             DFPrivateSimulatorErrorCodeTouchDispatchFailed,
             [NSString stringWithFormat:@"SimulatorKit could not construct arbitrary HID for page 0x%x usage 0x%x.", page, usage]
+        );
+    }
+
+    return message;
+}
+
+static IndigoHIDMessage *DFCreateScrollHIDMessage(uint32_t target, double deltaX, double deltaY, NSError **error) {
+    DFIndigoHIDMessageForScrollEventFn scrollMessage = (DFIndigoHIDMessageForScrollEventFn)dlsym(RTLD_DEFAULT, "IndigoHIDMessageForScrollEvent");
+    if (scrollMessage == NULL) {
+        if (error != NULL) {
+            *error = DFMakeError(
+                DFPrivateSimulatorErrorCodeTouchDispatchFailed,
+                @"SimulatorKit did not expose IndigoHIDMessageForScrollEvent."
+            );
+        }
+        return NULL;
+    }
+
+    IndigoHIDMessage *message = scrollMessage(target, deltaX, deltaY, 0);
+    if (message == NULL && error != NULL) {
+        *error = DFMakeError(
+            DFPrivateSimulatorErrorCodeTouchDispatchFailed,
+            [NSString stringWithFormat:@"SimulatorKit could not construct scroll HID for delta %.3f.", deltaY]
         );
     }
 
@@ -3491,6 +3515,57 @@ static BOOL DFOpenAppSwitcherViaHIDClient(id hidClient, NSError **error) {
         *error = dispatchError ?: DFMakeError(
             DFPrivateSimulatorErrorCodeTouchDispatchFailed,
             [NSString stringWithFormat:@"SimulatorKit rejected hardware button `%@` %@.", buttonName ?: @"", pressed ? @"down" : @"up"]
+        );
+    }
+
+    return success;
+}
+
+- (BOOL)rotateDigitalCrownByDelta:(double)delta
+                             error:(NSError * _Nullable __autoreleasing *)error {
+    if (!isfinite(delta)) {
+        if (error != NULL) {
+            *error = DFMakeError(
+                DFPrivateSimulatorErrorCodeTouchDispatchFailed,
+                @"Digital Crown delta must be finite."
+            );
+        }
+        return NO;
+    }
+
+    __block BOOL success = NO;
+    __block NSError *dispatchError = nil;
+
+    dispatch_block_t work = ^{
+        if (self->_hidClient == nil) {
+            dispatchError = DFMakeError(
+                DFPrivateSimulatorErrorCodeTouchDispatchFailed,
+                @"SimulatorKit did not provide a headless HID client for Digital Crown rotation."
+            );
+            return;
+        }
+
+        NSError *messageError = nil;
+        IndigoHIDMessage *message = DFCreateScrollHIDMessage(DFIndigoTouchTarget, 0, delta, &messageError);
+        if (message == NULL || !DFSendHIDMessage(self->_hidClient, message, YES, &messageError)) {
+            dispatchError = messageError;
+            return;
+        }
+
+        DFLog(@"Sending Digital Crown rotation delta=%.3f", delta);
+        success = YES;
+    };
+
+    if (dispatch_get_specific(DFPrivateSimulatorCallbackQueueKey) != NULL) {
+        work();
+    } else {
+        dispatch_sync(_callbackQueue, work);
+    }
+
+    if (!success && error != NULL) {
+        *error = dispatchError ?: DFMakeError(
+            DFPrivateSimulatorErrorCodeTouchDispatchFailed,
+            @"SimulatorKit rejected Digital Crown rotation."
         );
     }
 

--- a/cli/DFPrivateSimulatorDisplayBridge.m
+++ b/cli/DFPrivateSimulatorDisplayBridge.m
@@ -3415,6 +3415,9 @@ static BOOL DFOpenAppSwitcherViaHIDClient(id hidClient, NSError **error) {
             @"volume-down": @[ @(DFConsumerControlUsagePage), @234 ],
             @"action": @[ @(0x0b), @45 ],
             @"mute": @[ @(0x0b), @46 ],
+            @"digital-crown": @[ @(DFConsumerControlUsagePage), @64 ],
+            @"side-button": @[ @(DFConsumerControlUsagePage), @149 ],
+            @"left-side-button": @[ @(0xff01), @512 ],
         };
     });
 

--- a/cli/XCWChromeRenderer.m
+++ b/cli/XCWChromeRenderer.m
@@ -12,6 +12,7 @@ static NSString * const XCWChromeRendererErrorDomain = @"SimDeck.ChromeRenderer"
 + (nullable NSDictionary *)inputNamed:(NSString *)buttonName
                          chromeInfo:(NSDictionary *)chromeInfo
                               error:(NSError * _Nullable __autoreleasing *)error;
++ (NSEdgeInsets)devicePaddingForChromeInfo:(NSDictionary *)chromeInfo;
 @end
 
 @implementation XCWChromeRenderer
@@ -665,6 +666,14 @@ static NSString * const XCWChromeRendererErrorDomain = @"SimDeck.ChromeRenderer"
 
 + (CGRect)fullFrameForChromeInfo:(NSDictionary *)chromeInfo
                        chromeSize:(CGSize)chromeSize {
+    NSEdgeInsets padding = [self devicePaddingForChromeInfo:chromeInfo];
+    if (padding.top != 0.0 || padding.left != 0.0 || padding.bottom != 0.0 || padding.right != 0.0) {
+        return CGRectMake(-padding.left,
+                          -padding.top,
+                          chromeSize.width + padding.left + padding.right,
+                          chromeSize.height + padding.top + padding.bottom);
+    }
+
     CGRect bounds = CGRectMake(0.0, 0.0, chromeSize.width, chromeSize.height);
     NSDictionary *json = chromeInfo[@"json"];
     NSString *chromePath = chromeInfo[@"chromePath"];
@@ -712,53 +721,83 @@ static NSString * const XCWChromeRendererErrorDomain = @"SimDeck.ChromeRenderer"
                       inSize:(CGSize)size
                   offsetName:(NSString *)offsetName {
     NSDictionary *offsets = [input[@"offsets"] isKindOfClass:[NSDictionary class]] ? input[@"offsets"] : @{};
-    NSDictionary *requestedOffset = [offsets[offsetName] isKindOfClass:[NSDictionary class]] ? offsets[offsetName] : nil;
     NSDictionary *normalOffset = [offsets[@"normal"] isKindOfClass:[NSDictionary class]] ? offsets[@"normal"] : nil;
     NSDictionary *rolloverOffset = [offsets[@"rollover"] isKindOfClass:[NSDictionary class]] ? offsets[@"rollover"] : nil;
-    NSDictionary *offset = requestedOffset ?: rolloverOffset ?: normalOffset ?: @{};
-    CGFloat offsetX = [self numberValue:offset[@"x"]];
-    CGFloat offsetY = [self numberValue:offset[@"y"]];
+    NSDictionary *requestedOffset = [offsets[offsetName] isKindOfClass:[NSDictionary class]] ? offsets[offsetName] : nil;
+    NSDictionary *primaryOffset = normalOffset ?: rolloverOffset ?: requestedOffset ?: @{};
+    NSDictionary *secondaryOffset = rolloverOffset ?: normalOffset ?: requestedOffset ?: @{};
+    CGFloat normalX = [self numberValue:primaryOffset[@"x"]];
+    CGFloat normalY = [self numberValue:primaryOffset[@"y"]];
+    CGFloat rolloverX = [self numberValue:secondaryOffset[@"x"]];
+    CGFloat rolloverY = [self numberValue:secondaryOffset[@"y"]];
+    CGFloat restX = normalX;
+    CGFloat restY = normalY;
     NSString *anchor = [input[@"anchor"] isKindOfClass:[NSString class]] ? input[@"anchor"] : @"";
     NSString *align = [input[@"align"] isKindOfClass:[NSString class]] ? input[@"align"] : @"";
 
-    CGFloat x = offsetX - (assetSize.width / 2.0);
-    CGFloat y = offsetY;
+    if ([offsetName isEqualToString:@"rollover"]) {
+        restX = rolloverX;
+        restY = rolloverY;
+    } else if ([anchor isEqualToString:@"left"]) {
+        restX = rolloverX;
+        restY = rolloverY;
+    } else if ([anchor isEqualToString:@"right"] ||
+               [anchor isEqualToString:@"top"] ||
+               [anchor isEqualToString:@"bottom"]) {
+        restX = (2.0 * normalX) - rolloverX;
+        restY = (2.0 * normalY) - rolloverY;
+    }
+
+    CGFloat x = restX - (assetSize.width / 2.0);
+    CGFloat y = restY;
     if ([anchor isEqualToString:@"left"]) {
-        x = offsetX - (assetSize.width / 2.0);
+        x = restX - (assetSize.width / 2.0);
     } else if ([anchor isEqualToString:@"right"]) {
-        x = size.width + offsetX - (assetSize.width / 2.0);
+        x = size.width + restX;
+        y = restY;
     } else if ([anchor isEqualToString:@"top"]) {
-        y = offsetY;
+        if ([align isEqualToString:@"trailing"]) {
+            x = size.width + restX - assetSize.width;
+        } else {
+            x = restX;
+        }
+        y = restY - assetSize.height;
     } else if ([anchor isEqualToString:@"bottom"]) {
-        y = size.height + offsetY;
+        if ([align isEqualToString:@"trailing"]) {
+            x = size.width + restX - assetSize.width;
+        } else {
+            x = restX;
+        }
+        y = size.height + restY;
     }
 
     if ([anchor isEqualToString:@"left"] || [anchor isEqualToString:@"right"]) {
         if ([align isEqualToString:@"center"]) {
-            y = (size.height - assetSize.height) / 2.0 + offsetY;
+            y = (size.height - assetSize.height) / 2.0 + restY;
         } else if ([align isEqualToString:@"trailing"]) {
-            y = size.height - assetSize.height + offsetY;
+            y = size.height - assetSize.height + restY;
         }
     } else if ([anchor isEqualToString:@"top"] || [anchor isEqualToString:@"bottom"]) {
-        CGFloat baseX = 0.0;
         if ([align isEqualToString:@"center"]) {
-            baseX = size.width / 2.0;
-        } else if ([align isEqualToString:@"trailing"]) {
-            baseX = size.width;
-        }
-        x = baseX + offsetX - (assetSize.width / 2.0);
-        if ([align isEqualToString:@"center"]) {
-            x = (size.width / 2.0) + offsetX - (assetSize.width / 2.0);
-        } else if ([align isEqualToString:@"trailing"]) {
-            x = size.width + offsetX - (assetSize.width / 2.0);
+            x = (size.width / 2.0) + restX - (assetSize.width / 2.0);
         }
     } else if ([align isEqualToString:@"center"]) {
-        x = (size.width - assetSize.width) / 2.0 + offsetX;
+        x = (size.width - assetSize.width) / 2.0 + restX;
     } else if ([align isEqualToString:@"trailing"]) {
-        x = size.width - assetSize.width + offsetX;
+        x = size.width - assetSize.width + restX;
     }
 
     return CGRectMake(x, y, assetSize.width, assetSize.height);
+}
+
++ (NSEdgeInsets)devicePaddingForChromeInfo:(NSDictionary *)chromeInfo {
+    NSDictionary *json = chromeInfo[@"json"];
+    NSDictionary *images = [json[@"images"] isKindOfClass:[NSDictionary class]] ? json[@"images"] : @{};
+    NSDictionary *padding = [images[@"devicePadding"] isKindOfClass:[NSDictionary class]] ? images[@"devicePadding"] : @{};
+    return NSEdgeInsetsMake([self numberValue:padding[@"top"]],
+                            [self numberValue:padding[@"left"]],
+                            [self numberValue:padding[@"bottom"]],
+                            [self numberValue:padding[@"right"]]);
 }
 
 + (NSArray<NSDictionary<NSString *, id> *> *)buttonProfilesForChromeInfo:(NSDictionary *)chromeInfo

--- a/cli/XCWPrivateSimulatorSession.h
+++ b/cli/XCWPrivateSimulatorSession.h
@@ -66,6 +66,8 @@ typedef void (^XCWPrivateSimulatorEncodedFrameHandler)(NSData *sampleData,
                        usagePage:(nullable NSNumber *)usagePage
                            usage:(nullable NSNumber *)usage
                            error:(NSError * _Nullable * _Nullable)error;
+- (BOOL)rotateDigitalCrownByDelta:(double)delta
+                             error:(NSError * _Nullable * _Nullable)error;
 - (BOOL)openAppSwitcher:(NSError * _Nullable * _Nullable)error;
 - (BOOL)rotateRight:(NSError * _Nullable * _Nullable)error;
 - (BOOL)rotateLeft:(NSError * _Nullable * _Nullable)error;

--- a/cli/XCWPrivateSimulatorSession.m
+++ b/cli/XCWPrivateSimulatorSession.m
@@ -361,6 +361,11 @@ static NSString * const XCWPrivateSimulatorSessionErrorDomain = @"SimDeck.Privat
                                              error:error];
 }
 
+- (BOOL)rotateDigitalCrownByDelta:(double)delta
+                             error:(NSError * _Nullable __autoreleasing *)error {
+    return [_displayBridge rotateDigitalCrownByDelta:delta error:error];
+}
+
 - (BOOL)openAppSwitcher:(NSError * _Nullable __autoreleasing *)error {
     return [_displayBridge openAppSwitcher:error];
 }

--- a/cli/native/XCWNativeBridge.h
+++ b/cli/native/XCWNativeBridge.h
@@ -53,6 +53,7 @@ bool xcw_native_press_home(const char * _Nonnull udid, char * _Nullable * _Nulla
 bool xcw_native_open_app_switcher(const char * _Nonnull udid, char * _Nullable * _Nullable error_message);
 bool xcw_native_press_button(const char * _Nonnull udid, const char * _Nonnull button_name, uint32_t duration_ms, char * _Nullable * _Nullable error_message);
 bool xcw_native_send_button(const char * _Nonnull udid, const char * _Nonnull button_name, bool pressed, bool has_usage, uint32_t usage_page, uint32_t usage, char * _Nullable * _Nullable error_message);
+bool xcw_native_rotate_crown(const char * _Nonnull udid, double delta, char * _Nullable * _Nullable error_message);
 bool xcw_native_rotate_right(const char * _Nonnull udid, char * _Nullable * _Nullable error_message);
 bool xcw_native_rotate_left(const char * _Nonnull udid, char * _Nullable * _Nullable error_message);
 bool xcw_native_erase_simulator(const char * _Nonnull udid, char * _Nullable * _Nullable error_message);
@@ -84,6 +85,7 @@ bool xcw_native_session_send_key(void * _Nonnull handle, uint16_t key_code, uint
 bool xcw_native_session_press_home(void * _Nonnull handle, char * _Nullable * _Nullable error_message);
 bool xcw_native_session_press_button(void * _Nonnull handle, const char * _Nonnull button_name, uint32_t duration_ms, char * _Nullable * _Nullable error_message);
 bool xcw_native_session_send_button(void * _Nonnull handle, const char * _Nonnull button_name, bool pressed, bool has_usage, uint32_t usage_page, uint32_t usage, char * _Nullable * _Nullable error_message);
+bool xcw_native_session_rotate_crown(void * _Nonnull handle, double delta, char * _Nullable * _Nullable error_message);
 bool xcw_native_session_open_app_switcher(void * _Nonnull handle, char * _Nullable * _Nullable error_message);
 bool xcw_native_session_rotate_right(void * _Nonnull handle, char * _Nullable * _Nullable error_message);
 bool xcw_native_session_rotate_left(void * _Nonnull handle, char * _Nullable * _Nullable error_message);

--- a/cli/native/XCWNativeBridge.m
+++ b/cli/native/XCWNativeBridge.m
@@ -761,6 +761,22 @@ bool xcw_native_send_button(const char *udid, const char *button_name, bool pres
     }
 }
 
+bool xcw_native_rotate_crown(const char *udid, double delta, char **error_message) {
+    @autoreleasepool {
+        DFPrivateSimulatorDisplayBridge *bridge = XCWInputBridgeForUDID(udid, error_message);
+        if (bridge == nil) {
+            return false;
+        }
+        NSError *error = nil;
+        BOOL ok = [bridge rotateDigitalCrownByDelta:delta error:&error];
+        [bridge disconnect];
+        if (!ok) {
+            XCWSetErrorMessage(error_message, error);
+        }
+        return ok;
+    }
+}
+
 bool xcw_native_rotate_right(const char *udid, char **error_message) {
     @autoreleasepool {
         DFPrivateSimulatorDisplayBridge *bridge = XCWInputBridgeForUDID(udid, error_message);
@@ -1025,6 +1041,17 @@ bool xcw_native_session_send_button(void *handle, const char *button_name, bool 
                                                                     usagePage:has_usage ? @(usage_page) : nil
                                                                         usage:has_usage ? @(usage) : nil
                                                                         error:&error];
+        if (!ok) {
+            XCWSetErrorMessage(error_message, error);
+        }
+        return ok;
+    }
+}
+
+bool xcw_native_session_rotate_crown(void *handle, double delta, char **error_message) {
+    @autoreleasepool {
+        NSError *error = nil;
+        BOOL ok = [XCWNativeSessionFromHandle(handle) rotateDigitalCrownByDelta:delta error:&error];
         if (!ok) {
             XCWSetErrorMessage(error_message, error);
         }

--- a/cli/native/XCWNativeSession.h
+++ b/cli/native/XCWNativeSession.h
@@ -44,6 +44,8 @@ NS_ASSUME_NONNULL_BEGIN
                        usagePage:(nullable NSNumber *)usagePage
                            usage:(nullable NSNumber *)usage
                            error:(NSError * _Nullable * _Nullable)error;
+- (BOOL)rotateDigitalCrownByDelta:(double)delta
+                             error:(NSError * _Nullable * _Nullable)error;
 - (BOOL)openAppSwitcher:(NSError * _Nullable * _Nullable)error;
 - (BOOL)rotateRight:(NSError * _Nullable * _Nullable)error;
 - (BOOL)rotateLeft:(NSError * _Nullable * _Nullable)error;

--- a/cli/native/XCWNativeSession.m
+++ b/cli/native/XCWNativeSession.m
@@ -171,6 +171,11 @@ static xcw_native_shared_bytes XCWSharedBytesFromData(NSData *data) {
                                            error:error];
 }
 
+- (BOOL)rotateDigitalCrownByDelta:(double)delta
+                             error:(NSError * _Nullable __autoreleasing *)error {
+    return [self.session rotateDigitalCrownByDelta:delta error:error];
+}
+
 - (BOOL)openAppSwitcher:(NSError * _Nullable __autoreleasing *)error {
     return [self.session openAppSwitcher:error];
 }

--- a/client/src/api/controls.ts
+++ b/client/src/api/controls.ts
@@ -2,6 +2,7 @@ import { accessTokenFromLocation, apiRequest } from "./client";
 import { apiUrl } from "./config";
 import type {
   ButtonPayload,
+  CrownPayload,
   EdgeTouchPayload,
   KeyPayload,
   LaunchPayload,
@@ -18,6 +19,7 @@ export type ControlMessage =
   | ({ type: "multiTouch" } & MultiTouchPayload)
   | ({ type: "key" } & KeyPayload)
   | ({ type: "button" } & ButtonPayload)
+  | ({ type: "crown" } & CrownPayload)
   | { type: "dismissKeyboard" }
   | { type: "home" }
   | { type: "appSwitcher" }
@@ -30,6 +32,7 @@ async function postSimulatorAction(
   action: string,
   payload?:
     | ButtonPayload
+    | CrownPayload
     | KeyPayload
     | LaunchPayload
     | OpenUrlPayload
@@ -97,6 +100,10 @@ export function pressHome(udid: string) {
 
 export function pressSimulatorButton(udid: string, payload: ButtonPayload) {
   return postSimulatorAction(udid, "button", payload);
+}
+
+export function rotateDigitalCrown(udid: string, payload: CrownPayload) {
+  return postSimulatorAction(udid, "crown", payload);
 }
 
 export function openAppSwitcher(udid: string) {

--- a/client/src/api/types.ts
+++ b/client/src/api/types.ts
@@ -314,6 +314,10 @@ export interface ButtonPayload {
   usage?: number;
 }
 
+export interface CrownPayload {
+  delta: number;
+}
+
 export interface LaunchPayload {
   bundleId: string;
 }

--- a/client/src/app/AppShell.tsx
+++ b/client/src/app/AppShell.tsx
@@ -23,6 +23,7 @@ import {
   openSimulatorUrl,
   pressHome,
   pressSimulatorButton,
+  rotateDigitalCrown,
   rotateRight,
   simulatorControlSocketUrl,
   shutdownSimulator,
@@ -750,11 +751,18 @@ export function AppShell({
   const chromeHasInteractiveButtons = Boolean(
     viewportChromeProfile?.buttons?.length,
   );
+  const chromeHasCrown = Boolean(
+    viewportChromeProfile?.buttons?.some(
+      (button) =>
+        button.type?.toLowerCase() === "crown" ||
+        button.name.toLowerCase() === "digital-crown",
+    ),
+  );
   const chromeUrl = selectedSimulator
     ? buildChromeUrl(
         selectedSimulator.udid,
         streamStamp,
-        !chromeHasInteractiveButtons,
+        !chromeHasInteractiveButtons || chromeHasCrown,
       )
     : "";
   const chromeButtonUrl = useCallback(
@@ -1664,6 +1672,11 @@ export function AppShell({
       return;
     }
 
+    if (chromeHasCrown && selectedSimulator.isBooted) {
+      sendCrownRotation(deltaY);
+      return;
+    }
+
     setViewMode("manual");
     setPan((currentPan) =>
       clampPan(
@@ -1831,6 +1844,25 @@ export function AppShell({
             usagePage,
             usage,
           }),
+        false,
+      );
+    }
+  }
+
+  function sendCrownRotation(delta: number) {
+    if (!selectedSimulator || !Number.isFinite(delta) || delta === 0) {
+      return;
+    }
+    setAccessibilitySelectedId("");
+    setAccessibilityHoveredId(null);
+    if (
+      !sendControl(selectedSimulator.udid, {
+        type: "crown",
+        delta,
+      })
+    ) {
+      void runAction(
+        () => rotateDigitalCrown(selectedSimulator.udid, { delta }),
         false,
       );
     }

--- a/client/src/features/viewport/DeviceChrome.tsx
+++ b/client/src/features/viewport/DeviceChrome.tsx
@@ -309,8 +309,8 @@ function ChromeButtonHitTarget({
     "--button-rest-y": "0%",
     "--button-hover-x": `${(rolloverDelta.x / Math.max(button.width, 1)) * 100}%`,
     "--button-hover-y": `${(rolloverDelta.y / Math.max(button.height, 1)) * 100}%`,
-    "--button-pressed-x": `${((-rolloverDelta.x) / Math.max(button.width, 1)) * 100}%`,
-    "--button-pressed-y": `${((-rolloverDelta.y) / Math.max(button.height, 1)) * 100}%`,
+    "--button-pressed-x": `${(-rolloverDelta.x / Math.max(button.width, 1)) * 100}%`,
+    "--button-pressed-y": `${(-rolloverDelta.y / Math.max(button.height, 1)) * 100}%`,
   } as CSSProperties &
     Record<
       | "--button-rest-x"

--- a/client/src/features/viewport/DeviceChrome.tsx
+++ b/client/src/features/viewport/DeviceChrome.tsx
@@ -201,11 +201,13 @@ export function DeviceChrome({
 
 const CHROME_BUTTON_WIRE_NAMES: Record<string, string> = {
   action: "action",
+  "digital-crown": "digital-crown",
   home: "home",
+  "left-side-button": "left-side-button",
   lock: "power",
   mute: "mute",
   power: "power",
-  "side-button": "power",
+  "side-button": "side-button",
   "volume-down": "volume-down",
   "volume-up": "volume-up",
 };
@@ -303,16 +305,20 @@ function ChromeButtonHitTarget({
     left: `${(button.x / totalWidth) * 100}%`,
     top: `${(button.y / totalHeight) * 100}%`,
     width: `${(button.width / totalWidth) * 100}%`,
-    "--button-rest-x": `${(rolloverDelta.x / Math.max(button.width, 1)) * 100}%`,
-    "--button-rest-y": `${(rolloverDelta.y / Math.max(button.height, 1)) * 100}%`,
-    "--button-hover-x": `${((rolloverDelta.x * 2) / Math.max(button.width, 1)) * 100}%`,
-    "--button-hover-y": `${((rolloverDelta.y * 2) / Math.max(button.height, 1)) * 100}%`,
+    "--button-rest-x": "0%",
+    "--button-rest-y": "0%",
+    "--button-hover-x": `${(rolloverDelta.x / Math.max(button.width, 1)) * 100}%`,
+    "--button-hover-y": `${(rolloverDelta.y / Math.max(button.height, 1)) * 100}%`,
+    "--button-pressed-x": `${((-rolloverDelta.x) / Math.max(button.width, 1)) * 100}%`,
+    "--button-pressed-y": `${((-rolloverDelta.y) / Math.max(button.height, 1)) * 100}%`,
   } as CSSProperties &
     Record<
       | "--button-rest-x"
       | "--button-rest-y"
       | "--button-hover-x"
-      | "--button-hover-y",
+      | "--button-hover-y"
+      | "--button-pressed-x"
+      | "--button-pressed-y",
       string
     >;
 

--- a/client/src/styles/components.css
+++ b/client/src/styles/components.css
@@ -142,7 +142,7 @@
   padding: 6px;
   border: 1px solid var(--border);
   border-radius: 10px;
-  background: color-mix(in srgb, var(--surface) 94%, transparent);
+  background: var(--zoom-toolbar-bg);
   box-shadow: 0 12px 24px rgba(0, 0, 0, 0.2);
   backdrop-filter: blur(10px);
 }

--- a/client/src/styles/components.css
+++ b/client/src/styles/components.css
@@ -1575,7 +1575,11 @@
 
 .device-chrome-button:active,
 .device-chrome-button.is-pressed {
-  transform: translate3d(var(--button-rest-x, 0), var(--button-rest-y, 0), 0);
+  transform: translate3d(
+    var(--button-pressed-x, var(--button-rest-x, 0)),
+    var(--button-pressed-y, var(--button-rest-y, 0)),
+    0
+  );
 }
 
 .pan-enabled .device-bezel,

--- a/client/src/styles/tokens.css
+++ b/client/src/styles/tokens.css
@@ -1,9 +1,10 @@
 :root {
   color-scheme: light dark;
-  --bg: #1e1e1e;
+  --bg: #181818;
   --surface: #252526;
   --surface-hover: #2d2d2e;
-  --toolbar-bg: var(--surface);
+  --toolbar-bg: #181818;
+  --zoom-toolbar-bg: #2d2d2d;
   --toolbar-shadow: none;
   --border: #3c3c3c;
   --border-subtle: #333333;
@@ -28,6 +29,7 @@
     --surface: #ffffff;
     --surface-hover: #f5f5f5;
     --toolbar-bg: #ffffff;
+    --zoom-toolbar-bg: #ffffff;
     --toolbar-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
     --border: #e3e3e3;
     --border-subtle: #eeeeee;

--- a/docs/api/rest.md
+++ b/docs/api/rest.md
@@ -382,8 +382,8 @@ Content-Type: application/json
 
 Supported button names match the CLI and chrome controls: `home`, `lock`,
 `power`, `side-button`, `volume-up`, `volume-down`, `action`, `mute`,
-`app-switcher`, `siri`, and `apple-pay`. `durationMs` defaults to `0` and is
-used for press-and-hold interactions.
+`digital-crown`, `left-side-button`, `app-switcher`, `siri`, and `apple-pay`.
+`durationMs` defaults to `0` and is used for press-and-hold interactions.
 
 For live chrome interactions, send explicit button edges instead of a completed
 press:

--- a/docs/api/rest.md
+++ b/docs/api/rest.md
@@ -396,6 +396,20 @@ press:
 may also pass `usagePage` and `usage` from the device profile when an exact HID
 usage is available.
 
+### `POST /api/simulators/{udid}/crown`
+
+Rotates the Apple Watch Digital Crown using scroll delta semantics:
+
+```http
+POST /api/simulators/{udid}/crown
+Content-Type: application/json
+
+{ "delta": 50 }
+```
+
+The browser UI sends this automatically when scrolling over a Watch screen or
+crown chrome.
+
 ### `POST /api/simulators/{udid}/home`
 
 Presses the home button:

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -239,6 +239,7 @@ simdeck button <udid> lock --duration-ms 1000
 simdeck button <udid> volume-up
 simdeck button <udid> action --duration-ms 1000
 simdeck button <udid> digital-crown
+simdeck crown <udid> --delta 50
 simdeck button <udid> left-side-button
 simdeck dismiss-keyboard <udid>
 simdeck home <udid>

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -238,6 +238,8 @@ simdeck type <udid> --file message.txt
 simdeck button <udid> lock --duration-ms 1000
 simdeck button <udid> volume-up
 simdeck button <udid> action --duration-ms 1000
+simdeck button <udid> digital-crown
+simdeck button <udid> left-side-button
 simdeck dismiss-keyboard <udid>
 simdeck home <udid>
 simdeck app-switcher <udid>

--- a/scripts/integration/js-api.mjs
+++ b/scripts/integration/js-api.mjs
@@ -168,7 +168,7 @@ async function main() {
     await session.waitFor(
       simulatorUDID,
       { id: "fixture.continue" },
-      { source: "native-ax", maxDepth: 3, timeoutMs: 5_000, pollMs: 250 },
+      { source: "native-ax", maxDepth: 3, timeoutMs: 20_000, pollMs: 250 },
     );
   });
   await measuredStep("JS tree describe", async () => {

--- a/server/native_stubs.c
+++ b/server/native_stubs.c
@@ -212,6 +212,13 @@ bool xcw_native_send_button(const char *udid, const char *button_name,
   return xcw_unsupported(error_message);
 }
 
+bool xcw_native_rotate_crown(const char *udid, double delta,
+                             char **error_message) {
+  (void)udid;
+  (void)delta;
+  return xcw_unsupported(error_message);
+}
+
 bool xcw_native_rotate_right(const char *udid, char **error_message) {
   (void)udid;
   return xcw_unsupported(error_message);
@@ -418,6 +425,13 @@ bool xcw_native_session_send_button(void *handle, const char *button_name,
   (void)has_usage;
   (void)usage_page;
   (void)usage;
+  return xcw_unsupported(error_message);
+}
+
+bool xcw_native_session_rotate_crown(void *handle, double delta,
+                                     char **error_message) {
+  (void)handle;
+  (void)delta;
   return xcw_unsupported(error_message);
 }
 

--- a/server/src/android.rs
+++ b/server/src/android.rs
@@ -21,6 +21,8 @@ const ANDROID_TOUCH_SWIPE_THRESHOLD: f64 = 0.025;
 const ANDROID_TOUCH_MIN_DURATION_MS: u128 = 80;
 const ANDROID_TOUCH_MAX_DURATION_MS: u128 = 1500;
 const ANDROID_COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
+const ANDROID_UIAUTOMATOR_DUMP_ATTEMPTS: usize = 10;
+const ANDROID_UIAUTOMATOR_DUMP_RETRY_DELAY: Duration = Duration::from_millis(250);
 const RUNNING_EMULATOR_CACHE_TTL: Duration = Duration::from_secs(2);
 const AVD_GRPC_PORT_CACHE_TTL: Duration = Duration::from_secs(60);
 const SCREEN_SIZE_CACHE_TTL: Duration = Duration::from_secs(1);
@@ -775,21 +777,42 @@ impl AndroidBridge {
         max_depth: Option<usize>,
     ) -> Result<Value, AppError> {
         let serial = self.serial_for_id(id)?;
+        let max_depth = max_depth.unwrap_or(80).min(80);
+        let mut last_error = None;
+        for attempt in 1..=ANDROID_UIAUTOMATOR_DUMP_ATTEMPTS {
+            match self.android_accessibility_tree_for_serial(&serial, max_depth) {
+                Ok(tree) => return Ok(tree),
+                Err(error) => last_error = Some(error),
+            }
+            if attempt < ANDROID_UIAUTOMATOR_DUMP_ATTEMPTS {
+                thread::sleep(ANDROID_UIAUTOMATOR_DUMP_RETRY_DELAY);
+            }
+        }
+
+        Err(last_error.unwrap_or_else(|| {
+            AppError::native("Unable to capture Android UIAutomator hierarchy.")
+        }))
+    }
+
+    fn android_accessibility_tree_for_serial(
+        &self,
+        serial: &str,
+        max_depth: usize,
+    ) -> Result<Value, AppError> {
         let raw = self.run_adb_shell(
-            &serial,
+            serial,
             "uiautomator dump /sdcard/simdeck_ui.xml >/dev/null && cat /sdcard/simdeck_ui.xml",
         )?;
         let xml = extract_xml(&raw);
         let document = roxmltree::Document::parse(xml).map_err(|error| {
             AppError::native(format!("Unable to parse UIAutomator XML: {error}"))
         })?;
-        let mut roots = Vec::new();
         let root = document.root_element();
-        let max_depth = max_depth.unwrap_or(80).min(80);
+        let (width, height) = self.screen_size_for_serial(serial)?;
+        let mut roots = Vec::new();
         for child in root.children().filter(|node| node.has_tag_name("node")) {
             roots.push(android_node_value(child, 0, max_depth));
         }
-        let (width, height) = self.screen_size_for_serial(&serial)?;
         if roots.is_empty() {
             roots.push(json!({
                 "type": "screen",

--- a/server/src/api/routes.rs
+++ b/server/src/api/routes.rs
@@ -43,6 +43,7 @@ use tracing::Level;
 
 const SIMULATOR_INVENTORY_CACHE_TTL: Duration = Duration::from_secs(5);
 const SIMULATOR_INVENTORY_TIMEOUT: Duration = Duration::from_secs(8);
+const SIMULATOR_INVENTORY_FORCE_REFRESH_TIMEOUT: Duration = Duration::from_secs(90);
 const H264_WS_MAGIC: &[u8; 4] = b"SDH1";
 const H264_WS_HEADER_LEN: usize = 40;
 const H264_WS_FLAG_KEYFRAME: u8 = 1 << 0;
@@ -5412,15 +5413,25 @@ async fn list_simulators_cached(
         }
     }
 
+    let inventory_timeout = if force_refresh {
+        SIMULATOR_INVENTORY_FORCE_REFRESH_TIMEOUT
+    } else {
+        SIMULATOR_INVENTORY_TIMEOUT
+    };
+
     let simulators = match timeout(
-        SIMULATOR_INVENTORY_TIMEOUT,
+        inventory_timeout,
         run_bridge_action(state.clone(), |bridge| bridge.list_simulators()),
     )
     .await
     {
         Ok(result) => result?,
         Err(_) => {
-            tracing::warn!("Timed out listing iOS simulators; returning cached inventory.");
+            tracing::warn!(
+                timeout_seconds = inventory_timeout.as_secs(),
+                force_refresh,
+                "Timed out listing iOS simulators; returning cached inventory."
+            );
             let guard = state.simulator_inventory.inner.lock().await;
             return Ok(guard.simulators.clone().unwrap_or_default());
         }

--- a/server/src/api/routes.rs
+++ b/server/src/api/routes.rs
@@ -301,6 +301,9 @@ pub(crate) enum ControlMessage {
         usage_page: Option<u32>,
         usage: Option<u32>,
     },
+    Crown {
+        delta: f64,
+    },
     DismissKeyboard,
     Home,
     AppSwitcher,
@@ -326,6 +329,11 @@ struct ButtonPayload {
     #[serde(rename = "usagePage")]
     usage_page: Option<u32>,
     usage: Option<u32>,
+}
+
+#[derive(Deserialize)]
+struct CrownPayload {
+    delta: f64,
 }
 
 #[derive(Deserialize)]
@@ -448,6 +456,9 @@ enum BatchStep {
     Button {
         button: String,
         duration_ms: Option<u32>,
+    },
+    Crown {
+        delta: f64,
     },
     Launch {
         bundle_id: String,
@@ -602,6 +613,7 @@ pub fn router(state: AppState) -> Router {
             post(dismiss_keyboard),
         )
         .route("/api/simulators/{udid}/button", post(press_button))
+        .route("/api/simulators/{udid}/crown", post(rotate_crown))
         .route("/api/simulators/{udid}/home", post(press_home))
         .route(
             "/api/simulators/{udid}/app-switcher",
@@ -2482,6 +2494,7 @@ pub(crate) async fn run_control_message(
                 session.press_button(&button, duration_ms.unwrap_or(0))
             }
         }
+        ControlMessage::Crown { delta } => session.rotate_crown(delta),
         ControlMessage::DismissKeyboard => session.send_key(41, 0),
         ControlMessage::Home => session.press_home(),
         ControlMessage::AppSwitcher => session.open_app_switcher(),
@@ -2622,6 +2635,23 @@ async fn press_button(
         })
         .await?;
     }
+    Ok(json(json_value!({ "ok": true })))
+}
+
+async fn rotate_crown(
+    State(state): State<AppState>,
+    Path(udid): Path<String>,
+    Json(payload): Json<CrownPayload>,
+) -> Result<Json<Value>, AppError> {
+    if !payload.delta.is_finite() {
+        return Err(AppError::bad_request(
+            "Request body must include finite `delta`.",
+        ));
+    }
+    run_bridge_action(state, move |bridge| {
+        bridge.rotate_crown(&udid, payload.delta)
+    })
+    .await?;
     Ok(json(json_value!({ "ok": true })))
 }
 
@@ -3428,6 +3458,10 @@ async fn run_batch_step(state: AppState, udid: String, step: BatchStep) -> Resul
             })
             .await?;
             Ok(json_value!({ "action": "button" }))
+        }
+        BatchStep::Crown { delta } => {
+            run_bridge_action(state, move |bridge| bridge.rotate_crown(&udid, delta)).await?;
+            Ok(json_value!({ "action": "crown" }))
         }
         BatchStep::Launch { bundle_id } => {
             if android::is_android_id(&udid) {

--- a/server/src/api/routes.rs
+++ b/server/src/api/routes.rs
@@ -1894,6 +1894,9 @@ async fn run_android_control_message(
                 ControlMessage::AppSwitcher => android.open_app_switcher(&udid),
                 ControlMessage::RotateLeft => android.rotate_left(&udid),
                 ControlMessage::RotateRight => android.rotate_right(&udid),
+                ControlMessage::Crown { .. } => Err(AppError::bad_request(
+                    "Digital Crown rotation is only available for Apple Watch simulators.",
+                )),
                 ControlMessage::ToggleAppearance => android.toggle_appearance(&udid),
                 ControlMessage::Touch { .. }
                 | ControlMessage::EdgeTouch { .. }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -355,6 +355,11 @@ enum Command {
         #[arg(long, default_value_t = 0)]
         duration_ms: u32,
     },
+    Crown {
+        udid: String,
+        #[arg(long, default_value_t = 50.0)]
+        delta: f64,
+    },
     Batch {
         udid: String,
         #[arg(long = "step")]
@@ -1305,6 +1310,7 @@ fn is_known_command(value: &str) -> bool {
             | "key-combo"
             | "type"
             | "button"
+            | "crown"
             | "batch"
             | "dismiss-keyboard"
             | "home"
@@ -2715,6 +2721,17 @@ fn main() -> anyhow::Result<()> {
             )?;
             Ok(())
         }
+        Command::Crown { udid, delta } => {
+            if let Some(server_url) = service_url.as_deref() {
+                service_crown(server_url, &udid, delta)?;
+            } else {
+                bridge.rotate_crown(&udid, delta)?;
+            }
+            println_json(
+                &serde_json::json!({ "ok": true, "udid": udid, "action": "crown", "delta": delta }),
+            )?;
+            Ok(())
+        }
         Command::Batch {
             udid,
             steps,
@@ -3468,6 +3485,15 @@ fn service_button(
         udid,
         "button",
         &serde_json::json!({ "button": button, "durationMs": duration_ms }),
+    )
+}
+
+fn service_crown(server_url: &str, udid: &str, delta: f64) -> anyhow::Result<()> {
+    service_post_ok(
+        server_url,
+        udid,
+        "crown",
+        &serde_json::json!({ "delta": delta }),
     )
 }
 
@@ -4593,6 +4619,10 @@ fn batch_line_to_json_step(line: &str) -> anyhow::Result<Value> {
             "button": tokens.get(1).map(String::as_str).unwrap_or(""),
             "durationMs": args.value("duration-ms").and_then(|value| value.parse::<u32>().ok()).unwrap_or(0),
         }),
+        "crown" => serde_json::json!({
+            "action": "crown",
+            "delta": args.value("delta").and_then(|value| value.parse::<f64>().ok()).unwrap_or(50.0),
+        }),
         "home" => serde_json::json!({ "action": "home" }),
         "dismiss-keyboard" => serde_json::json!({ "action": "dismissKeyboard" }),
         "app-switcher" => serde_json::json!({ "action": "appSwitcher" }),
@@ -4844,6 +4874,14 @@ fn run_batch_step(
                 .ok_or_else(|| crate::error::AppError::bad_request("button requires a name."))?;
             bridge.press_button(udid, button, 0)?;
             Ok("button")
+        }
+        "crown" => {
+            let delta = tokens
+                .get(1)
+                .and_then(|value| value.parse::<f64>().ok())
+                .unwrap_or(50.0);
+            bridge.rotate_crown(udid, delta)?;
+            Ok("crown")
         }
         "key" => {
             let key = tokens.get(1).ok_or_else(|| {

--- a/server/src/native/bridge.rs
+++ b/server/src/native/bridge.rs
@@ -473,6 +473,20 @@ impl NativeBridge {
         }
     }
 
+    pub fn rotate_crown(&self, udid: &str, delta: f64) -> Result<(), AppError> {
+        if !delta.is_finite() {
+            return Err(AppError::bad_request("Digital Crown delta must be finite."));
+        }
+        let udid = CString::new(udid).map_err(|e| AppError::bad_request(e.to_string()))?;
+        unsafe {
+            let mut error = ptr::null_mut();
+            bool_result(
+                ffi::xcw_native_rotate_crown(udid.as_ptr(), delta, &mut error),
+                error,
+            )
+        }
+    }
+
     pub fn rotate_right(&self, udid: &str) -> Result<(), AppError> {
         let udid = CString::new(udid).map_err(|e| AppError::bad_request(e.to_string()))?;
         unsafe {
@@ -894,6 +908,19 @@ impl NativeSession {
                     usage.unwrap_or(0),
                     &mut error,
                 ),
+                error,
+            )
+        }
+    }
+
+    pub fn rotate_crown(&self, delta: f64) -> Result<(), AppError> {
+        if !delta.is_finite() {
+            return Err(AppError::bad_request("Digital Crown delta must be finite."));
+        }
+        unsafe {
+            let mut error = ptr::null_mut();
+            bool_result(
+                ffi::xcw_native_session_rotate_crown(self.handle, delta, &mut error),
                 error,
             )
         }

--- a/server/src/native/ffi.rs
+++ b/server/src/native/ffi.rs
@@ -124,6 +124,11 @@ unsafe extern "C" {
         usage: u32,
         error_message: *mut *mut c_char,
     ) -> bool;
+    pub fn xcw_native_rotate_crown(
+        udid: *const c_char,
+        delta: f64,
+        error_message: *mut *mut c_char,
+    ) -> bool;
     pub fn xcw_native_rotate_right(udid: *const c_char, error_message: *mut *mut c_char) -> bool;
     pub fn xcw_native_rotate_left(udid: *const c_char, error_message: *mut *mut c_char) -> bool;
     pub fn xcw_native_erase_simulator(udid: *const c_char, error_message: *mut *mut c_char)
@@ -253,6 +258,11 @@ unsafe extern "C" {
         has_usage: bool,
         usage_page: u32,
         usage: u32,
+        error_message: *mut *mut c_char,
+    ) -> bool;
+    pub fn xcw_native_session_rotate_crown(
+        handle: *mut c_void,
+        delta: f64,
         error_message: *mut *mut c_char,
     ) -> bool;
     pub fn xcw_native_session_open_app_switcher(

--- a/server/src/simulators/session.rs
+++ b/server/src/simulators/session.rs
@@ -279,6 +279,10 @@ impl SimulatorSession {
             .send_button(button, pressed, usage_page, usage)
     }
 
+    pub fn rotate_crown(&self, delta: f64) -> Result<(), AppError> {
+        self.inner.native.rotate_crown(delta)
+    }
+
     pub fn open_app_switcher(&self) -> Result<(), AppError> {
         self.inner.native.open_app_switcher()
     }

--- a/server/src/transport/webrtc.rs
+++ b/server/src/transport/webrtc.rs
@@ -891,6 +891,9 @@ async fn run_android_webrtc_control_message(
         ControlMessage::AppSwitcher => state.android.open_app_switcher(&udid),
         ControlMessage::RotateLeft => state.android.rotate_left(&udid),
         ControlMessage::RotateRight => state.android.rotate_right(&udid),
+        ControlMessage::Crown { .. } => Err(AppError::bad_request(
+            "Digital Crown rotation is only available for Apple Watch simulators.",
+        )),
         ControlMessage::ToggleAppearance => state.android.toggle_appearance(&udid),
         ControlMessage::Touch { .. }
         | ControlMessage::EdgeTouch { .. }

--- a/skills/simdeck/SKILL.md
+++ b/skills/simdeck/SKILL.md
@@ -146,6 +146,8 @@ simdeck button <UDID> volume-up
 simdeck button <UDID> volume-down
 simdeck button <UDID> action --duration-ms 1000
 simdeck button <UDID> mute
+simdeck button <UDID> digital-crown
+simdeck button <UDID> left-side-button
 simdeck button <UDID> siri
 simdeck button <UDID> apple-pay
 simdeck home <UDID>

--- a/skills/simdeck/SKILL.md
+++ b/skills/simdeck/SKILL.md
@@ -147,6 +147,7 @@ simdeck button <UDID> volume-down
 simdeck button <UDID> action --duration-ms 1000
 simdeck button <UDID> mute
 simdeck button <UDID> digital-crown
+simdeck crown <UDID> --delta 50
 simdeck button <UDID> left-side-button
 simdeck button <UDID> siri
 simdeck button <UDID> apple-pay


### PR DESCRIPTION
## Summary
- Expanded chrome rendering to respect DeviceKit watch padding and anchor math, so Watch bezels and button placements match the bundle metadata more closely.
- Added Watch-specific hardware button handling for `digital-crown`, `side-button`, and `left-side-button` through the native HID path and browser chrome controls.
- Updated the browser button overlay to preserve the correct wire names and press/hover transforms for Watch chrome.
- Kept the CLI, REST docs, README, and operator guide in sync with the new button set.

## Testing
- `npm run build` passed.
- `npm test` passed.
- Verified `chrome-profile` output for a Watch simulator returns the expected Watch button names, usage pairs, and chrome bounds.