### PR TITLE
Overhaul SimDeck documentation for usage-focused guidance

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -7,7 +7,7 @@ const siteUrl = "https://simdeck.nativescript.org";
 export default defineConfig({
   title: "SimDeck",
   description:
-    "A local-first iOS Simulator control plane with a browser UI, REST API, and WebRTC video.",
+    "Stream, inspect, and automate iOS Simulators and Android emulators from a browser, CLI, or test.",
   lang: "en-US",
   cleanUrls: true,
   lastUpdated: true,
@@ -21,7 +21,7 @@ export default defineConfig({
       {
         property: "og:description",
         content:
-          "A local iOS Simulator control plane with a browser UI, REST API, and WebRTC video.",
+          "Stream, inspect, and automate iOS Simulators and Android emulators from a browser, CLI, or test.",
       },
     ],
     ["meta", { property: "og:url", content: `${siteUrl}/` }],
@@ -36,7 +36,7 @@ export default defineConfig({
       { text: "CLI", link: "/cli/", activeMatch: "/cli/" },
       { text: "API", link: "/api/rest", activeMatch: "/api/" },
       {
-        text: "Inspector",
+        text: "Inspectors",
         link: "/inspector/",
         activeMatch: "/inspector/",
       },
@@ -46,16 +46,10 @@ export default defineConfig({
         activeMatch: "/extensions/",
       },
       {
-        text: "0.1.0",
+        text: "0.1.5",
         items: [
-          {
-            text: "Changelog",
-            link: `${githubUrl}/releases`,
-          },
-          {
-            text: "Contributing",
-            link: "/contributing",
-          },
+          { text: "Changelog", link: `${githubUrl}/releases` },
+          { text: "Contributing", link: "/contributing" },
         ],
       },
     ],
@@ -63,28 +57,28 @@ export default defineConfig({
     sidebar: {
       "/guide/": [
         {
-          text: "Getting Started",
+          text: "Start",
           items: [
-            { text: "Introduction", link: "/guide/" },
-            { text: "Installation", link: "/guide/installation" },
+            { text: "Overview", link: "/guide/" },
+            { text: "Install", link: "/guide/installation" },
             { text: "Quick Start", link: "/guide/quick-start" },
           ],
         },
         {
-          text: "Concepts",
+          text: "Use",
           items: [
-            { text: "Architecture", link: "/guide/architecture" },
-            { text: "Video Pipeline", link: "/guide/video" },
+            { text: "Daemon", link: "/guide/daemon" },
+            { text: "Video & Streaming", link: "/guide/video" },
             { text: "LAN Access", link: "/guide/lan-access" },
-            { text: "Project Daemon", link: "/guide/daemon" },
             { text: "Testing", link: "/guide/testing" },
             { text: "GitHub Actions", link: "/guide/github-actions" },
           ],
         },
         {
-          text: "Operating SimDeck",
+          text: "Reference",
           items: [
             { text: "Troubleshooting", link: "/guide/troubleshooting" },
+            { text: "How It Works", link: "/guide/architecture" },
             { text: "Contributing", link: "/contributing" },
           ],
         },
@@ -95,23 +89,18 @@ export default defineConfig({
           text: "CLI",
           items: [
             { text: "Overview", link: "/cli/" },
-            { text: "Command Reference", link: "/cli/commands" },
-            { text: "Flags & Options", link: "/cli/flags" },
+            { text: "Commands", link: "/cli/commands" },
+            { text: "Flags", link: "/cli/flags" },
           ],
         },
       ],
 
       "/api/": [
         {
-          text: "HTTP API",
+          text: "API",
           items: [
-            { text: "REST Endpoints", link: "/api/rest" },
+            { text: "REST", link: "/api/rest" },
             { text: "Health & Metrics", link: "/api/health" },
-          ],
-        },
-        {
-          text: "Inspectors",
-          items: [
             { text: "Inspector Protocol", link: "/api/inspector-protocol" },
           ],
         },
@@ -119,26 +108,14 @@ export default defineConfig({
 
       "/inspector/": [
         {
-          text: "Inspector",
+          text: "Inspectors",
           items: [
             { text: "Overview", link: "/inspector/" },
             { text: "Accessibility", link: "/inspector/accessibility" },
-            {
-              text: "Swift In-App Agent",
-              link: "/inspector/swift",
-            },
-            {
-              text: "NativeScript Runtime",
-              link: "/inspector/nativescript",
-            },
-            {
-              text: "React Native Runtime",
-              link: "/inspector/react-native",
-            },
-            {
-              text: "Flutter Runtime",
-              link: "/inspector/flutter",
-            },
+            { text: "Swift", link: "/inspector/swift" },
+            { text: "NativeScript", link: "/inspector/nativescript" },
+            { text: "React Native", link: "/inspector/react-native" },
+            { text: "Flutter", link: "/inspector/flutter" },
           ],
         },
       ],
@@ -167,7 +144,7 @@ export default defineConfig({
 
     footer: {
       message: "Released under the Apache-2.0 License.",
-      copyright: `Copyright © 2026 SimDeck contributors.`,
+      copyright: "Copyright (c) 2026 SimDeck contributors.",
     },
 
     outline: {

--- a/docs/api/health.md
+++ b/docs/api/health.md
@@ -1,10 +1,14 @@
 # Health & Metrics
 
-Two endpoints expose every observable signal SimDeck collects: `GET /api/health` for the bootstrap surface and `GET /api/metrics` for the running counters.
+Use these endpoints to check whether a daemon is reachable and to diagnose stream performance.
 
-## `GET /api/health`
+## Health
 
-Returns the static bootstrap information the browser client needs, plus a freshness timestamp.
+```http
+GET /api/health
+```
+
+Example:
 
 ```json
 {
@@ -13,6 +17,11 @@ Returns the static bootstrap information the browser client needs, plus a freshn
   "timestamp": 1714094761.234,
   "videoCodec": "auto",
   "lowLatency": false,
+  "realtimeStream": true,
+  "localStreamFps": 60,
+  "streamQuality": {
+    "profile": "full"
+  },
   "webRtc": {
     "iceServers": [{ "urls": ["stun:stun.l.google.com:19302"] }],
     "iceTransportPolicy": "all"
@@ -20,118 +29,42 @@ Returns the static bootstrap information the browser client needs, plus a freshn
 }
 ```
 
-| Field                       | Notes                                                                                                 |
-| --------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `ok`                        | Always `true` if the route is reachable. Network failures are signalled by HTTP errors.               |
-| `httpPort`                  | HTTP port for the REST API, browser UI, and WebRTC offer endpoint.                                    |
-| `timestamp`                 | Server-side `time.now()` as a fractional Unix epoch in seconds.                                       |
-| `videoCodec`                | Requested encoder mode. One of `auto`, `hardware`, or `software`. See [Video Pipeline](/guide/video). |
-| `lowLatency`                | `true` when software H.264 low-latency mode was enabled at daemon startup.                            |
-| `realtimeStream`            | `true` when the WebRTC stream is configured to favor freshness and realtime pacing.                   |
-| `localStreamFps`            | Local quality stream frame target, from 15 to 240 fps. Defaults to 60.                                |
-| `streamQuality`             | Active realtime quality profile and encoder limits such as `maxEdge`, `fps`, and bitrate.             |
-| `webRtc.iceServers`         | ICE servers the browser should use when creating the WebRTC peer connection.                          |
-| `webRtc.iceTransportPolicy` | Browser ICE transport policy. One of `all` or `relay`.                                                |
+Important fields:
 
-The default access token is regenerated every time the server restarts. A client should refetch `/api/health` after any disconnection.
+| Field           | Meaning                                                 |
+| --------------- | ------------------------------------------------------- |
+| `ok`            | Server is alive                                         |
+| `httpPort`      | Port serving UI and API                                 |
+| `videoCodec`    | Requested codec mode: `auto`, `hardware`, or `software` |
+| `streamQuality` | Active stream profile and limits                        |
+| `webRtc`        | ICE settings the browser should use                     |
 
-## `GET /api/metrics`
+## Metrics
 
-Returns a snapshot of every server-side counter and the rolling buffer of client-reported stats:
-
-```json
-{
-  "frames_encoded": 12039,
-  "keyframes_encoded": 17,
-  "frames_sent": 11982,
-  "frames_dropped_server": 21,
-  "keyframe_requests": 4,
-  "active_streams": 1,
-  "subscribers_connected": 3,
-  "subscribers_disconnected": 2,
-  "avg_send_queue_depth": 0.91,
-  "max_send_queue_depth": 2,
-  "latest_first_frame_ms": 412,
-  "encoders": [
-    {
-      "udid": "9D7E5BB7-...",
-      "encoder": {
-        "encoderMode": "auto",
-        "activeEncoderMode": "hardware",
-        "clientForeground": true,
-        "autoSoftwareFallbackActive": false,
-        "hardwareAccelerated": true,
-        "overloadState": "nominal",
-        "averageEncoderLoadPercent": 42.1,
-        "averageEncodeLatencyUs": 7021.0,
-        "encoderBudgetUs": 16667,
-        "overloadEvents": 0
-      }
-    }
-  ],
-  "client_streams": [
-    {
-      "clientId": "browser-ABC",
-      "kind": "viewport",
-      "udid": "9D7E5BB7-...",
-      "timestampMs": 1714094761234.0,
-      "codec": "h264",
-      "width": 1170,
-      "height": 2532,
-      "decodedFps": 59.7,
-      "renderedFps": 59.7,
-      "droppedFps": 0.0,
-      "latestRenderMs": 6.2
-    }
-  ]
-}
+```http
+GET /api/metrics
 ```
 
-### Counter glossary
+Useful fields:
 
-| Counter                    | Increments when…                                                                        |
-| -------------------------- | --------------------------------------------------------------------------------------- |
-| `frames_encoded`           | The native bridge produces a frame.                                                     |
-| `keyframes_encoded`        | The encoder emits a keyframe (always a subset of `frames_encoded`).                     |
-| `frames_sent`              | A frame is written to a WebRTC client.                                                  |
-| `frames_dropped_server`    | A client is too slow and the broadcast channel skips frames for them.                   |
-| `keyframe_requests`        | The transport hub asks the encoder for a fresh keyframe (e.g. on reconnect or refresh). |
-| `active_streams`           | Currently open WebRTC streams.                                                          |
-| `subscribers_connected`    | Lifetime count of WebRTC streams opened.                                                |
-| `subscribers_disconnected` | Lifetime count of WebRTC streams closed.                                                |
-| `avg_send_queue_depth`     | Running average of broadcast channel pressure.                                          |
-| `max_send_queue_depth`     | Peak broadcast channel pressure.                                                        |
-| `latest_first_frame_ms`    | First-frame latency for the most recent connect, in milliseconds.                       |
+| Field                              | What to look for                             |
+| ---------------------------------- | -------------------------------------------- |
+| `latest_first_frame_ms`            | First-frame startup time                     |
+| `frames_dropped_server`            | Server dropping stale frames to stay current |
+| `keyframe_requests`                | Stream refresh or recovery activity          |
+| `active_streams`                   | Open browser streams                         |
+| `encoders[].encoder.overloadState` | `nominal`, `strained`, or `overloaded`       |
+| `client_streams`                   | Recent browser decoder and render reports    |
 
-### Encoder overload state
+If `overloadState` is `overloaded` or dropped frames keep increasing, lower stream quality or restart with software encoding:
 
-`encoders` contains one entry per active simulator session. `encoder.overloadState`
-is derived from native VideoToolbox submit-to-output latency:
+```sh
+simdeck daemon restart --video-codec software --stream-quality low
+```
 
-| State        | Meaning                                                                                 |
-| ------------ | --------------------------------------------------------------------------------------- |
-| `nominal`    | Smoothed encode latency is comfortably below the active frame budget.                   |
-| `strained`   | Smoothed latency is near the frame budget or several frames are close to budget.        |
-| `overloaded` | Smoothed latency exceeds the budget or several frames in a row took longer than budget. |
+## Submit Client Stats
 
-This is an inferred pressure signal rather than a private macOS hardware queue
-counter. It is useful for deciding when to lower stream resolution/FPS or switch
-from hardware to software encoding. When `encoderMode` is `auto`, SimDeck uses
-this signal to temporarily rebuild the active session with software H.264 if the
-hardware encoder is overloaded, then retries hardware after a cooldown. The
-`activeEncoderMode`, `autoSoftwareFallbackActive`, `autoSoftwareFallbacks`, and
-`autoHardwareRetries` fields expose that state. `clientForeground` is `false`
-when all current browser viewers for the simulator are hidden or unfocused; in
-that state the native session uses software H.264 until a viewer returns
-foreground.
-
-### Client stream stats
-
-`client_streams` is a rolling buffer of the most recent reports from browser stream transports. WebRTC clients normally send reports over the telemetry data channel, H.264 WebSocket clients send them on the stream socket, and simple clients can still post to `POST /api/client-stream-stats`. The server keeps the last 48 entries per `(clientId, kind)` pair.
-
-The browser client uses these to render its in-app diagnostics overlay and to size its decoder workers. Every field is optional except `clientId` and `kind`; see [`ClientStreamStats`](https://github.com/NativeScript/SimDeck/blob/main/server/src/metrics/counters.rs) for the full schema.
-
-## Submitting client stats
+Custom clients can report their own stream stats:
 
 ```http
 POST /api/client-stream-stats
@@ -142,31 +75,16 @@ Content-Type: application/json
   "kind": "viewport",
   "udid": "9D7E5BB7-...",
   "codec": "h264",
-  "width": 1170,
-  "height": 2532,
   "decodedFps": 59.7,
   "droppedFps": 0.0,
   "latestRenderMs": 6.2
 }
 ```
 
-Required fields:
+Required fields are `clientId` and `kind`.
 
-- `clientId` — any stable identifier you pick.
-- `kind` — what slice of the client is reporting (`viewport`, `decoder`, `renderer`, …).
+Read only the client buffer:
 
-Anything else is optional but typed; unknown fields are rejected.
-
-A successful submission returns:
-
-```json
-{ "ok": true }
-```
-
-## `GET /api/client-stream-stats`
-
-Returns the same `clientStreams` array that `GET /api/metrics` includes, in case you only want the client-side view:
-
-```json
-{ "clientStreams": [ ... ] }
+```http
+GET /api/client-stream-stats
 ```

--- a/docs/api/inspector-protocol.md
+++ b/docs/api/inspector-protocol.md
@@ -1,60 +1,45 @@
 # Inspector Protocol
 
-In-app inspectors talk to SimDeck using a small newline-delimited JSON protocol called `SDI/0.1`. Both transports (TCP and WebSocket) speak the same envelope and method set, so app-side code is interchangeable between them.
+In-app inspectors use SimDeck's small JSON protocol to publish richer UI trees and handle debug actions.
+
+Most users do not need this page. Use it when you are building or debugging an inspector runtime.
 
 ## Transports
 
-There are two equivalent transports:
+| Transport                                                    | Used by                                                          |
+| ------------------------------------------------------------ | ---------------------------------------------------------------- |
+| TCP on `127.0.0.1:47370-47402`                               | Swift in-app agent                                               |
+| WebSocket `/api/inspector/connect`                           | NativeScript, React Native, Flutter, and other outbound runtimes |
+| Polling `/api/inspector/poll` plus `/api/inspector/response` | Fallback when WebSocket is unavailable                           |
 
-### Newline-delimited TCP
-
-The original Swift in-app agent listens on TCP. The default port is `47370`; if it is busy the agent tries the next 32 ports and listens on the first free one. Clients should probe `47370–47402` and call `Inspector.getInfo` to disambiguate.
+TCP is newline-delimited JSON:
 
 ```sh
 printf '{"id":1,"method":"Inspector.getInfo"}\n' | nc 127.0.0.1 47370
 ```
 
-The agent also advertises Bonjour service type `_simdeckinspector._tcp`.
+## Envelope
 
-### WebSocket via the server
-
-NativeScript apps connect outbound to the SimDeck server:
-
-```text
-GET /api/inspector/connect
-```
-
-After connection the server sends `Inspector.getInfo` and waits for a response that includes a `processIdentifier`. Once that arrives, the server treats the WebSocket as the preferred transport for that PID and routes inspector requests there.
-
-While the inspector is registered, the daemon advertises it in `~/.simdeck/inspectors.json` so other local SimDeck daemons can find the owning daemon and relay requests to the same app inspector.
-
-A polling fallback is available for environments without WebSocket support:
-
-- `GET /api/inspector/poll?processIdentifier=<pid>` — long-polls for the next request, returning `204 No Content` if nothing arrives within 25 seconds.
-- `POST /api/inspector/response` — submits the response body.
-
-## Envelopes
-
-### Request
+Request:
 
 ```json
 {
   "id": 1,
   "method": "View.getHierarchy",
-  "params": { "includeHidden": false }
+  "params": { "maxDepth": 4 }
 }
 ```
 
-### Response
+Success:
 
 ```json
 {
   "id": 1,
-  "result": { "protocolVersion": "0.1", "roots": [] }
+  "result": { "roots": [] }
 }
 ```
 
-### Error
+Error:
 
 ```json
 {
@@ -66,65 +51,50 @@ A polling fallback is available for environments without WebSocket support:
 }
 ```
 
-### Event
+Event:
 
 ```json
 {
   "event": "Inspector.connected",
-  "params": { "protocolVersion": "0.1", "framing": "ndjson" }
+  "params": { "protocolVersion": "0.1" }
 }
 ```
 
-If the agent is started with an `authToken`, every request must include a matching top-level `token` field.
+If an inspector is started with an auth token, requests must include a matching top-level `token`.
 
-All point input and `frameInScreen` values use UIKit screen points, **not pixels**. Multiply by `displayScale` from `Inspector.getInfo` to convert to native pixels.
+## Core Methods
 
-## Methods
+| Method                 | Purpose                                                |
+| ---------------------- | ------------------------------------------------------ |
+| `Runtime.ping`         | Connectivity check                                     |
+| `Inspector.getInfo`    | Protocol version, app metadata, display scale, sources |
+| `View.getHierarchy`    | Current UI hierarchy                                   |
+| `View.get`             | One subtree by ID                                      |
+| `View.hitTest`         | Topmost view at a point                                |
+| `View.describeAtPoint` | Hit view plus ancestors                                |
+| `View.listActions`     | Supported actions for a view                           |
+| `View.perform`         | Run an action such as `tap`, `setText`, or `scrollBy`  |
+| `View.getProperties`   | Editable debug properties                              |
+| `View.setProperty`     | Best-effort runtime property edit                      |
+| `View.evaluateScript`  | Debug script evaluation                                |
 
-The full method list. The SimDeck HTTP proxy at `POST /api/simulators/{udid}/inspector/request` only allows a curated subset (see [REST endpoints](/api/rest#post-api-simulators-udid-inspector-request)); direct TCP/WebSocket clients can call any of them.
+Coordinates and frames use UIKit screen points, not pixels. Multiply by `displayScale` when you need pixels.
 
-### `Runtime.ping`
-
-Quick connectivity check. Returns:
-
-```json
-{ "result": { "ok": true } }
-```
-
-### `Inspector.getInfo`
-
-Returns protocol version, app process metadata, display scale, coordinate space, and the available method list. Required first call after connect.
+## Hierarchy Request
 
 ```json
 {
-  "result": {
-    "protocolVersion": "0.1",
-    "processIdentifier": 73214,
-    "bundleIdentifier": "com.example.MyApp",
-    "bundleName": "MyApp",
-    "displayScale": 3,
-    "coordinateSpace": "uikit-screen-points",
-    "appHierarchy": {
-      "available": true,
-      "source": "nativescript"
-    }
+  "id": 2,
+  "method": "View.getHierarchy",
+  "params": {
+    "includeHidden": false,
+    "maxDepth": 20,
+    "source": "uikit"
   }
 }
 ```
 
-### `View.getHierarchy`
-
-Returns the current hierarchy rooted at every visible window.
-
-Params:
-
-```json
-{ "includeHidden": false, "maxDepth": 20, "source": "uikit" }
-```
-
-By default the agent returns the published framework hierarchy (for example NativeScript, React Native, Flutter, or SwiftUI) when one exists. Pass `"source": "uikit"` to force the raw UIKit tree when the runtime supports UIKit inspection.
-
-Published framework nodes may include `sourceLocation`:
+Framework runtimes may return logical nodes with source locations:
 
 ```json
 {
@@ -133,124 +103,29 @@ Published framework nodes may include `sourceLocation`:
   "sourceLocation": {
     "file": "src/app/home.component.html",
     "line": 12,
-    "column": 5,
-    "offset": 238
+    "column": 5
   }
 }
 ```
 
-`line` and `column` are one-based when produced by NativeScript or React Native development metadata.
-
-### `View.get`
-
-Returns one view subtree by id:
+## Actions
 
 ```json
 {
-  "id": 4,
-  "method": "View.get",
-  "params": { "id": "view:0x1234", "maxDepth": 2 }
-}
-```
-
-IDs are process-local and valid until the underlying object is destroyed.
-
-### `View.hitTest`
-
-Returns the topmost hit-tested view for a screen point:
-
-```json
-{
-  "id": 5,
-  "method": "View.hitTest",
-  "params": { "x": 120, "y": 240, "maxDepth": 1 }
-}
-```
-
-### `View.describeAtPoint`
-
-Returns the hit view plus its ancestor chain.
-
-```json
-{ "id": 6, "method": "View.describeAtPoint", "params": { "x": 120, "y": 240 } }
-```
-
-### `View.listActions`
-
-Lists the safe interactions a view supports.
-
-```json
-{ "id": 7, "method": "View.listActions", "params": { "id": "view:0x1234" } }
-```
-
-### `View.perform`
-
-Performs a high-level action on a view.
-
-Supported actions: `tap`, `focus`, `resignFirstResponder`, `accessibilityActivate`, `setText`, `setValue`, `toggle`, `scrollBy`, `scrollTo`.
-
-Examples:
-
-```json
-{
-  "id": 8,
-  "method": "View.perform",
-  "params": { "id": "view:0x1234", "action": "tap" }
-}
-```
-
-```json
-{
-  "id": 9,
-  "method": "View.perform",
-  "params": { "id": "view:0x1234", "action": "setText", "value": "hello" }
-}
-```
-
-```json
-{
-  "id": 10,
+  "id": 3,
   "method": "View.perform",
   "params": {
     "id": "view:0x1234",
-    "action": "scrollBy",
-    "y": 400,
-    "animated": true
+    "action": "tap"
   }
 }
 ```
 
-### `View.getProperties`
+Common actions include `tap`, `focus`, `resignFirstResponder`, `setText`, `setValue`, `toggle`, `scrollBy`, and `scrollTo`. Support depends on the inspector runtime and selected view.
 
-Returns editable runtime properties for a view:
+## SwiftUI Publishing
 
-```json
-{ "id": 11, "method": "View.getProperties", "params": { "id": "view:0x1234" } }
-```
-
-### `View.setProperty`
-
-Sets a UIKit property dynamically. This is a debug-only escape hatch; agents reject unsafe property names and coerce structured UIKit values such as `UIColor`, `CGRect`, `CGPoint`, `CGSize`, and `UIEdgeInsets`.
-
-```json
-{
-  "id": 12,
-  "method": "View.setProperty",
-  "params": {
-    "id": "view:0x1234",
-    "property": "backgroundColor",
-    "value": { "$type": "UIColor", "hex": "#FF6600FF" }
-  }
-}
-```
-
-### `View.evaluateScript`
-
-Evaluates a small UIKit script against a view. Used by the browser inspector to run pre-canned diagnostics.
-
-## SwiftUI
-
-For SwiftUI apps you control, attach the root publisher to the top of your scene:
+Swift apps can publish a SwiftUI root tree:
 
 ```swift
 WindowGroup {
@@ -259,23 +134,16 @@ WindowGroup {
 }
 ```
 
-The agent reflects the current SwiftUI value/body tree and publishes it as the `swiftui` hierarchy source. `View.getHierarchy` returns that tree by default; pass `"source": "uikit"` to inspect the backing hosting views instead.
-
-This is a debug aid built on Swift reflection. It can show the declared view/body structure, including custom subviews, containers, labels, modifier names, active conditional branches, and `ForEach` rows whose data and content builder are available through SwiftUI's public API. Private/custom containers may still be opaque when they do not expose a child view value or content builder.
-
-The agent also exposes SwiftUI in the raw UIKit tree:
-
-1. **Automatic detection.** UIKit bridge or hosting views whose runtime classes contain `SwiftUI` or `UIHosting` are reported with `swiftUI.isHost` or `swiftUI.isProbe` markers.
-2. **Source-level tags.** Apps can tag SwiftUI views with `View.simDeckInspectorTag(_:id:metadata:)` from the Swift agent. Tagged views appear as lightweight probe `UIView`s with `swiftUI.isProbe = true`.
+They can also tag specific SwiftUI views so the inspector can find them:
 
 ```swift
 Text("Continue")
     .simDeckInspectorTag("continue-label", id: "onboarding.continue.label")
 ```
 
-## Allowed proxy methods
+## HTTP Proxy Allow List
 
-When you call the inspector via `POST /api/simulators/{udid}/inspector/request`, the SimDeck server enforces an allow-list to keep the HTTP surface small:
+The public proxy at `POST /api/simulators/{udid}/inspector/request` allows:
 
 - `Runtime.ping`
 - `Inspector.getInfo`
@@ -287,4 +155,4 @@ When you call the inspector via `POST /api/simulators/{udid}/inspector/request`,
 - `View.listActions`
 - `View.perform`
 
-For anything not in this list, talk directly to the inspector over TCP or WebSocket.
+For other methods, talk directly to the inspector transport.

--- a/docs/api/rest.md
+++ b/docs/api/rest.md
@@ -1,776 +1,201 @@
-# REST Endpoints
+# REST API
 
-The SimDeck server exposes one REST API over plain HTTP. Every route lives under `/api/`. Responses are JSON unless explicitly noted otherwise. Errors return a JSON body with `{"error": "..."}` and an appropriate HTTP status.
+SimDeck serves the browser UI and API from the same HTTP server. Routes under `/api/*` return JSON unless noted.
 
-The served browser UI receives the generated access token automatically through a strict same-site cookie. Direct API callers must send `X-SimDeck-Token: <token>` or `Authorization: Bearer <token>`.
+Use the CLI for most automation. Use the API when you are building a custom client, test harness, or editor integration.
 
-## Conventions
+## Authentication
 
-- Method casing follows REST conventions. `GET` for queries, `POST` for state changes.
-- Path parameters use `{name}` notation in this reference. UDIDs come from `GET /api/simulators` (or `simdeck list`).
-- Most mutation endpoints return `{ "ok": true }`; boot and shutdown return refreshed simulator metadata.
-- Timestamps are numeric unless a route documents otherwise.
+Browser sessions loaded from the SimDeck server receive auth automatically. Direct callers should send the daemon token from `simdeck daemon status`:
 
-## Health and metrics
-
-### `GET /api/health`
-
-Returns server health and the active video encoder mode.
-
-```json
-{
-  "ok": true,
-  "httpPort": 4310,
-  "timestamp": 1714094761.234,
-  "videoCodec": "auto",
-  "lowLatency": false,
-  "webRtc": {
-    "iceServers": [{ "urls": ["stun:stun.l.google.com:19302"] }],
-    "iceTransportPolicy": "all"
-  }
-}
+```text
+X-SimDeck-Token: <token>
+Authorization: Bearer <token>
 ```
 
-The browser client polls this endpoint at startup to detect server restarts and
-to mirror the daemon's WebRTC ICE configuration.
-
-### `GET /api/metrics`
-
-Returns server-side video stats, active encoder overload states, and a rolling
-buffer of client-side stats. See [Video Pipeline](/guide/video#tuning-with-metrics)
-for an annotated example.
-
-### `GET /api/client-stream-stats`
-
-Returns just the client-side stats:
-
-```json
-{ "clientStreams": [{ "clientId": "...", "kind": "viewport", ... }] }
-```
-
-### `POST /api/client-stream-stats`
-
-Submit a stats sample from a client. The server keeps the last 48 entries per `(clientId, kind)`:
+LAN browsers can pair with the printed six-digit code through:
 
 ```http
-POST /api/client-stream-stats
-Content-Type: application/json
-
-{
-  "clientId": "browser-ABC",
-  "kind": "viewport",
-  "codec": "h264",
-  "width": 1170,
-  "height": 2532,
-  "decodedFps": 59.7,
-  "droppedFps": 0.0,
-  "latestRenderMs": 6.2
-}
+POST /api/pair
 ```
 
-Required fields: `clientId` and `kind`. Every other field is optional but typed in `ClientStreamStats`.
+## Quick Examples
 
-### `GET /api/stream-quality`
+```sh
+curl -H "X-SimDeck-Token: $SIMDECK_TOKEN" \
+  http://127.0.0.1:4310/api/simulators
+```
 
-Returns the active stream encoder settings and available quality profiles.
+```sh
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -H "X-SimDeck-Token: $SIMDECK_TOKEN" \
+  -d '{"url":"https://example.com"}' \
+  http://127.0.0.1:4310/api/simulators/<udid>/open-url
+```
 
-### `POST /api/stream-quality`
+## Server
 
-Updates the active stream encoder settings for newly encoded frames. Browser
-clients normally send these updates on the active WebRTC data channel or H.264
-WebSocket; this endpoint remains for scripts and fallback clients.
+| Method | Path                       | Purpose                                                    |
+| ------ | -------------------------- | ---------------------------------------------------------- |
+| `GET`  | `/api/health`              | Server health, version-ish runtime settings, stream config |
+| `GET`  | `/api/metrics`             | Video, encoder, and client stream counters                 |
+| `GET`  | `/api/client-stream-stats` | Recent client stream reports                               |
+| `POST` | `/api/client-stream-stats` | Submit client stream stats                                 |
+| `GET`  | `/api/stream-quality`      | Current stream quality settings                            |
+| `POST` | `/api/stream-quality`      | Update stream quality settings                             |
+
+See [Health & Metrics](/api/health) for details.
+
+## Devices
+
+| Method | Path                                       | Purpose                                   |
+| ------ | ------------------------------------------ | ----------------------------------------- |
+| `GET`  | `/api/simulators`                          | List iOS Simulators and Android emulators |
+| `GET`  | `/api/simulators/{udid}/state`             | Get one device state                      |
+| `POST` | `/api/simulators/{udid}/boot`              | Boot a simulator or emulator              |
+| `POST` | `/api/simulators/{udid}/shutdown`          | Shut it down                              |
+| `POST` | `/api/simulators/{udid}/erase`             | Erase data and settings                   |
+| `POST` | `/api/simulators/{udid}/toggle-appearance` | Toggle light/dark appearance              |
+
+Device IDs come from `/api/simulators`. Android IDs use the `android:` prefix.
+
+## Apps
+
+| Method | Path                               | Body                                |
+| ------ | ---------------------------------- | ----------------------------------- |
+| `POST` | `/api/simulators/{udid}/install`   | `{ "appPath": "/path/to/App.app" }` |
+| `POST` | `/api/simulators/{udid}/uninstall` | `{ "bundleId": "com.example.App" }` |
+| `POST` | `/api/simulators/{udid}/launch`    | `{ "bundleId": "com.example.App" }` |
+| `POST` | `/api/simulators/{udid}/open-url`  | `{ "url": "https://example.com" }`  |
+
+## Live Video
+
+| Method | Path                                  | Purpose                                |
+| ------ | ------------------------------------- | -------------------------------------- |
+| `POST` | `/api/simulators/{udid}/webrtc/offer` | WebRTC offer/answer stream setup       |
+| `GET`  | `/api/simulators/{udid}/h264`         | H.264 WebSocket fallback               |
+| `GET`  | `/api/simulators/{udid}/input`        | Input WebSocket for fallback transport |
+| `GET`  | `/api/simulators/{udid}/control`      | Alias for input control WebSocket      |
+| `POST` | `/api/simulators/{udid}/refresh`      | Request a fresh frame or keyframe      |
+
+For normal clients, copy the browser behavior instead of hand-coding a raw decoder. The UI supports WebRTC first and H.264 WebSocket fallback.
+
+Minimal WebRTC request:
 
 ```json
 {
-  "videoCodec": "hardware",
-  "fps": 60,
-  "profile": "full"
-}
-```
-
-`videoCodec` accepts `hardware` or `software` from the UI, and the API also
-accepts `auto`. `fps` is clamped to the local stream range. Browser viewers show
-five H.264 resolution profiles: `full` (4096 px at 60 fps), `balanced`
-(1280 px at 60 fps), `economy` (1080 px at 30 fps), `low` (720 px at 30 fps),
-and `tiny` (540 px at 30 fps). The API still accepts the legacy `quality`,
-`fast`, `smooth`, and `ci-software` profiles for CLI/provider compatibility.
-When
-`profile` is provided, its resolution preset is applied; send `maxEdge` without
-`profile` for a custom resolution cap.
-
-## Simulator inventory
-
-### `GET /api/simulators`
-
-Returns every iOS Simulator known to the native bridge plus every Android AVD
-found in the Android SDK, enriched with any session state SimDeck has attached:
-
-```json
-{
-  "simulators": [
-    {
-      "udid": "9D7E5BB7-...",
-      "name": "iPhone 15 Pro",
-      "runtimeName": "iOS 18.0",
-      "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-15-Pro",
-      "isBooted": true,
-      "platform": "ios-simulator",
-      "privateDisplay": {
-        "displayReady": true,
-        "displayStatus": "running",
-        "displayWidth": 1170,
-        "displayHeight": 2532,
-        "frameSequence": 8124,
-        "rotationQuarterTurns": 0
-      }
-    }
-  ]
-}
-```
-
-Android emulators use IDs prefixed with `android:` and include Android metadata:
-
-```json
-{
-  "udid": "android:SimDeck_Pixel_8_API_36",
-  "name": "SimDeck_Pixel_8_API_36",
-  "platform": "android-emulator",
-  "runtimeName": "Android",
-  "deviceTypeName": "Android Emulator",
-  "isBooted": true,
-  "android": {
-    "avdName": "SimDeck_Pixel_8_API_36",
-    "serial": "emulator-5554",
-    "grpcPort": 8554
-  }
-}
-```
-
-For iOS, `privateDisplay` is `null` until a stream attaches. For Android,
-SimDeck fills display size from `adb shell wm size` when the emulator is booted.
-
-## Simulator lifecycle
-
-### `POST /api/simulators/{udid}/boot`
-
-Boots the simulator or Android emulator and returns the refreshed device metadata:
-
-```json
-{ "simulator": { ... } }
-```
-
-### `POST /api/simulators/{udid}/shutdown`
-
-Tears down the live session (if any) and shuts the simulator or emulator down.
-
-### `POST /api/simulators/{udid}/toggle-appearance`
-
-Toggles between light and dark appearance via `simctl ui appearance` on iOS or
-`cmd uimode night` on Android.
-
-```json
-{ "ok": true }
-```
-
-### `POST /api/simulators/{udid}/refresh`
-
-Forces the iOS encoder to emit a fresh frame. For Android IDs, this route is a
-no-op that returns `{ "ok": true, "stream": "screenshot" }`; Android WebRTC
-keyframe requests are handled through the WebRTC control channel and RTCP
-feedback.
-
-```json
-{ "ok": true }
-```
-
-### `POST /api/simulators/{udid}/webrtc/offer`
-
-WebRTC transport for browser-native live video. The browser sends an SDP offer
-and the server responds with an SDP answer for a receive-only H.264 video track:
-
-```json
-{
-  "sdp": "v=0\r\n...",
+  "type": "offer",
+  "sdp": "v=0...",
   "streamConfig": {
+    "profile": "balanced",
     "fps": 60,
-    "profile": "full",
     "videoCodec": "auto"
-  },
-  "type": "offer"
+  }
 }
 ```
+
+Response:
 
 ```json
 {
-  "sdp": "v=0\r\n...",
-  "type": "answer"
+  "type": "answer",
+  "sdp": "v=0..."
 }
 ```
-
-For iOS, samples come from the native simulator display session and are sent as
-an H.264 media track. Android loopback clients use the same endpoint and control
-channels, but receive raw RGBA frames over the `simdeck-rgba` data channel.
-Non-loopback Android clients receive VideoToolbox-encoded H.264.
-
-The browser also opens `simdeck-control` and `simdeck-telemetry` data channels.
-In addition to input messages, clients can request a keyframe or tune the
-stream attached to that peer:
-
-```json
-{ "type": "streamControl", "forceKeyframe": true }
-```
-
-Clients can also report page focus/visibility through stream control. When all
-current viewers for a simulator report `foreground: false`, the native session
-uses software H.264 until a viewer returns foreground:
-
-```json
-{ "type": "streamControl", "clientId": "browser", "foreground": false }
-```
-
-```json
-{ "type": "streamQuality", "config": { "profile": "low", "fps": 30 } }
-```
-
-The telemetry channel accepts:
-
-```json
-{ "type": "clientStats", "stats": { "clientId": "browser", "kind": "webrtc" } }
-```
-
-### `GET /api/simulators/{udid}/h264`
-
-Direct H.264 video over WebSocket for browsers that support WebCodecs but
-cannot establish WebRTC media. The server sends binary messages with this
-layout:
-
-| Offset | Size | Field                                               |
-| ------ | ---- | --------------------------------------------------- |
-| 0      | 4    | Magic bytes `SDH1`                                  |
-| 4      | 1    | Version, currently `1`                              |
-| 5      | 1    | Flags: bit 0 keyframe, bit 1 decoder config present |
-| 6      | 2    | Header length, big-endian                           |
-| 8      | 8    | Frame sequence, big-endian                          |
-| 16     | 8    | Timestamp in microseconds, big-endian               |
-| 24     | 4    | Encoded width, big-endian                           |
-| 28     | 4    | Encoded height, big-endian                          |
-| 32     | 4    | Decoder config byte length, big-endian              |
-| 36     | 4    | H.264 sample byte length, big-endian                |
-
-The optional decoder config bytes follow the header, then the encoded H.264
-sample bytes. Clients can pass initial stream settings as query parameters
-(`profile`, `fps`, `videoCodec`) and can send text control messages on the same
-socket:
-
-```json
-{ "type": "streamControl", "forceKeyframe": true }
-```
-
-```json
-{ "type": "streamControl", "clientId": "browser", "foreground": false }
-```
-
-```json
-{ "type": "streamQuality", "config": { "profile": "low", "fps": 30 } }
-```
-
-```json
-{ "type": "clientStats", "stats": { "clientId": "browser", "kind": "page" } }
-```
-
-Touch and keyboard input should use the separate `/api/simulators/{udid}/input`
-WebSocket. The video socket is latest-frame oriented: clients should paint the
-latest decoded frame locally and request a keyframe if the decoder loses sync,
-rather than ACKing every rendered frame.
-
-### `POST /api/simulators/{udid}/open-url`
-
-Opens a URL inside the simulator:
-
-```http
-POST /api/simulators/{udid}/open-url
-Content-Type: application/json
-
-{ "url": "https://example.com" }
-```
-
-```json
-{ "ok": true }
-```
-
-### `POST /api/simulators/{udid}/launch`
-
-Launches an installed app:
-
-```http
-POST /api/simulators/{udid}/launch
-Content-Type: application/json
-
-{ "bundleId": "com.apple.Preferences" }
-```
-
-```json
-{ "ok": true }
-```
-
-### `GET /api/simulators/{udid}/screenshot.png`
-
-Returns a PNG screenshot for the selected device. iOS screenshots come from the
-native simulator bridge; Android screenshots come from `adb exec-out screencap
--p`. The browser client uses this endpoint for still-image diagnostics and
-fallbacks.
 
 ## Input
 
-### `POST /api/simulators/{udid}/touch`
-
-Replays a single touch event. For drags, send `began`, one or more `moved`, then `ended` (or `cancelled`).
-
-```http
-POST /api/simulators/{udid}/touch
-Content-Type: application/json
-
-{ "x": 240.0, "y": 480.0, "phase": "began" }
-```
-
-Allowed `phase` values: `began`, `moved`, `ended`, `cancelled`.
-
-### `POST /api/simulators/{udid}/touch-sequence`
-
-Replays multiple normalized touch events through one native input session:
-
-```http
-POST /api/simulators/{udid}/touch-sequence
-Content-Type: application/json
-
-{
-  "events": [
-    { "x": 0.5, "y": 0.7, "phase": "began", "delayMsAfter": 25 },
-    { "x": 0.5, "y": 0.4, "phase": "moved", "delayMsAfter": 25 },
-    { "x": 0.5, "y": 0.2, "phase": "ended" }
-  ]
-}
-```
-
-This is the preferred API for agent gestures because it avoids one HTTP request
-per touch phase.
-
-### `POST /api/simulators/{udid}/key`
-
-Replays a single keyboard event by HID key code:
-
-```http
-POST /api/simulators/{udid}/key
-Content-Type: application/json
-
-{ "keyCode": 4, "modifiers": 0 }
-```
-
-`keyCode` is the HID usage value. `modifiers` is a bitmask defined by the HID input subsystem (defaults to `0`).
-
-### `POST /api/simulators/{udid}/key-sequence`
-
-Replays multiple HID key codes through one native input session:
-
-```http
-POST /api/simulators/{udid}/key-sequence
-Content-Type: application/json
-
-{ "keyCodes": [11, 8, 15, 15, 18], "delayMs": 5 }
-```
-
-`delayMs` defaults to `0`.
-
-### `POST /api/simulators/{udid}/button`
-
-Presses a hardware button:
-
-```http
-POST /api/simulators/{udid}/button
-Content-Type: application/json
-
-{ "button": "lock", "durationMs": 50 }
-```
-
-Supported button names match the CLI and chrome controls: `home`, `lock`,
-`power`, `side-button`, `volume-up`, `volume-down`, `action`, `mute`,
-`digital-crown`, `left-side-button`, `app-switcher`, `siri`, and `apple-pay`.
-`durationMs` defaults to `0` and is used for press-and-hold interactions.
-
-For live chrome interactions, send explicit button edges instead of a completed
-press:
-
-```json
-{ "button": "power", "phase": "down" }
-```
-
-`phase` accepts `down`, `up`, `began`, `ended`, and `cancelled`. Chrome controls
-may also pass `usagePage` and `usage` from the device profile when an exact HID
-usage is available.
-
-### `POST /api/simulators/{udid}/crown`
-
-Rotates the Apple Watch Digital Crown using scroll delta semantics:
-
-```http
-POST /api/simulators/{udid}/crown
-Content-Type: application/json
-
-{ "delta": 50 }
-```
-
-The browser UI sends this automatically when scrolling over a Watch screen or
-crown chrome.
-
-### `POST /api/simulators/{udid}/home`
-
-Presses the home button:
-
-```json
-{ "ok": true }
-```
-
-### `POST /api/simulators/{udid}/app-switcher`
-
-Invokes the app switcher as one server-side native action.
-
-### `POST /api/simulators/{udid}/rotate-left`
-
-Rotates the simulator 90° counter-clockwise.
-
-### `POST /api/simulators/{udid}/rotate-right`
-
-Rotates the simulator 90° clockwise.
-
-## Chrome rendering
-
-### `GET /api/simulators/{udid}/chrome-profile`
-
-Returns the bezel layout for the simulator:
-
-```json
-{
-  "totalWidth": 1240,
-  "totalHeight": 2602,
-  "screenX": 35,
-  "screenY": 35,
-  "screenWidth": 1170,
-  "screenHeight": 2532,
-  "cornerRadius": 220,
-  "buttons": [
-    {
-      "name": "power",
-      "label": "Sleep/Wake",
-      "x": 1210,
-      "y": 420,
-      "width": 18,
-      "height": 112,
-      "anchor": "right",
-      "onTop": false,
-      "normalOffset": { "x": -2, "y": 420 },
-      "rolloverOffset": { "x": -4, "y": 420 },
-      "imageName": "SideButton",
-      "imageDownName": "SideButtonPressed"
-    }
-  ]
-}
-```
-
-The browser client uses this to compose chrome around the live frame and to
-render physical button sprites over or under the device body.
-
-### `GET /api/simulators/{udid}/chrome.png`
-
-Returns the rendered bezel as a PNG. Pass `?buttons=false` to omit physical
-button sprites when the client renders them interactively. Cache headers are set
-to `no-cache, no-store, must-revalidate` so changes (e.g. after a device
-rotation) are picked up immediately.
-
-### `GET /api/simulators/{udid}/chrome-button/{button}.png`
-
-Returns a rendered physical button sprite. Pass `?pressed=true` for the
-pressed-state sprite when the device profile exposes one.
-
-## Accessibility
-
-### `GET /api/simulators/{udid}/accessibility-tree`
-
-Returns the current accessibility tree. The server merges framework inspectors, the Swift in-app agent, and the native accessibility tree. Query parameters:
-
-| `source`                     | Behaviour                                                                                              |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `auto` _(default)_ / unset   | Use the most accurate source available, falling back to AX.                                            |
-| `nativescript` / `ns`        | Force the NativeScript logical tree if a NativeScript inspector is connected for the foreground app.   |
-| `react-native` / `rn`        | Force the React Native component tree if a React Native inspector is connected for the foreground app. |
-| `flutter` / `fl`             | Force the Flutter widget tree if a Flutter inspector is connected for the foreground app.              |
-| `swiftui` / `swift-ui`       | Force the published SwiftUI logical tree if the Swift agent root publisher is installed in the app.    |
-| `uikit` / `in-app-inspector` | Force the raw UIKit hierarchy from the in-app inspector agent (NativeScript or Swift).                 |
-| `native-ax` / `ax`           | Always use the native accessibility snapshot.                                                          |
-| `android-uiautomator`        | Force the Android emulator UIAutomator hierarchy.                                                      |
-
-| Parameter       | Default | Description                                                                                     |
-| --------------- | ------- | ----------------------------------------------------------------------------------------------- |
-| `maxDepth`      | `80`    | Limits returned descendants for in-app inspectors. Native AX responses are trimmed server-side. |
-| `includeHidden` | `false` | Includes hidden in-app inspector views when supported by the connected inspector runtime.       |
-
-The response always includes:
-
-```json
-{
-  "roots": [...],
-  "source": "nativescript|react-native|flutter|swiftui|in-app-inspector|native-ax",
-  "availableSources": ["nativescript", "react-native", "flutter", "swiftui", "in-app-inspector", "native-ax"],
-  "fallbackReason": "...",
-  "inspector": { ... }
-}
-```
-
-`fallbackReason` is only present when the server could not honour the requested source.
-
-### `GET /api/simulators/{udid}/accessibility-point?x=...&y=...`
-
-Returns the AX-style accessibility description of the topmost element at a screen point. `x` and `y` are in UIKit screen points and must be finite, non-negative numbers.
-
-## Inspector proxy
-
-### `POST /api/simulators/{udid}/inspector/request`
-
-Proxies a single inspector method to the active in-app inspector (NativeScript or Swift) for the simulator. This is used by the browser client to fetch view properties, list available actions, and run debug-only edits.
-
-```http
-POST /api/simulators/{udid}/inspector/request
-Content-Type: application/json
-
-{
-  "method": "View.getProperties",
-  "params": { "id": "view:0x1234" }
-}
-```
-
-Allowed methods (the server enforces this allow-list):
-
-- `Inspector.getInfo`
-- `Runtime.ping`
-- `View.get`
-- `View.evaluateScript`
-- `View.getHierarchy`
-- `View.getProperties`
-- `View.setProperty`
-- `View.listActions`
-- `View.perform`
-
-The response includes both the inspector's `result` and metadata about the inspector that handled the request:
-
-```json
-{
-  "result": { "id": "view:0x1234", "properties": [...] },
-  "inspector": {
-    "bundleIdentifier": "com.example.MyApp",
-    "bundleName": "MyApp",
-    "transport": "websocket",
-    "processIdentifier": 73214,
-    "daemonUrl": null,
-    "host": "127.0.0.1",
-    "port": null,
-    "displayScale": 3,
-    "protocolVersion": "0.1"
-  }
-}
-```
-
-For the full method semantics, see the [Inspector Protocol](/api/inspector-protocol).
-
-## DevTools inspectors
-
-SimDeck serves WebKit Remote Inspector targets and Chrome DevTools Protocol
-targets separately at the API layer. The browser UI combines both sources into
-one resizeable DevTools panel with a single target list.
-
-## WebKit inspector
-
-### `GET /api/simulators/{udid}/webkit/targets`
-
-Discovers inspectable WebKit targets exposed by the simulator's `webinspectord`
-Remote Inspector socket. These are Safari pages and app web content that WebKit
-has made inspectable. On iOS 16.4 and newer, app-owned `WKWebView` instances must
-set `isInspectable = true` before they appear here.
-
-```json
-{
-  "udid": "4889B81C-FD88-49A9-BC1D-2087E7C451A2",
-  "socketPath": "/private/var/tmp/.../com.apple.webinspectord_sim.socket",
-  "targets": [
-    {
-      "id": "5049443a3731353731-1",
-      "appId": "PID:71571",
-      "appName": "Example",
-      "pageId": 1,
-      "title": "Example",
-      "url": "https://example.com/",
-      "kind": "app-web-content",
-      "inspectorUrl": "/webkit-inspector-ui/Main.html?ws=127.0.0.1:4310/api/simulators/{udid}/webkit/targets/5049443a3731353731-1/socket",
-      "webSocketUrl": "/api/simulators/{udid}/webkit/targets/5049443a3731353731-1/socket"
-    }
-  ],
-  "warnings": []
-}
-```
-
-`kind` is best-effort metadata:
-
-- `safari-page` for Mobile Safari targets.
-- `app-web-content` for app-owned inspectable web content.
-- `web-content-proxy` for WebKit proxy targets.
-
-This endpoint lists **inspectable WebKit targets**, not every `WKWebView` object
-in UIKit. AX can still reveal visible web areas that are not inspectable.
-
-### `GET /api/simulators/{udid}/webkit/targets/{targetId}/socket`
-
-Upgrades to a WebSocket. The server bridges JSON Web Inspector frontend messages
-to the simulator's binary-plist WebKit Remote Inspector protocol for the selected
-target. The `inspectorUrl` returned by `webkit/targets` points WebInspectorUI at
-this socket.
-
-### `GET /webkit-inspector-ui/Main.html`
-
-Serves the local macOS WebInspectorUI resources with a SimDeck browser host shim.
-This is authenticated like the rest of the server routes.
-
-## Chrome DevTools inspector
-
-### `GET /api/simulators/{udid}/devtools/targets`
-
-Discovers app runtime inspector sessions that can be opened with the embedded
-Chrome DevTools frontend. This includes SimDeck's in-app inspector protocol for
-React Native and NativeScript runtimes, UIKit/SwiftUI fallback metadata when
-those are the only connected logical sources, Metro React Native DevTools
-targets, and generic local Chrome Inspector targets.
-
-```json
-{
-  "udid": "4889B81C-FD88-49A9-BC1D-2087E7C451A2",
-  "targets": [
-    {
-      "id": "sdi-73214",
-      "title": "React Native: Example",
-      "type": "page",
-      "url": "simdeck://com.example.Example",
-      "description": "SimDeck React Native inspector target",
-      "devtoolsFrontendUrl": "/chrome-devtools-ui/inspector.html?ws=127.0.0.1:4310/api/simulators/{udid}/devtools/targets/sdi-73214/socket",
-      "webSocketDebuggerUrl": "ws://127.0.0.1:4310/api/simulators/{udid}/devtools/targets/sdi-73214/socket",
-      "source": "react-native",
-      "processIdentifier": 73214,
-      "bundleIdentifier": "com.example.Example",
-      "appName": "Example"
-    }
-  ],
-  "warnings": []
-}
-```
-
-Metro-discovered targets use `source: "react-native-metro"` and point at
-`/chrome-devtools-ui/rn_fusebox.html` when the target supports the React Native
-Fusebox frontend. SimDeck probes common Metro ports and matching local
-Node/React Native listener ports instead of assuming one fixed port. Generic
-Chrome Inspector targets use `source: "chrome-inspector"` and are discovered from
-common Inspector ports such as `9222-9230` plus matching local Chrome/Node
-listener ports. Proxied targets return a SimDeck `webSocketDebuggerUrl`; SimDeck
-then connects to the upstream `/inspector/debug` or Chrome DevTools WebSocket.
-
-### `GET /api/simulators/{udid}/devtools/targets/{targetId}/socket`
-
-Upgrades to a WebSocket speaking enough of the Chrome DevTools Protocol for the
-frontend to open a target, evaluate console expressions through
-`View.evaluateScript`, and render the published logical hierarchy as DOM nodes.
-
-### `GET /chrome-devtools-ui/inspector.html`
-
-Serves the bundled Chrome DevTools frontend. SimDeck uses the React Native
-debugger frontend package for these static assets and copies them into
-`client/dist/chrome-devtools-ui` during the client build.
-
-## NativeScript inspector hub
-
-### `GET /api/inspector/connect`
-
-Upgrades to a WebSocket. Used by the [`@nativescript/simdeck-inspector`](/inspector/nativescript) runtime to register itself as an in-app inspector.
-
-After connection the server sends `Inspector.getInfo` and waits for a response that includes a `processIdentifier`. Once registered, the server uses this socket as the preferred transport for `accessibility-tree` and `inspector/request` calls that target the same process.
-
-Registered WebSocket and polled inspectors are advertised in `~/.simdeck/inspectors.json` with the owning daemon URL, access token, process id, and advertised hierarchy sources. Other SimDeck daemons read this registry, validate that the process belongs to the requested simulator, and relay inspector requests through the owning daemon. Entries are refreshed while the inspector is alive and expire automatically if the daemon or app exits.
-
-### `GET /api/inspector/poll?processIdentifier=...`
-
-Long-poll fallback for environments where the WebSocket transport is not viable. Returns the next pending request as JSON, or `204 No Content` after 25 seconds with no work.
-
-### `POST /api/inspector/request`
-
-Protected daemon-to-daemon relay endpoint. A daemon uses this after discovering a matching inspector in `~/.simdeck/inspectors.json`; app runtimes and browsers should use the WebSocket/poll endpoints or `POST /api/simulators/{udid}/inspector/request` instead.
-
-```http
-POST /api/inspector/request
-Content-Type: application/json
-X-SimDeck-Token: <owning-daemon-token>
-
-{
-  "processIdentifier": 73214,
-  "method": "Runtime.ping",
-  "params": null
-}
-```
-
-### `POST /api/inspector/response`
-
-Posts a response to a previous polled request:
-
-```http
-POST /api/inspector/response
-Content-Type: application/json
-
-{
-  "processIdentifier": 73214,
-  "id": 12,
-  "result": { "ok": true }
-}
-```
-
-Pass `error` instead of `result` to deliver an error.
-
-## Logs
-
-### `GET /api/simulators/{udid}/logs`
-
-Returns recent simulator logs. Without `backfill=true`, the server tails the live `os_log` stream it has already started for the simulator. With `backfill=true`, the server runs a fresh `simctl spawn ... log show` over the requested window.
-
-| Query parameter | Default | Notes                                                                         |
-| --------------- | ------- | ----------------------------------------------------------------------------- |
-| `backfill`      | `false` | When `true`, fetch a one-shot history instead of streaming.                   |
-| `seconds`       | `30`    | Backfill window in seconds. Clamped to `[1, 1800]`.                           |
-| `limit`         | `250`   | Max entries to return. Clamped to `[1, 1000]`.                                |
-| `levels`        | _none_  | Comma-separated list of log levels to keep (`debug,info,notice,error,fault`). |
-| `processes`     | _none_  | Comma-separated list of process names (case-insensitive substring matches).   |
-| `q`             | _none_  | Free-text filter applied to the rendered log message.                         |
-
-```json
-{
-  "entries": [
-    {
-      "timestamp": "2026-04-23T19:14:12.123Z",
-      "level": "info",
-      "process": "MyApp",
-      "subsystem": "com.example.MyApp",
-      "category": "ui",
-      "pid": 73214,
-      "message": "Loaded 12 items"
-    }
-  ]
-}
-```
+| Method | Path                                      | Body                                       |
+| ------ | ----------------------------------------- | ------------------------------------------ |
+| `POST` | `/api/simulators/{udid}/tap`              | Selector or coordinate tap                 |
+| `POST` | `/api/simulators/{udid}/touch`            | `{ "x": 120, "y": 240, "phase": "began" }` |
+| `POST` | `/api/simulators/{udid}/touch-sequence`   | Multiple touch phases                      |
+| `POST` | `/api/simulators/{udid}/key`              | `{ "keyCode": 4, "modifiers": 0 }`         |
+| `POST` | `/api/simulators/{udid}/key-sequence`     | `{ "keyCodes": [11,8,15], "delayMs": 5 }`  |
+| `POST` | `/api/simulators/{udid}/button`           | `{ "button": "lock", "durationMs": 50 }`   |
+| `POST` | `/api/simulators/{udid}/crown`            | `{ "delta": 50 }`                          |
+| `POST` | `/api/simulators/{udid}/dismiss-keyboard` | Dismiss the software keyboard              |
+| `POST` | `/api/simulators/{udid}/home`             | Press Home                                 |
+| `POST` | `/api/simulators/{udid}/app-switcher`     | Open app switcher                          |
+| `POST` | `/api/simulators/{udid}/rotate-left`      | Rotate left                                |
+| `POST` | `/api/simulators/{udid}/rotate-right`     | Rotate right                               |
+
+Touch coordinates are screen points unless the endpoint body explicitly uses normalized values.
+
+## UI State And Inspection
+
+| Method | Path                                                     | Purpose                         |
+| ------ | -------------------------------------------------------- | ------------------------------- |
+| `GET`  | `/api/simulators/{udid}/accessibility-tree`              | Current UI tree                 |
+| `GET`  | `/api/simulators/{udid}/accessibility-point?x=120&y=240` | Element at a point              |
+| `POST` | `/api/simulators/{udid}/query`                           | Query tree by selector          |
+| `POST` | `/api/simulators/{udid}/wait-for`                        | Wait until selector appears     |
+| `POST` | `/api/simulators/{udid}/assert`                          | Assert selector exists          |
+| `POST` | `/api/simulators/{udid}/batch`                           | Run multiple control steps      |
+| `POST` | `/api/simulators/{udid}/inspector/request`               | Call an in-app inspector method |
+
+Tree query parameters:
+
+| Parameter       | Values                                                                                                    |
+| --------------- | --------------------------------------------------------------------------------------------------------- |
+| `source`        | `auto`, `nativescript`, `react-native`, `flutter`, `swiftui`, `uikit`, `native-ax`, `android-uiautomator` |
+| `maxDepth`      | Integer depth limit                                                                                       |
+| `includeHidden` | `true` or `false`                                                                                         |
+
+Every tree response reports the `source` used and may include a `fallbackReason`.
+
+## DevTools And WebKit
+
+| Method | Path                                                        | Purpose                                             |
+| ------ | ----------------------------------------------------------- | --------------------------------------------------- |
+| `GET`  | `/api/simulators/{udid}/webkit/targets`                     | Inspectable Safari or WKWebView targets             |
+| `GET`  | `/api/simulators/{udid}/webkit/targets/{targetId}/socket`   | WebKit inspector WebSocket                          |
+| `GET`  | `/webkit-inspector-ui/Main.html`                            | WebInspectorUI frontend                             |
+| `GET`  | `/api/simulators/{udid}/devtools/targets`                   | React Native, app runtime, Metro, or Chrome targets |
+| `GET`  | `/api/simulators/{udid}/devtools/targets/{targetId}/socket` | DevTools WebSocket                                  |
+| `GET`  | `/chrome-devtools-ui/inspector.html`                        | Chrome DevTools frontend                            |
+
+For app-owned `WKWebView` on iOS 16.4 or newer, the app must set `isInspectable = true`.
+
+## Evidence And Chrome
+
+| Method | Path                                            | Purpose                                        |
+| ------ | ----------------------------------------------- | ---------------------------------------------- |
+| `GET`  | `/api/simulators/{udid}/screenshot.png`         | PNG screenshot                                 |
+| `GET`  | `/api/simulators/{udid}/pasteboard`             | Get pasteboard text                            |
+| `POST` | `/api/simulators/{udid}/pasteboard`             | Set pasteboard text with `{ "text": "hello" }` |
+| `GET`  | `/api/simulators/{udid}/logs`                   | Recent logs                                    |
+| `GET`  | `/api/simulators/{udid}/chrome-profile`         | Screen and chrome geometry                     |
+| `GET`  | `/api/simulators/{udid}/chrome.png`             | Rendered device chrome PNG                     |
+| `GET`  | `/api/simulators/{udid}/chrome-button/{button}` | Rendered button sprite                         |
+| `GET`  | `/api/simulators/{udid}/screen-mask.png`        | Rendered screen mask PNG                       |
+
+Log query parameters:
+
+| Parameter            | Notes                                        |
+| -------------------- | -------------------------------------------- |
+| `backfill=true`      | Fetch recent history instead of current tail |
+| `seconds=30`         | Time window                                  |
+| `limit=250`          | Max entries                                  |
+| `levels=error,fault` | Filter by level                              |
+| `processes=MyApp`    | Filter by process substring                  |
+| `q=Loaded`           | Message text filter                          |
+
+## Inspector Runtime Hub
+
+| Method | Path                                        | Purpose                                 |
+| ------ | ------------------------------------------- | --------------------------------------- |
+| `GET`  | `/api/inspector/connect`                    | WebSocket for in-app runtime inspectors |
+| `GET`  | `/api/inspector/poll?processIdentifier=...` | Long-poll fallback                      |
+| `POST` | `/api/inspector/request`                    | Protected daemon-to-daemon relay        |
+| `POST` | `/api/inspector/response`                   | Response for polled requests            |
+
+Most clients should call `/api/simulators/{udid}/inspector/request` instead of these hub routes.
 
 ## Errors
 
-Error bodies look like:
+Errors are JSON:
 
 ```json
 {
@@ -780,9 +205,10 @@ Error bodies look like:
 }
 ```
 
-| Status | Cause                                                                                       |
-| ------ | ------------------------------------------------------------------------------------------- |
-| `400`  | Bad request body or query parameter (e.g. missing `url`, invalid `x`/`y`).                  |
-| `404`  | Unknown simulator.                                                                          |
-| `408`  | Timed out waiting for a downstream component (encoder keyframe, AX, inspector).             |
-| `500`  | Unhandled native bridge error. Always reported as JSON with the original message preserved. |
+| Status | Common cause                                         |
+| ------ | ---------------------------------------------------- |
+| `400`  | Bad body or query parameter                          |
+| `401`  | Missing or invalid token                             |
+| `404`  | Unknown simulator, target, or asset                  |
+| `408`  | Timed out waiting for a device, stream, or inspector |
+| `500`  | Native bridge or server error                        |

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -1,174 +1,31 @@
-# Command Reference
+# Commands
 
-Every public subcommand exposed by `simdeck`. Replace `simdeck` with `./build/simdeck` when running from a local checkout.
+Replace `simdeck` with `./build/simdeck` when running from a source checkout.
 
 ## UI And Daemon
 
-### No Subcommand
+| Command                          | Purpose                                     |
+| -------------------------------- | ------------------------------------------- |
+| `simdeck`                        | Start a foreground browser session          |
+| `simdeck <name-or-udid>`         | Start and select a device                   |
+| `simdeck -d`                     | Start or reuse the detached project daemon  |
+| `simdeck -k`                     | Stop the detached project daemon            |
+| `simdeck -r`                     | Restart the detached project daemon         |
+| `simdeck ui --open`              | Open the browser UI from a daemon           |
+| `simdeck daemon status`          | Show daemon URL, PID, token, and log path   |
+| `simdeck daemon stop`            | Stop the current project daemon             |
+| `simdeck daemon killall`         | Stop all project daemons                    |
+| `simdeck service on/off/restart` | Manage the optional always-on macOS service |
 
-Start a foreground workspace daemon and print clean local and LAN browser URLs:
-
-```sh
-simdeck
-simdeck "iPhone 17 Pro Max"
-simdeck 9750DF52-0471-48FF-B49A-B184C4BD3A3D
-simdeck --detached
-simdeck --kill
-simdeck --restart
-```
-
-The single optional argument is a simulator name or UDID to select by default in the UI. The foreground daemon binds to all interfaces, advertises the detected LAN address when available, prints the LAN HTTP URL plus a six-digit LAN pairing code, and stops when the command exits, when you press `q`, or when you press Ctrl-C.
-
-Shorthand lifecycle flags are available without a subcommand:
-
-- `-d`, `--detached` starts or reuses the background project daemon, like `simdeck daemon start`.
-- `-k`, `--kill` stops the background project daemon and returns the killed PID.
-- `-r`, `--restart` stops the background project daemon, starts a fresh one, and returns the same JSON shape as `daemon start`.
-
-### `ui`
-
-Start or reuse the project daemon and serve the browser UI.
+Examples:
 
 ```sh
-simdeck ui [--port 4310] [--bind 127.0.0.1] [--advertise-host <host>]
-           [--client-root <path>] [--video-codec auto|hardware|software]
-           [--low-latency] [--stream-quality <profile>]
-           [--local-stream-fps <15-240>] [--open]
+simdeck ui --port 4320 --open
+simdeck ui --open
+simdeck daemon restart --video-codec software --stream-quality low
 ```
 
-`--open` opens the authenticated local URL after the daemon is ready.
-
-### `studio expose`
-
-Expose one local simulator through SimDeck Studio:
-
-```sh
-simdeck studio expose [simulator] [--studio-url https://simdeck.djdev.me]
-                      [--port 4310] [--bind 127.0.0.1]
-                      [--video-codec auto|hardware|software]
-                      [--low-latency] [--stream-quality <profile>]
-```
-
-Studio expose defaults to software H.264, realtime stream delivery, and the
-`smooth` stream quality profile. The process prints the Studio URL plus the
-active codec/profile, and keeps the outbound bridge alive until Ctrl-C.
-`--video-codec hardware` opts back into the hardware encoder when that is preferable.
-
-### `provider`
-
-Run a self-hosted SimDeck Studio provider on an always-on Mac:
-
-```sh
-simdeck provider connect --studio-url https://simdeck.djdev.me \
-                         --host-id <id> --host-token <token>
-simdeck provider run [--max-capacity 1] [--simulator-template "iPhone 17 Pro"]
-simdeck provider status
-```
-
-`provider connect` stores the Studio host credential in
-`~/.simdeck/studio-provider.json` with user-only permissions. `provider run`
-starts or reuses the local daemon, heartbeats to Studio, polls for allocation
-jobs, clones simulators from the configured template, installs downloaded
-artifacts, launches the configured bundle id, proxies Studio API requests to the
-local daemon, and deletes session clones on release.
-
-### `daemon start`
-
-Start or reuse the project daemon without opening the browser:
-
-```sh
-simdeck daemon start [--port 4310] [--bind 127.0.0.1]
-                     [--advertise-host <host>] [--client-root <path>]
-                     [--video-codec auto|hardware|software] [--low-latency]
-                     [--stream-quality <profile>] [--local-stream-fps <15-240>]
-```
-
-Output:
-
-```json
-{
-  "ok": true,
-  "projectRoot": "/path/to/app",
-  "pid": 12345,
-  "pairingCode": "123456",
-  "url": "http://127.0.0.1:4310",
-  "started": true
-}
-```
-
-### `daemon status`
-
-Print daemon metadata for the current project:
-
-```sh
-simdeck daemon status
-```
-
-Detached daemons report the supervisor PID and `logPath`; the supervised child
-process is restarted automatically after recoverable server exits.
-
-### `daemon restart`
-
-Stop the daemon for the current project, then start a fresh one with the same
-options as `daemon start`:
-
-```sh
-simdeck daemon restart [--port 4310] [--bind 127.0.0.1]
-                       [--advertise-host <host>] [--client-root <path>]
-                       [--video-codec auto|hardware|software] [--low-latency]
-                       [--stream-quality <profile>] [--local-stream-fps <15-240>]
-```
-
-### `daemon stop`
-
-Stop the daemon for the current project:
-
-```sh
-simdeck daemon stop
-```
-
-### `daemon killall`
-
-Stop SimDeck project daemons across all workspaces:
-
-```sh
-simdeck daemon killall
-```
-
-### `service`
-
-Manage the optional always-on macOS user service. Use `simdeck daemon` for the
-normal per-project process; use `simdeck service` when you want a LaunchAgent
-that starts after login and stays available.
-
-```sh
-simdeck service on [--port 4310] [--bind 127.0.0.1]
-                   [--advertise-host <host>] [--client-root <path>]
-                   [--video-codec auto|hardware|software] [--low-latency]
-                   [--stream-quality <profile>] [--local-stream-fps <15-240>]
-                   [--access-token <token>]
-simdeck service restart [same options as service on]
-simdeck service off
-```
-
-`service on` installs `~/Library/LaunchAgents/dev.nativescript.simdeck.plist`
-and starts a LaunchAgent that serves SimDeck after login. It is intended for
-agents and editor integrations that should be able to open the UI without first
-starting a project daemon.
-
-### `core-simulator`
-
-Manage Apple's CoreSimulator service layer:
-
-```sh
-simdeck core-simulator restart
-simdeck core-simulator start
-simdeck core-simulator shutdown
-```
-
-Use this when `simctl` reports stale service state or simulator display attachment gets stuck before the first frame.
-
-## Simulator Lifecycle
+## Device Lifecycle
 
 ```sh
 simdeck list
@@ -177,12 +34,7 @@ simdeck shutdown <udid>
 simdeck erase <udid>
 ```
 
-`list` returns the same simulator inventory the browser UI renders, including
-Android AVDs as IDs like `android:Pixel_8_API_36`. iOS lifecycle commands use
-the native bridge. `boot` uses the private CoreSimulator path and does not fall
-back to `xcrun simctl boot`; other iOS lifecycle commands still use `xcrun
-simctl` where Apple exposes stable subcommands. Android lifecycle commands use
-the Android SDK `emulator` and `adb` tools.
+Android emulators appear as IDs such as `android:Pixel_8_API_36`.
 
 ## Apps And URLs
 
@@ -195,9 +47,7 @@ simdeck open-url <udid> https://example.com
 simdeck toggle-appearance <udid>
 ```
 
-`launch` and `open-url` use the warm daemon fast path when available.
-
-## Inspect
+## Inspect UI
 
 ```sh
 simdeck describe <udid>
@@ -208,14 +58,10 @@ simdeck describe <udid> --source react-native
 simdeck describe <udid> --source flutter
 simdeck describe <udid> --source uikit
 simdeck describe <udid> --source native-ax
-simdeck describe <udid> --source android-uiautomator
 simdeck describe <udid> --point 120,240
-simdeck describe <udid> --direct
 ```
 
-By default, `describe` uses the project daemon so it can prefer connected NativeScript, React Native, Flutter, or UIKit in-app inspectors, then fall back to the private CoreSimulator accessibility bridge. `--direct` skips the daemon and uses the native accessibility bridge directly.
-
-Use `--format agent` for compact hierarchy text intended for agent planning, and `--format compact-json` when a script needs parseable lower-token output.
+Default source selection prefers a connected framework inspector, then the Swift in-app agent, then native accessibility.
 
 ## Input
 
@@ -225,23 +71,25 @@ Coordinates are screen points unless `--normalized` is present.
 simdeck tap <udid> 120 240
 simdeck tap <udid> 0.5 0.5 --normalized
 simdeck tap <udid> --label "Continue" --wait-timeout-ms 5000
-simdeck touch <udid> 0.5 0.5 --phase began --normalized
-simdeck touch <udid> 120 240 --down --up --delay-ms 800
 simdeck swipe <udid> 200 700 200 200
 simdeck gesture <udid> scroll-down
 simdeck pinch <udid> --start-distance 160 --end-distance 80
 simdeck rotate-gesture <udid> --radius 100 --degrees 90
+simdeck type <udid> "hello"
+simdeck type <udid> --file message.txt
 simdeck key <udid> enter
 simdeck key-sequence <udid> --keycodes h,e,l,l,o
 simdeck key-combo <udid> --modifiers cmd --key a
-simdeck type <udid> "hello"
-simdeck type <udid> --file message.txt
+```
+
+System controls:
+
+```sh
 simdeck button <udid> lock --duration-ms 1000
 simdeck button <udid> volume-up
-simdeck button <udid> action --duration-ms 1000
+simdeck button <udid> action
 simdeck button <udid> digital-crown
 simdeck crown <udid> --delta 50
-simdeck button <udid> left-side-button
 simdeck dismiss-keyboard <udid>
 simdeck home <udid>
 simdeck app-switcher <udid>
@@ -249,50 +97,53 @@ simdeck rotate-left <udid>
 simdeck rotate-right <udid>
 ```
 
-Use selectors (`--id`, `--label`, `--value`, `--element-type`) when possible. Use `--stdin` or `--file` for text containing quotes, newlines, or shell-sensitive characters.
-
 ## Batch
-
-Run a known sequence through one command:
 
 ```sh
 simdeck batch <udid> \
   --step "tap --label Continue --wait-timeout-ms 5000" \
   --step "type 'hello world'" \
-  --step "wait-for --label 'hello world' --timeout-ms 5000" \
-  --step "gesture scroll-down"
+  --step "wait-for --label 'hello world' --timeout-ms 5000"
 ```
 
-Batch input can come from `--step`, `--file`, or `--stdin`. Use `wait-for` or `assert` with selector flags (`--id`, `--label`, `--value`, `--element-type`) to wait for UI state instead of fixed delays. `sleep 500` waits 500 ms; suffix seconds explicitly with `s`, as in `sleep 0.5s`. It fails fast by default; pass `--continue-on-error` for best-effort execution.
+Use `wait-for` or `assert` steps instead of fixed sleeps when possible.
 
 ## Evidence
 
 ```sh
 simdeck screenshot <udid> --output screen.png
 simdeck screenshot <udid> --stdout > screen.png
-simdeck stream <udid> --frames 120 > stream.h264
 simdeck pasteboard set <udid> "hello"
 simdeck pasteboard get <udid>
 simdeck logs <udid> --seconds 30 --limit 200
 simdeck chrome-profile <udid>
 ```
 
-`stream` writes Annex B H.264 samples to stdout and runs until interrupted, or
-until `--frames` samples have been written. It is intended for diagnostics and
-external tools, and is iOS-only. Android live viewing in the browser uses the
-WebRTC H.264 endpoint; raw frames come from emulator gRPC and are encoded
-through VideoToolbox.
-
-`logs` fetches recent simulator logs or Android `logcat` output. `chrome-profile`
-returns the CoreSimulator chrome layout for iOS and a screen-sized profile for
-Android.
-
-## HTTP Fast Path
-
-Supported hot controls use the daemon automatically. To target a specific daemon, set:
+Diagnostic iOS H.264 stream:
 
 ```sh
-export SIMDECK_SERVER_URL=http://127.0.0.1:4310
+simdeck stream <udid> --frames 120 > stream.h264
 ```
 
-This avoids repeated native setup in short-lived CLI processes. Commands that need local files, screenshots, pasteboard, or direct AX point queries still use the direct native path when appropriate.
+## Studio And Providers
+
+For hosted Studio workflows:
+
+```sh
+simdeck studio expose [simulator]
+simdeck provider connect --studio-url <url> --host-id <id> --host-token <token>
+simdeck provider run
+simdeck provider status
+```
+
+These commands are mainly for managed remote simulator hosts.
+
+## CoreSimulator Service
+
+```sh
+simdeck core-simulator restart
+simdeck core-simulator start
+simdeck core-simulator shutdown
+```
+
+Use this when Apple's simulator service is stale or unresponsive.

--- a/docs/cli/flags.md
+++ b/docs/cli/flags.md
@@ -1,96 +1,75 @@
-# Flags & Options
+# Flags
 
-A consolidated list of the public SimDeck CLI flags, grouped by command.
-
-::: tip Help output
-Pass `--help` to any command to see the generated flag list from the binary:
+Pass `--help` to any command for the generated flag list:
 
 ```sh
-simdeck ui --help
-simdeck daemon start --help
+simdeck --help
 simdeck tap --help
+simdeck daemon start --help
 ```
 
-:::
+## Global
 
-## Global Flags
+| Flag                 | Env                  | Purpose                          |
+| -------------------- | -------------------- | -------------------------------- |
+| `--server-url <url>` | `SIMDECK_SERVER_URL` | Target a specific running daemon |
 
-### `--server-url <url>`
+## Server Options
 
-| Default | unset                |
-| ------- | -------------------- |
-| Env     | `SIMDECK_SERVER_URL` |
-| Type    | `http://` URL        |
+Used by `simdeck ui`, `daemon start`, `daemon restart`, `service on`, and `service restart`.
 
-Targets a specific running SimDeck daemon for commands that support the HTTP fast path. If unset, commands start or reuse the current project's daemon when needed.
-
-## `ui`, `daemon start`, And `daemon restart`
-
-`ui`, `daemon start`, and `daemon restart` accept the same server options. `ui` also accepts `--open`.
-
-| Flag                 | Default               | Description                                                                                                                   |
-| -------------------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `--port <u16>`       | `4310`                | HTTP port for the REST API, browser UI, and WebRTC offer endpoint.                                                            |
-| `--bind <ip>`        | `127.0.0.1`           | Bind address (`0.0.0.0` for [LAN access](/guide/lan-access), `::` for IPv6).                                                  |
-| `--advertise-host`   | matches local host    | Hostname or IP printed for LAN browser access.                                                                                |
-| `--client-root`      | bundled `client/dist` | Override the static browser client directory.                                                                                 |
-| `--video-codec`      | `auto`                | One of `auto`, `hardware`, or `software`. See [Video Pipeline](/guide/video).                                                 |
-| `--low-latency`      | `false`               | Software H.264 profile for slower runners: caps at 15 fps and favors freshness.                                               |
-| `--stream-quality`   | `full`                | Realtime stream quality profile: `full`, `quality`, `balanced`, `fast`, `smooth`, `economy`, `low`, `tiny`, or `ci-software`. |
-| `--local-stream-fps` | `60`                  | Local quality stream frame target, from 15 to 240 fps.                                                                        |
-| `--open`             | `false`               | `ui` only. Open the browser after the daemon is ready.                                                                        |
-
-`studio expose` defaults to software H.264. Pass `--video-codec hardware` to
-opt into the hardware encoder when that is preferable.
-
-The public commands generate an access token automatically. Use `simdeck daemon status` to read it for direct API callers.
+| Flag                         | Default        | Notes                                                                             |
+| ---------------------------- | -------------- | --------------------------------------------------------------------------------- | ------ | ------------ |
+| `--port <port>`              | `4310`         | HTTP port                                                                         |
+| `--bind <ip>`                | `127.0.0.1`    | Use `0.0.0.0` or `::` for LAN access                                              |
+| `--advertise-host <host>`    | detected       | Host printed for remote browsers                                                  |
+| `--client-root <path>`       | bundled client | Static client directory                                                           |
+| `--video-codec auto          | hardware       | software`                                                                         | `auto` | Encoder mode |
+| `--stream-quality <profile>` | `full`         | `full`, `balanced`, `economy`, `low`, `tiny`, `ci-software`, and related profiles |
+| `--local-stream-fps <fps>`   | `60`           | Local stream frame target                                                         |
+| `--low-latency`              | off            | Conservative software H.264 profile                                               |
+| `--open`                     | off            | `ui` only                                                                         |
 
 ## `describe`
 
-| Flag               | Default                        | Description                                                                                                          |
-| ------------------ | ------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
-| `--format`         | `json`                         | Output format: `json`, `compact-json`, or `agent`.                                                                   |
-| `--source`         | `auto`                         | Hierarchy source: `auto`, `nativescript`, `react-native`, `flutter`, `uikit`, `native-ax`, or `android-uiautomator`. |
-| `--max-depth`      | unlimited native / `80` daemon | Trim descendants after the requested depth.                                                                          |
-| `--include-hidden` | `false`                        | Include hidden in-app inspector views when supported.                                                                |
-| `--direct`         | `false`                        | Skip the daemon and use the private native accessibility bridge directly.                                            |
-| `--point <x>,<y>`  | unset                          | Return the native element at a screen point.                                                                         |
+| Flag               | Purpose                                           |
+| ------------------ | ------------------------------------------------- | ------------ | ------------------- | ----- | --------- | -------------------- | --------------------- |
+| `--format json     | compact-json                                      | agent`       | Choose output shape |
+| `--source auto     | nativescript                                      | react-native | flutter             | uikit | native-ax | android-uiautomator` | Pick inspector source |
+| `--max-depth <n>`  | Trim hierarchy depth                              |
+| `--include-hidden` | Include hidden nodes when supported               |
+| `--point <x>,<y>`  | Describe the element at a screen point            |
+| `--direct`         | Skip daemon and use native accessibility directly |
 
-## Input Flags
+## Input
 
-Common input commands:
+| Command          | Useful flags                                                                                         |
+| ---------------- | ---------------------------------------------------------------------------------------------------- |
+| `tap`            | `--id`, `--label`, `--value`, `--element-type`, `--wait-timeout-ms`, `--normalized`, `--duration-ms` |
+| `touch`          | `--phase`, `--normalized`, `--down`, `--up`, `--delay-ms`                                            |
+| `swipe`          | `--normalized`, `--duration-ms`, `--steps`                                                           |
+| `gesture`        | `--normalized`, `--duration-ms`, `--delta`                                                           |
+| `pinch`          | `--start-distance`, `--end-distance`, `--angle-degrees`, `--normalized`                              |
+| `rotate-gesture` | `--radius`, `--degrees`, `--normalized`                                                              |
+| `type`           | `--stdin`, `--file`, `--delay-ms`                                                                    |
+| `key`            | `--modifiers`, `--duration-ms`                                                                       |
+| `key-sequence`   | `--keycodes`, `--delay-ms`                                                                           |
+| `key-combo`      | `--modifiers`, `--key`                                                                               |
+| `button`         | `--duration-ms`                                                                                      |
 
-| Command          | Important flags                                                                                                                                                 |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `tap`            | `--id`, `--label`, `--value`, `--element-type`, `--wait-timeout-ms`, `--poll-interval-ms`, `--normalized`, `--duration-ms`, `--pre-delay-ms`, `--post-delay-ms` |
-| `touch`          | `--phase`, `--normalized`, `--down`, `--up`, `--delay-ms`                                                                                                       |
-| `swipe`          | `--normalized`, `--duration-ms`, `--steps`, `--pre-delay-ms`, `--post-delay-ms`                                                                                 |
-| `gesture`        | `--screen-width`, `--screen-height`, `--normalized`, `--duration-ms`, `--delta`, `--pre-delay-ms`, `--post-delay-ms`                                            |
-| `pinch`          | `--start-distance`, `--end-distance`, `--angle-degrees`, `--normalized`, `--duration-ms`, `--steps`                                                             |
-| `rotate-gesture` | `--radius`, `--degrees`, `--normalized`, `--duration-ms`, `--steps`                                                                                             |
-| `type`           | `--stdin`, `--file`, `--delay-ms`                                                                                                                               |
-| `key`            | `--modifiers`, `--duration-ms`, `--pre-delay-ms`, `--post-delay-ms`                                                                                             |
-| `key-sequence`   | `--keycodes`, `--delay-ms`                                                                                                                                      |
-| `key-combo`      | `--modifiers`, `--key`                                                                                                                                          |
-| `button`         | `--duration-ms`                                                                                                                                                 |
-
-Coordinates are screen points unless `--normalized` is present. Normalized coordinates are clamped to `0.0..1.0`.
-
-## Evidence And Batch Flags
+## Evidence And Batch
 
 | Command          | Flags                                                |
 | ---------------- | ---------------------------------------------------- |
 | `screenshot`     | `--output <path>`, `--stdout`                        |
-| `logs`           | `--seconds <f64>`, `--limit <usize>`                 |
+| `logs`           | `--seconds <seconds>`, `--limit <count>`             |
 | `pasteboard set` | `--stdin`, `--file`                                  |
 | `batch`          | `--step`, `--file`, `--stdin`, `--continue-on-error` |
 
 ## Exit Codes
 
-| Exit code | Meaning                                                                    |
-| --------- | -------------------------------------------------------------------------- |
-| `0`       | Success.                                                                   |
-| `1`       | Command-level failure (bad usage, missing simulator, native bridge error). |
-| `2`       | Clap parser errors.                                                        |
-
-Errors print a short message to stderr; structured JSON is reserved for success output.
+| Code | Meaning                    |
+| ---- | -------------------------- |
+| `0`  | Success                    |
+| `1`  | Runtime or command failure |
+| `2`  | Argument parsing failure   |

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -1,50 +1,58 @@
 # CLI
 
-The `simdeck` binary is the only entrypoint SimDeck ships. It opens the browser UI, manages a warm project daemon, and exposes simulator-control subcommands for scripts and tests.
+`simdeck` is the main entrypoint for opening the browser UI, managing the daemon, and scripting simulator actions.
 
-## Synopsis
+## Common Use
+
+```sh
+simdeck
+simdeck "iPhone 17 Pro Max"
+simdeck -d
+simdeck -k
+simdeck -r
+```
+
+With no subcommand, SimDeck starts a foreground server and prints browser URLs. A single simulator name or UDID selects that device in the UI. The shorthand flags start, stop, and restart the detached project daemon.
+
+## Command Shape
 
 ```sh
 simdeck [SIMULATOR_NAME_OR_UDID]
-simdeck [-d|--detached]
-simdeck [-k|--kill]
-simdeck [-r|--restart]
-simdeck [--server-url <url>] <COMMAND> [OPTIONS]
+simdeck [--server-url <url>] <command> [options]
 ```
 
-With no subcommand, `simdeck` starts a foreground workspace daemon and prints local/LAN browser URLs. A single argument selects that simulator by name or UDID in the UI. Use `-d`, `-k`, and `-r` as short aliases for detached start, stop, and restart.
-
-Most commands automatically start or reuse the project daemon when that is the fastest path. Set `SIMDECK_SERVER_URL=http://127.0.0.1:4310` or pass `--server-url` to target a specific already-running daemon.
-
-## Top-level commands
-
-| Command                                                 | Purpose                                                     |
-| ------------------------------------------------------- | ----------------------------------------------------------- |
-| _(none)_                                                | Start a foreground UI daemon until `q` or Ctrl-C.           |
-| `ui`                                                    | Start or reuse the project daemon and serve the browser UI. |
-| `daemon start/status/stop`                              | Manage the project daemon explicitly.                       |
-| `core-simulator ...`                                    | Restart or manage Apple's CoreSimulator service layer.      |
-| `list`                                                  | Print every simulator known to the native bridge as JSON.   |
-| `boot` / `shutdown` / `erase`                           | Manage simulator lifecycle.                                 |
-| `install` / `uninstall` / `launch` / `open-url`         | Manage apps and URLs inside a simulator.                    |
-| `describe`                                              | Print accessibility or in-app inspector hierarchy data.     |
-| `tap` / `swipe` / `gesture` / `type` / `key` / `button` | Drive simulator input.                                      |
-| `screenshot` / `logs` / `pasteboard` / `chrome-profile` | Collect evidence and device metadata.                       |
-
-Every subcommand returns an exit code that follows shell conventions: zero on success, non-zero on failure.
-
-## Output format
-
-Most subcommands print JSON. This makes the CLI easy to consume from scripts:
+Use `--server-url` or `SIMDECK_SERVER_URL` when a script should target a specific daemon:
 
 ```sh
-simdeck list | jq '.simulators[] | select(.isBooted)'
+SIMDECK_SERVER_URL=http://127.0.0.1:4310 simdeck list
 ```
 
-Errors print a short human-readable message to stderr and a non-zero exit code. They do not print structured JSON for failure cases.
+## Most-Used Commands
 
-## See also
+```sh
+simdeck list
+simdeck boot <udid>
+simdeck install <udid> /path/to/App.app
+simdeck launch <udid> com.example.App
+simdeck open-url <udid> https://example.com
+simdeck tap <udid> --label "Continue" --wait-timeout-ms 5000
+simdeck describe <udid> --format agent --max-depth 3
+simdeck screenshot <udid> --output screen.png
+simdeck logs <udid> --seconds 30 --limit 200
+```
 
-- **[Command Reference](/cli/commands)** — every subcommand in detail.
-- **[Flags & Options](/cli/flags)** — global flags and per-subcommand options.
-- **[REST API](/api/rest)** — the HTTP equivalent of every CLI subcommand.
+Most successful commands print JSON so they can be piped into tools such as `jq`.
+
+## Help
+
+```sh
+simdeck --help
+simdeck tap --help
+simdeck daemon start --help
+```
+
+## Next
+
+- [Commands](/cli/commands)
+- [Flags](/cli/flags)
+- [REST API](/api/rest)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,126 +1,76 @@
 # Contributing
 
-SimDeck welcomes contributions. This page covers the toolchain, the layout, and the working rules to follow when proposing a change.
+This page covers local setup, checks, and the boundaries to keep in mind when changing SimDeck.
 
-## Toolchain
+## Setup
 
-You'll need:
+Requirements:
 
-- **macOS 13+** with the iOS Simulator runtimes installed.
-- **Xcode command-line tools**: `xcode-select --install`.
-- **Node.js ≥ 18** and npm.
-- **Rust stable** via [rustup](https://rustup.rs/).
-
-Optional:
-
-- **`prettier`** for formatting (installed via `npm install`).
-- **`cargo fmt`** and **`cargo clippy`** for Rust formatting and lints (ship with rustup).
-
-## First-time setup
-
-Clone, install dependencies, and build the CLI plus browser client:
+- macOS with Xcode and iOS Simulator runtimes.
+- Node.js 18 or newer.
+- Rust stable.
+- Optional Android SDK tools for Android emulator work.
 
 ```sh
 git clone https://github.com/NativeScript/SimDeck.git
-cd simdeck
+cd SimDeck
 npm install
 npm run build
 ```
 
-`npm install` installs JavaScript tooling only. `npm run build` rebuilds the Rust binary and React bundle. Use `npm run build:all` when you also need the NativeScript inspector, React Native inspector, and `simdeck/test` outputs.
-
-## Running locally
-
-```sh
-npm run dev
-```
-
-This starts the Rust server in the background and runs the Vite dev server for the React client. The server log lands at `build/cli.log`.
-
-To run only the production server:
+Run the built CLI:
 
 ```sh
 ./build/simdeck
 ```
 
-## Layout
+Run the development server:
 
-| Folder                             | What lives here                                                                                            |
-| ---------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `server/`                          | CLI entrypoint, project daemon, Rust HTTP server, stream transports, inspector hub, registry, and metrics. |
-| `cli/`                             | Objective-C native bridge for private CoreSimulator and SimulatorKit APIs.                                 |
-| `client/`                          | React UI served at `/`.                                                                                    |
-| `packages/nativescript-inspector/` | TypeScript runtime for the NativeScript inspector.                                                         |
-| `packages/flutter-inspector/`      | Flutter runtime plugin for publishing widget, render, and semantics hierarchy data.                        |
-| `packages/inspector-agent/`        | Swift Package for the Swift in-app inspector agent.                                                        |
-| `packages/simdeck-test/`           | JS/TS testing API for daemon-backed simulator automation.                                                  |
-| `packages/vscode-extension/`       | VS Code extension that opens the simulator inside an editor panel.                                         |
-| `scripts/`                         | Repeatable build entrypoints used by both local dev and CI.                                                |
-| `bin/`                             | Node launcher that locates and runs the compiled binary.                                                   |
-| `docs/`                            | This documentation site (VitePress).                                                                       |
+```sh
+npm run dev
+```
 
-## Working rules
+The server log is written to `build/cli.log`.
 
-If you contribute, keep these invariants in mind. They are also enforced by the `AGENTS.md` guide that lives at the repo root.
+## Repository Map
 
-- Simulator-native logic stays in Objective-C under `cli/`.
-- Rust server logic stays under `server/`.
-- Browser-only presentation logic stays in `client/`.
-- NativeScript app runtime inspection logic stays in `packages/nativescript-inspector/`.
-- React Native app runtime inspection logic stays in `packages/react-native-inspector/`.
-- Flutter app runtime inspection logic stays in `packages/flutter-inspector/`.
-- Prefer adding a server endpoint before adding client-only assumptions.
-- Don't add a Node or Swift dependency to solve work that already fits in Foundation/AppKit.
-- When touching private API usage, keep the adaptation small and explicit and document any simulator/runtime assumptions in `AGENTS.md`.
-- Prefer stable CLI subcommands over hidden environment variables.
-- The supported live video paths are the WebRTC H.264 offer endpoint plus the `/api/simulators/{udid}/h264` WebSocket fallback. Do not bring back legacy `/stream.h264` handling.
-- If a feature depends on a booted simulator, fail with a clear JSON error instead of silently returning an empty asset.
+| Folder      | Purpose                                                |
+| ----------- | ------------------------------------------------------ |
+| `server/`   | CLI entrypoint, daemon, API, stream transport, metrics |
+| `cli/`      | macOS simulator bridge                                 |
+| `client/`   | Browser UI                                             |
+| `packages/` | Inspectors, VS Code extension, and `simdeck/test`      |
+| `scripts/`  | Build, package, and test helpers                       |
+| `docs/`     | VitePress documentation                                |
 
-## Linting and formatting
+## Working Rules
 
-Format the entire repo:
+- Keep simulator-native logic in `cli/`.
+- Keep server behavior in `server/`.
+- Keep browser presentation in `client/`.
+- Keep runtime inspector logic in the matching `packages/*-inspector` package.
+- Prefer a stable CLI command or API route over hidden environment behavior.
+- Update docs when changing CLI flags, API routes, stream behavior, or inspector methods.
+
+## Build And Check
 
 ```sh
 npm run format
-```
-
-Check formatting in CI mode (no writes):
-
-```sh
-npm run format:check
-```
-
-Run all lints:
-
-```sh
 npm run lint
-```
-
-This runs:
-
-- `prettier --check .`
-- `cargo fmt --check`
-- `cargo clippy --all-targets -- -D warnings`
-- `tsc --noEmit` for the React client.
-
-## Tests
-
-```sh
 npm run test
+npm run ci
 ```
 
-This runs the Cargo test suite for the server and the Vitest suite for the client.
+What `npm run ci` covers:
 
-Build the JS/TS testing package with:
+1. Formatting and lint checks.
+2. Full build.
+3. Rust and client tests.
+4. VS Code extension package.
 
-```sh
-npm run build:simdeck-test
-```
+## Integration Tests
 
-The simulator-backed CLI integration suite is separate because it creates,
-boots, drives, erases, and deletes a temporary iOS simulator. The suite also
-builds and installs a tiny UIKit fixture app directly with `clang` so install,
-uninstall, and opt-in launch checks use a deterministic local app bundle:
+iOS:
 
 ```sh
 npm run build:cli
@@ -128,78 +78,49 @@ npm run build:client
 npm run test:integration:cli
 ```
 
-For an interactive local run that opens Simulator.app and prints each CLI/HTTP
-step with timings:
+Verbose iOS run:
 
 ```sh
 npm run test:integration:cli:verbose
 ```
 
-The integration runner captures `describe` after each control step. If iOS
-shows a known system URL-opening confirmation, the runner handles it and then
-captures the UI again before continuing.
-
-Verbose mode prints CLI commands, command output, timings, and UI checkpoints.
-Set `SIMDECK_INTEGRATION_TRACE_HTTP=1` if you also need raw HTTP request logs.
-
-Set `SIMDECK_INTEGRATION_KEEP_SIMULATOR=1` with the verbose command if you want
-the temporary simulator left around for inspection after the suite exits.
-
-GitHub Actions runs the iOS suite on macOS after the normal build/test pipeline.
-It also runs the Android integration suite on an Ubuntu runner with a real
-Android emulator. Linux builds use a native iOS stub so the Android bridge,
-daemon, CLI, and `simdeck/test` API can be exercised without macOS frameworks.
-The Android CI job preboots the AVD with `android-emulator-runner` before
-starting SimDeck; local Android integration runs skip cleanly unless an emulator
-is already booted or `SIMDECK_INTEGRATION_BOOT_ANDROID=1` is set.
-The integration suites do not require the live video display bridge; REST input
-routes use the non-display input path, and the video stream is covered by
-lower-level protocol tests.
-
-## Full CI pipeline
+Android:
 
 ```sh
-npm run ci
+npm run build:cli
+npm run build:simdeck-test
+npm run test:integration:android
 ```
 
-This is the normal local CI script:
+Useful variables:
 
-1. `npm run lint` — formatting and lint checks.
-2. `npm run build:all` — Rust + Objective-C, React client, NativeScript inspector, React Native inspector, and `simdeck/test`.
-3. `npm run test` — Rust and TypeScript tests.
-4. `npm run package:vscode-extension` — VS Code `.vsix`.
+| Variable                                 | Purpose                         |
+| ---------------------------------------- | ------------------------------- |
+| `SIMDECK_INTEGRATION_VERBOSE=1`          | Print more detail               |
+| `SIMDECK_INTEGRATION_SHOW_SIMULATOR=1`   | Show Simulator.app during tests |
+| `SIMDECK_INTEGRATION_KEEP_SIMULATOR=1`   | Keep temporary iOS simulator    |
+| `SIMDECK_INTEGRATION_ANDROID_AVD=<name>` | Pick an Android AVD             |
+| `SIMDECK_INTEGRATION_BOOT_ANDROID=1`     | Boot Android locally            |
 
-GitHub Actions runs `npm run ci`, then `npm run test:integration:cli` for the
-temp-simulator CLI and REST control sweep, plus
-`npm run test:integration:android` on Ubuntu for Android emulator coverage. A
-clean `npm run ci` and integration run are required for any PR that changes
-simulator control behavior.
-
-## Documentation
-
-This site is a VitePress project under `docs/`. To preview it:
+## Docs
 
 ```sh
 npm run docs:dev
-```
-
-To build the static site:
-
-```sh
 npm run docs:build
 ```
 
-The build artefact lands at `docs/.vitepress/dist`. The docs deploy workflow (`.github/workflows/docs.yml`) publishes that directory to GitHub Pages on every push to `main`.
+The docs site lives under `docs/` and deploys to GitHub Pages from `.github/workflows/docs.yml`.
 
-When you change something in the repo that the docs already cover — a CLI flag, a route, a packet field, an inspector method — please update the matching docs page in the same PR.
+## Issues And PRs
 
-## Filing issues and PRs
+For simulator or stream bugs, include:
 
-- Open an issue for anything that requires discussion before code.
-- For straightforward fixes, a PR is fine without a paired issue.
-- Include reproduction steps and the macOS / Xcode version when filing simulator-related bugs.
-- Include the server log (`build/cli.log` from `npm run dev`, or foreground daemon output from a reproduction) when filing video-stream bugs.
+- Reproduction steps.
+- `simdeck --version`.
+- macOS and Xcode versions.
+- Foreground daemon output or `build/cli.log`.
+- Any relevant screenshots or CLI output.
 
 ## License
 
-SimDeck is licensed under the Apache License 2.0. By contributing you agree to license your changes under the same terms.
+SimDeck is licensed under Apache-2.0. Contributions are licensed under the same terms.

--- a/docs/extensions/browser-client.md
+++ b/docs/extensions/browser-client.md
@@ -1,104 +1,67 @@
 # Browser Client
 
-The default UI SimDeck serves at `/` is a React app built with Vite. It lives at `client/` in this repo and is bundled into `client/dist/` for production. The Rust server serves the bundle as static assets.
+The browser client is the UI served by `simdeck` at `/`. It is the same surface used in normal browser sessions and inside the VS Code extension.
 
-You almost certainly don't need to know about the internals — the client just works. This page is for contributors and for anyone who wants to embed the same surface somewhere else.
+## Open It
 
-## Tech stack
-
-- **React 19** — view layer.
-- **TypeScript** — strict typing for everything in `client/src/`.
-- **Vite** — dev server and production build.
-- **Vitest** — unit tests.
-
-## Layout
-
-```text
-client/
-├── index.html
-├── vite.config.js
-├── package.json
-└── src/
-    ├── main.tsx
-    ├── app/
-    │   ├── App.tsx
-    │   └── AppShell.tsx
-    ├── api/
-    │   ├── client.ts
-    │   ├── controls.ts
-    │   ├── simulators.ts
-    │   └── types.ts
-    ├── features/
-    │   ├── simulators/
-    │   ├── viewport/
-    │   ├── stream/
-    │   ├── input/
-    │   ├── accessibility/
-    │   └── toolbar/
-    ├── shared/
-    └── styles/
+```sh
+simdeck
 ```
 
-| Folder                    | Responsibility                                                                       |
-| ------------------------- | ------------------------------------------------------------------------------------ |
-| `api/`                    | Typed wrappers around the SimDeck REST API and shared TypeScript types.              |
-| `features/simulators/`    | Sidebar list of simulators plus boot/shutdown affordances.                           |
-| `features/viewport/`      | Frame canvas, chrome compositing, hit testing.                                       |
-| `features/stream/`        | WebRTC media/RGBA stream client, H.264 fallback, receiver stats, and frame plumbing. |
-| `features/input/`         | Touch / keyboard / hardware-button affordances.                                      |
-| `features/accessibility/` | Accessibility tree pane and source switcher.                                         |
-| `features/toolbar/`       | Top toolbar (rotate, home, app switcher, dark mode toggle, refresh).                 |
+Then open the printed local URL.
 
-## Bootstrap flow
+Detached flow:
 
-1. The browser fetches `index.html` from the Rust server.
-2. `main.tsx` mounts the React tree at `#root`.
-3. `AppShell` calls `GET /api/health` to learn the active encoder mode.
-4. The simulator sidebar fetches `GET /api/simulators` and renders the list.
-5. Selecting a device posts an SDP offer to `/api/simulators/<udid>/webrtc/offer`.
-6. The browser renders the WebRTC stream. iOS uses an H.264 media track; Android loopback clients use a raw RGBA data channel, while non-loopback Android clients use VideoToolbox-encoded H.264.
-7. Touch and key events round-trip through `POST /api/simulators/<udid>/touch` and `/key`.
+```sh
+simdeck ui --open
+```
 
-## Dev workflow
+LAN flow:
 
-The repo's `npm run dev` script runs the server and Vite together:
+```sh
+simdeck ui --bind 0.0.0.0 --advertise-host 192.168.1.50 --open
+```
+
+## What The UI Provides
+
+- Device list with boot and selection controls.
+- Live video with stream quality controls.
+- Pointer, keyboard, and hardware-button input.
+- Rotation, home, app switcher, dark-mode toggle, and refresh actions.
+- Accessibility and framework inspector panes.
+- DevTools panel for supported WebKit, Metro, Chrome, and runtime targets.
+- Stream diagnostics.
+
+## Stream URL Options
+
+Force a stream transport while debugging:
+
+```text
+http://127.0.0.1:4310?stream=webrtc
+http://127.0.0.1:4310?stream=h264
+```
+
+Use the default URL for normal operation.
+
+## Serve A Custom Client
+
+Point the daemon at another static bundle:
+
+```sh
+simdeck ui --client-root /path/to/dist --open
+```
+
+Your client should use the [REST API](/api/rest), WebRTC offer endpoint, and control WebSocket documented in the API reference.
+
+## Develop The Built-In Client
 
 ```sh
 npm run dev
 ```
 
-This:
-
-- Builds the Rust CLI if it isn't built.
-- Stops any stale SimDeck server listening on `4310`.
-- Starts the Rust server in the background, logging to `build/cli.log`.
-- Runs `vite` from `client/` against the local server, with hot-module reload.
-
-Vite serves on `http://127.0.0.1:5173` and proxies API calls to the Rust server on `4310`.
-
-## Tests and types
+This starts the local SimDeck server and the Vite dev server. Client checks:
 
 ```sh
 npm run --prefix client typecheck
 npm run --prefix client test
 ```
-
-`typecheck` runs `tsc --noEmit` against the strict client config. `test` runs the Vitest suite in `client/src/`.
-
-## Replacing the client
-
-The daemon takes a `--client-root <path>` flag. You can ship a completely different UI by pointing it at a directory of static files:
-
-```sh
-simdeck ui --port 4310 --client-root /path/to/your/dist --open
-```
-
-As long as your client speaks the documented [REST API](/api/rest) and WebRTC offer endpoint, it will work end to end.
-
-## Embedding in another app
-
-The browser client is designed to live inside any container that can host a webview. The bundled VS Code extension is one example; embedding it in an Electron app, a Tauri shell, or a custom dashboard works the same way:
-
-1. Point the host at `http://<simdeck-host>:<port>/`.
-2. Allow the host to talk to the same HTTP origin exposed by the server.
-3. For direct API calls outside the served origin, pass the SimDeck access token with `X-SimDeck-Token` or `Authorization: Bearer`.

--- a/docs/extensions/vscode.md
+++ b/docs/extensions/vscode.md
@@ -1,76 +1,71 @@
 # VS Code Extension
 
-A bundled VS Code extension opens the SimDeck browser client inside an editor panel and can start or reuse the project daemon when needed. The extension lives in `packages/vscode-extension/` and ships pre-bundled with the npm package.
+The VS Code extension opens the SimDeck browser UI in an editor panel and can start the project daemon for you.
 
 ## Install
 
-The fastest path is to package the extension from this checkout and install it locally with the VS Code CLI:
-
-```sh
-npm run package:vscode-extension
-npm run install:vscode-extension
-```
-
-Short aliases are available too:
+From a source checkout:
 
 ```sh
 npm run package:vscode
 npm run install:vscode
 ```
 
-This:
+This builds and installs `build/vscode/simdeck-vscode.vsix`.
 
-1. Builds a `.vsix` at `build/vscode/simdeck-vscode.vsix`.
-2. Installs it via `code --install-extension build/vscode/simdeck-vscode.vsix --force`.
+If the `code` command is missing, run **Shell Command: Install 'code' command in PATH** from the VS Code command palette.
 
-If the `code` command isn't on your `PATH`, install it from VS Code via **Shell Command: Install 'code' command in PATH** in the command palette.
+## Open SimDeck
 
-## Use it
-
-After installing, open the command palette and run:
+Run this command from the command palette:
 
 ```text
 SimDeck: Open Simulator View
 ```
 
-The extension opens a webview panel pointed at a SimDeck daemon URL. If the configured URL is not reachable, the extension runs `simdeck ui`, reads the returned daemon URL, and loads that URL in the webview.
+The extension tries the configured server URL first. If it is not reachable and auto-start is enabled, it runs `simdeck ui` for the current workspace.
 
-Two more commands round out the surface:
+## Commands
 
-- **SimDeck: Stop Project Daemon** — runs `simdeck daemon stop` for the current workspace.
-- **SimDeck: Show Output** — opens the extension's output channel for debugging.
+| Command                        | Purpose                   |
+| ------------------------------ | ------------------------- |
+| `SimDeck: Open Simulator View` | Open the webview panel    |
+| `SimDeck: Stop Project Daemon` | Run `simdeck daemon stop` |
+| `SimDeck: Show Output`         | Open extension logs       |
 
 ## Settings
 
-All settings live under the `simdeck.*` namespace in VS Code settings:
+| Setting                   | Default                 | Purpose                      |
+| ------------------------- | ----------------------- | ---------------------------- |
+| `simdeck.serverUrl`       | `http://127.0.0.1:4310` | Preferred daemon URL         |
+| `simdeck.cliPath`         | empty                   | Explicit path to the CLI     |
+| `simdeck.port`            | `4310`                  | Port for auto-start          |
+| `simdeck.bindAddress`     | `127.0.0.1`             | Bind address for auto-start  |
+| `simdeck.autoStartDaemon` | `true`                  | Start the daemon when needed |
 
-| Setting                   | Default                 | Notes                                                                                                                                   |
-| ------------------------- | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `simdeck.serverUrl`       | `http://127.0.0.1:4310` | Preferred URL to try first. If auto-start launches the daemon on a different port, the extension uses the URL returned by `simdeck ui`. |
-| `simdeck.cliPath`         | _empty_                 | Optional explicit path to the `simdeck` CLI. Empty means: workspace `build/`, then `PATH`.                                              |
-| `simdeck.port`            | `4310`                  | Preferred port passed to `simdeck ui` when auto-starting the project daemon.                                                            |
-| `simdeck.bindAddress`     | `127.0.0.1`             | Bind address passed to `simdeck ui` when auto-starting the project daemon.                                                              |
-| `simdeck.autoStartDaemon` | `true`                  | If `true`, the extension starts or reuses the project daemon when opening the simulator view if the preferred URL is not reachable.     |
-| `simdeck.autoStartServer` | `true`                  | Deprecated compatibility alias for `simdeck.autoStartDaemon`.                                                                           |
+CLI resolution order:
 
-## Resolving the CLI
+1. `simdeck.cliPath`
+2. Workspace `build/simdeck`
+3. `simdeck` on `PATH`
 
-When the extension needs to start or stop the project daemon it looks for the CLI in this order:
+## Remote Or LAN Server
 
-1. The explicit `simdeck.cliPath` setting.
-2. The workspace's `build/simdeck` (handy when developing on this repo).
-3. `simdeck` from `PATH`.
+Set `simdeck.serverUrl` to the remote SimDeck URL and disable auto-start:
 
-If none of those resolve, the extension surfaces an error in the output channel pointing you at this documentation.
+```json
+{
+  "simdeck.serverUrl": "http://192.168.1.50:4310",
+  "simdeck.autoStartDaemon": false
+}
+```
 
-## Talking to a remote server
-
-Set `simdeck.serverUrl` to any reachable SimDeck endpoint. The extension is purely a webview shell and doesn't ship its own version of the React client. Whatever the daemon serves is what you get.
-
-For [LAN-reachable daemons](/guide/lan-access), point the extension at `http://<advertise-host>:<port>` and disable `autoStartDaemon` so the extension does not start a local project daemon.
+Pair in the webview if the server asks for the LAN code.
 
 ## Troubleshooting
 
-- **The webview shows a blank panel.** Open the output channel; the extension logs the daemon URL returned by `simdeck ui` and any CLI stderr.
-- **Auto-start doesn't work.** Ensure the resolved `cliPath` exists and is executable. The extension shows the resolved path in the output channel.
-- **Stale daemon stays running.** Use **SimDeck: Stop Project Daemon** to run `simdeck daemon stop`, then reopen the simulator view.
+| Symptom                  | Fix                                                                 |
+| ------------------------ | ------------------------------------------------------------------- |
+| Blank panel              | Open `SimDeck: Show Output` and check the daemon URL and CLI stderr |
+| Auto-start fails         | Set `simdeck.cliPath` to the real CLI path                          |
+| Old server keeps loading | Run `SimDeck: Stop Project Daemon`, then reopen                     |

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -1,128 +1,60 @@
-# Architecture
+# How It Works
 
-SimDeck is intentionally split into a small number of clearly-scoped layers. Every layer has a single concern and a single owner directory in the repo.
+This page is a short mental model for users and contributors. For daily usage, start with [Quick Start](/guide/quick-start) and [CLI commands](/cli/commands).
 
-## High-level layout
+## Pieces
 
-SimDeck has three layers stacked between the browser and the target device:
+| Piece              | What it does                                                        |
+| ------------------ | ------------------------------------------------------------------- |
+| CLI                | Starts SimDeck and exposes scriptable commands                      |
+| Local daemon       | Serves the browser UI, API, streams, metrics, and inspector routing |
+| Browser client     | Shows the live device, toolbar, inspector panes, and diagnostics    |
+| Native bridge      | Handles simulator-specific work on macOS                            |
+| Inspector runtimes | Optional app packages that publish richer UI trees                  |
+| `simdeck/test`     | JS/TS wrapper for automation                                        |
 
-1. **Browser / VS Code** runs the React client from `client/`. It speaks HTTP for control and WebRTC H.264 for live video, served by the Rust server.
-2. **The Rust server** (`server/`, built on `axum` + `tokio`) owns the CLI entrypoint, project daemon lifecycle, REST routes (`api/`), the stream transports (`transport/`), the inspector WebSocket hub (`inspector.rs`), the per-UDID session registry (`simulators/`), metrics, and log streaming.
-3. **Native device bridges** own platform-specific work. The Objective-C bridge (`cli/`) is reached through a narrow C ABI in `cli/native/XCWNativeBridge.*` for iOS. The Rust Android bridge (`server/src/android.rs`) shells out to the Android SDK for AVD discovery, emulator lifecycle, ADB input, screenshots, UIAutomator, and logcat.
+## Request Flow
 
-Underneath all of that are the iOS Simulator (`CoreSimulator` and `SimulatorKit`) and the Android emulator (`emulator` and `adb`).
+Most user actions follow the same path:
 
-## Layer responsibilities
+1. Browser, CLI, or test sends a command to the daemon.
+2. The daemon checks the selected device and starts a warm session when needed.
+3. SimDeck performs the requested simulator or emulator action.
+4. The command returns JSON, a screenshot, logs, or updated stream state.
 
-### `server/` — Rust HTTP and WebRTC transport
+This is why a long-lived daemon feels faster than repeatedly calling lower-level simulator tools.
 
-Owns the public CLI shape (`simdeck`, `simdeck ui`, `daemon`, `boot`, `shutdown`, …), daemon metadata, the HTTP API, WebRTC streaming, the inspector hub, log streaming, and metrics.
+## Video Flow
 
-Key modules:
+The browser opens a live stream for the selected device. SimDeck sends fresh frames, drops stale ones when a client falls behind, and lets the browser request refreshes. The UI can use WebRTC or H.264-over-WebSocket fallback depending on browser support and network behavior.
 
-| Module                              | Responsibility                                                                                                   |
-| ----------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `server/src/main.rs`                | CLI entrypoint, project daemon management, AppKit main-thread shim, tokio runtime bootstrap.                     |
-| `server/src/api/routes.rs`          | Every `/api/*` route, including simulator control, accessibility, and inspector proxy.                           |
-| `server/src/android.rs`             | Android AVD discovery, emulator lifecycle, ADB input, emulator gRPC video, screenshots, UIAutomator, and logcat. |
-| `server/src/transport/webrtc.rs`    | WebRTC offer/answer endpoint for H.264 browser video.                                                            |
-| `server/src/transport/packet.rs`    | Shared encoded frame type used between simulator sessions and transports.                                        |
-| `server/src/inspector.rs`           | WebSocket hub for the NativeScript runtime inspector.                                                            |
-| `server/src/simulators/registry.rs` | Per-UDID session registry with lazy attachment to the native bridge.                                             |
-| `server/src/simulators/session.rs`  | Frame broadcast channel, keyframe gating, refresh requests.                                                      |
-| `server/src/metrics/counters.rs`    | Atomic counters and per-client stream stats accepted from stream transports or `/api/client-stream-stats`.       |
-| `server/src/logs.rs`                | `os_log` log streaming and filtering.                                                                            |
+Tune this from the user-facing controls or with:
 
-The Rust server runs the tokio runtime on a worker thread while the AppKit main loop spins on the main thread. The native bridge needs the main loop to deliver display callbacks and HID events.
+```sh
+simdeck daemon restart --video-codec software --stream-quality low
+```
 
-### `cli/` — Objective-C native bridge
+## Inspector Flow
 
-Anything that depends on macOS frameworks, `xcrun simctl`, or private `CoreSimulator` / `SimulatorKit` APIs lives here. The Rust side talks to it through a narrow C ABI:
+`simdeck describe` and the browser inspector use the best available source:
 
-- `cli/native/XCWNativeBridge.{h,m}` — exported C functions for simulator control, chrome rendering, and frame callbacks.
-- `cli/native/XCWNativeSession.{h,m}` — wraps one Objective-C private simulator session handle for the Rust registry.
+1. Framework runtime inspector, such as NativeScript, React Native, or Flutter.
+2. Swift in-app agent for UIKit or SwiftUI apps.
+3. Native accessibility snapshot as the universal fallback.
 
-Inside the bridge:
+The response tells you which source was used and why a requested source fell back.
 
-- **`XCWSimctl.{h,m}`** wraps `xcrun simctl` for discovery, lifecycle management, app launching, URL opening, and screenshot capture.
-- **`XCWPrivateSimulatorBooter.{h,m}`** uses private `CoreSimulator` APIs for direct simulator boot without launching Simulator.app.
-- **`DFPrivateSimulatorDisplayBridge.{h,m}`** owns headless private display frames plus HID-based touch and keyboard injection. It resolves the active Xcode developer directory explicitly, prefers direct CoreSimulator screen IOSurface callbacks, and activates the older SimulatorKit offscreen renderable view only when direct frame callbacks are unavailable.
-- **`XCWPrivateSimulatorSession.{h,m}`** owns one private display bridge per booted simulator plus a selectable hardware or software H.264 encoder.
-- **`XCWPrivateSimulatorChromeBridge.{h,m}`** is an experimental private `SimulatorKit` chrome bridge kept nearby as a reference.
-- **`XCWChromeRenderer.{h,m}`** renders Apple's CoreSimulator device-type PDF chrome assets into PNGs for the browser.
-- **`XCWH264Encoder.{h,m}`** software / hardware H.264 encode.
+## Repository Layout
 
-### `client/` — React browser UI
+| Folder      | Purpose                                           |
+| ----------- | ------------------------------------------------- |
+| `server/`   | CLI entrypoint, daemon, API, streaming, metrics   |
+| `cli/`      | macOS simulator bridge                            |
+| `client/`   | Browser UI                                        |
+| `packages/` | Inspectors, VS Code extension, and `simdeck/test` |
+| `scripts/`  | Build, packaging, and integration helpers         |
+| `docs/`     | Documentation site                                |
 
-The React app served at `/` is a thin shell that calls the REST API. It consumes
-live device video over WebRTC H.264. iOS frames come from the native simulator
-display bridge; Android frames come from emulator gRPC `streamScreenshot` and
-are encoded through VideoToolbox on the server.
+## Contributor Boundary
 
-Layout under `client/src/`:
-
-- `app/AppShell.tsx` — top-level shell.
-- `api/` — typed wrappers around `/api/*` (`client.ts`, `controls.ts`, `simulators.ts`, `types.ts`).
-- `features/stream/` — WebRTC client, receiver stats, and frame plumbing.
-- `features/viewport/` — frame canvas, hit testing, chrome compositing.
-- `features/input/` — touch/keyboard/hardware button affordances.
-- `features/accessibility/` — accessibility tree pane and source switcher.
-- `features/simulators/` — simulator list, boot/shutdown affordances.
-- `features/toolbar/` — top toolbar (rotate, home, app switcher, dark mode toggle).
-
-The client never depends on private APIs and never assumes anything not exposed by the HTTP API.
-
-### `packages/` — companion packages
-
-- **`packages/nativescript-inspector/`** ships `@nativescript/simdeck-inspector`, a TypeScript runtime that connects from a NativeScript app to the server's WebSocket inspector hub. See [NativeScript Runtime](/inspector/nativescript).
-- **`packages/react-native-inspector/`** ships `react-native-simdeck`, a React Native runtime that connects from an app to the server's WebSocket inspector hub and publishes React Fiber hierarchy data. See [React Native Runtime](/inspector/react-native).
-- **`packages/flutter-inspector/`** ships `simdeck_flutter_inspector`, a Flutter runtime plugin that connects from an app to the server's WebSocket inspector hub and publishes widget, render, and semantics hierarchy data. See [Flutter Runtime](/inspector/flutter).
-- **`packages/inspector-agent/`** ships `SimDeckInspectorAgent`, a Swift Package you can link from a debug iOS app to expose its UIKit hierarchy. See [Swift In-App Agent](/inspector/swift).
-- **`packages/vscode-extension/`** is the VS Code extension that opens the browser client inside a webview panel and auto-starts the server.
-- **`packages/simdeck-test/`** ships `simdeck/test`, a small JS/TS wrapper around daemon startup and the REST control API. See [Testing](/guide/testing).
-
-## Data flow
-
-### Simulator control
-
-Most control endpoints follow the same path: a typed Rust handler in `server/src/api/routes.rs` calls `SessionRegistry::bridge()`, which dispatches into `cli/native/XCWNativeBridge.*` over the C ABI. From there the call lands in the matching Objective-C unit. For example, `POST /api/simulators/{udid}/boot` ends up in `XCWPrivateSimulatorBooter`, which uses private `CoreSimulator` APIs for direct boot and returns a clear error if that private path fails.
-
-### Live video
-
-The browser posts an SDP offer to `/api/simulators/{udid}/webrtc/offer`. The handler in `transport::webrtc` starts the selected frame source, waits for the first H.264 keyframe, returns an SDP answer, and writes H.264 samples to a WebRTC video track. iOS frames come from the private display bridge, which first waits for direct CoreSimulator screen IOSurface callbacks and then falls back to the SimulatorKit offscreen renderable view. For Android, the source is emulator gRPC raw pixels passed through the shared VideoToolbox encoder path.
-
-### Input
-
-Touch and keyboard events POST to `/api/simulators/{udid}/touch` and `/key`. The handler resolves the active session and replays the event through the private display bridge using HID.
-
-### Inspectors
-
-The accessibility tree endpoint blends three sources, in priority order:
-
-1. **NativeScript runtime inspector** — preferred when the foreground app has connected to `/api/inspector/connect` over WebSocket.
-2. **Swift in-app inspector agent** — used when the foreground app links the `SimDeckInspectorAgent` Swift Package and listens on a TCP port discovered between `47370` and `47402`.
-3. **Accessibility snapshot** — a final fallback that shells out to the accessibility snapshot
-
-The server discovers which inspectors are reachable for a given Simulator and surfaces the available list in the `availableSources` field on every accessibility-tree response.
-
-## Process model
-
-SimDeck stays in one OS process. The Rust binary:
-
-1. Calls `xcw_native_initialize_app()` so AppKit creates an `NSApplication` on the main thread.
-2. Spawns a tokio runtime on a worker thread that owns the HTTP server, WebRTC transport, inspector hub, and registry.
-3. Spins the AppKit main loop in 50 ms slices on the main thread to dispatch display and HID callbacks.
-
-Normal CLI commands may spawn `simdeck daemon run` in the background for the current project. The daemon writes metadata under the system temp directory, and later commands reuse it while `/api/health` stays healthy.
-
-## Working rules
-
-If you contribute, keep the following invariants in mind:
-
-- Simulator-native logic stays in Objective-C under `cli/`.
-- Rust server logic stays under `server/`.
-- Browser-only presentation logic stays in `client/`.
-- NativeScript app runtime inspection logic stays in `packages/nativescript-inspector/`.
-- Flutter app runtime inspection logic stays in `packages/flutter-inspector/`.
-- Add a server endpoint before adding client-only assumptions.
-- The supported live video paths are the WebRTC H.264 offer endpoint plus the `/api/simulators/{udid}/h264` WebSocket fallback. Do not bring back legacy `/stream.h264` handling.
+Keep platform-specific simulator work in the native layer, server behavior in `server/`, and browser presentation in `client/`. Add API support before adding UI assumptions that cannot be scripted.

--- a/docs/guide/daemon.md
+++ b/docs/guide/daemon.md
@@ -1,152 +1,86 @@
-# Project Daemon
+# Daemon
 
-SimDeck runs one warm native host per project. The daemon owns the HTTP API, the WebRTC video endpoint, inspector routing, and lazy native simulator sessions.
+SimDeck runs a local server for the current project. The server owns the browser UI, REST API, live stream, inspector connections, and warm device sessions.
 
-Normal CLI commands start the daemon automatically when they need it. Use `simdeck daemon` only when you want to manage it explicitly.
+Most commands start or reuse the project daemon automatically. Manage it directly only when you need a specific lifecycle.
 
-Running `simdeck` with no subcommand starts a foreground workspace daemon, prints local and LAN HTTP URLs, prints a six-digit pairing code for LAN browsers, and stops when the command exits, when you press `q`, or when you press Ctrl-C. Pass a simulator name or UDID as the only argument to select it by default:
+## Foreground
 
 ```sh
 simdeck
-simdeck "iPhone 17 Pro Max"
-simdeck -d
-simdeck -k
-simdeck -r
 ```
 
-The shorthand flags map to detached start, kill, and restart respectively. `simdeck -k` reports the PID that was killed, and `simdeck -r` returns the same JSON shape as `simdeck daemon start`.
+Use this for normal interactive work. It prints browser URLs and stops when you press `q` or Ctrl-C.
 
-`simdeck daemon` is project-scoped. `simdeck service` is the optional macOS
-LaunchAgent wrapper for users who want an always-on daemon after login.
-
-## Start
+## Detached
 
 ```sh
+simdeck -d
 simdeck daemon start
 ```
 
-The command starts the daemon for the current project root and prints JSON:
+Both start or reuse a background daemon for the current project. Detached mode is useful for tests, editor integrations, and scripts.
 
-```json
-{
-  "ok": true,
-  "projectRoot": "/path/to/app",
-  "pid": 12345,
-  "pairingCode": "123456",
-  "url": "http://127.0.0.1:4310",
-  "started": true
-}
+```sh
+simdeck daemon status
+simdeck daemon stop
+simdeck daemon restart
+simdeck daemon killall
 ```
 
-If a healthy daemon is already running for that project, `started` is `false` and the same daemon is reused.
+`daemon killall` stops SimDeck project daemons from every workspace.
 
-## Open The UI
-
-For day-to-day use, `ui` is the shortest path:
+## Open The Browser UI
 
 ```sh
 simdeck ui --open
 ```
 
-This starts or reuses the project daemon, serves the bundled browser client, and opens the authenticated local URL.
+This starts or reuses the daemon, then opens the authenticated local URL.
 
-## Options
+## Common Server Options
 
-`daemon start`, `daemon restart`, and `ui` accept the same server options:
+`simdeck ui`, `daemon start`, `daemon restart`, and `service restart` use the same core options:
 
-| Flag                 | Default               | Notes                                                                                |
-| -------------------- | --------------------- | ------------------------------------------------------------------------------------ |
-| `--port <u16>`       | `4310`                | HTTP port for the REST API, browser UI, and WebRTC offer endpoint.                   |
-| `--bind <ip>`        | `127.0.0.1`           | Bind address. Use `0.0.0.0` for [LAN access](/guide/lan-access).                     |
-| `--advertise-host`   | matches local host    | Hostname or IP advertised to browser clients.                                        |
-| `--client-root`      | bundled `client/dist` | Override the static browser client directory.                                        |
-| `--video-codec`      | `auto`                | One of `auto`, `hardware`, or `software`. See [Video](/guide/video).                 |
-| `--low-latency`      | `false`               | Software H.264 profile for slower runners; caps at 15 fps and drops stale frames.    |
-| `--stream-quality`   | `full`                | Realtime stream quality profile, including `full`, `low`, `tiny`, and `ci-software`. |
-| `--local-stream-fps` | `60`                  | Local quality stream frame target, from 15 to 240 fps.                               |
-| `--open`             | `false`               | `ui` only. Open the browser after the daemon is ready.                               |
+| Flag                         | Default        | Use it when                                |
+| ---------------------------- | -------------- | ------------------------------------------ | ------ | ---------------------------------- |
+| `--port <port>`              | `4310`         | The default port is busy                   |
+| `--bind <ip>`                | `127.0.0.1`    | You need LAN access with `0.0.0.0` or `::` |
+| `--advertise-host <host>`    | detected       | Remote browsers need a specific host or IP |
+| `--video-codec auto          | hardware       | software`                                  | `auto` | You need to force encoder behavior |
+| `--stream-quality <profile>` | `full`         | You want lower CPU or bandwidth use        |
+| `--local-stream-fps <fps>`   | `60`           | You want a different local stream target   |
+| `--client-root <path>`       | bundled client | You are serving a custom static client     |
 
 Example:
 
 ```sh
-simdeck ui --bind 0.0.0.0 --advertise-host 192.168.1.50 --open
+simdeck daemon start --port 4320 --video-codec software --stream-quality low
 ```
-
-## Status
-
-```sh
-simdeck daemon status
-```
-
-The status output includes the daemon URL, supervisor PID, project root, access
-token, and detached daemon log path. Local same-origin browser use does not
-require copying the token; direct remote API callers should send it as
-`X-SimDeck-Token` or `Authorization: Bearer <token>`.
-
-## Restart
-
-```sh
-simdeck daemon restart
-```
-
-This stops the daemon for the current project, starts a fresh one, and returns the same JSON shape as `daemon start`.
-
-## Stop
-
-```sh
-simdeck daemon stop
-```
-
-This terminates the daemon for the current project and removes its metadata file from the system temp directory. The next CLI command that needs the daemon starts a fresh one.
-
-## Kill All Project Daemons
-
-```sh
-simdeck daemon killall
-```
-
-This scans SimDeck daemon metadata across all workspaces, terminates live daemon PIDs, and removes stale metadata files.
 
 ## Always-On Service
 
-For agents and editor integrations that should be able to reach SimDeck at any
-time after login, use `simdeck service` to install the macOS user service:
+Use the macOS user service when SimDeck should be reachable after login without starting a project daemon first:
 
 ```sh
 simdeck service on
-```
-
-This writes `~/Library/LaunchAgents/dev.nativescript.simdeck.plist`, starts the
-server with `launchctl`, and keeps it alive. It binds to `127.0.0.1:4310` by
-default and serves the bundled browser client.
-
-Restart it after changing options:
-
-```sh
-simdeck service restart --port 4310 --video-codec software --low-latency
-```
-
-Disable it when you do not want a persistent daemon:
-
-```sh
+simdeck service restart --port 4310
 simdeck service off
 ```
 
-Prefer the project daemon for project-scoped metadata and automatic lifecycle.
-Use the service when the priority is easy access from Codex, VS Code, or a
-browser at any time.
+Prefer the project daemon for normal repository work. Use the service for long-lived agent or editor setups.
 
-## CoreSimulator Service Layer
+## Restart CoreSimulator
 
-The project daemon is different from Apple's CoreSimulator service. If `simctl` reports stale service state or the live display never produces a first frame, restart Apple's service layer:
+If `simctl` hangs, reports a stale service version, or devices never attach:
 
 ```sh
 simdeck core-simulator restart
 ```
 
-You can also manage it explicitly:
+Then retry:
 
 ```sh
-simdeck core-simulator start
-simdeck core-simulator shutdown
+simdeck list
+simdeck boot <udid>
 ```

--- a/docs/guide/github-actions.md
+++ b/docs/guide/github-actions.md
@@ -1,24 +1,20 @@
 # GitHub Actions
 
-SimDeck can run an iOS Simulator session from a pull request comment. A repository
-needs two pieces:
+SimDeck can post a temporary hosted simulator session from a pull request comment.
 
-1. A build workflow that uploads a zipped iOS Simulator `.app` artifact.
-2. A comment workflow that calls SimDeck's session action when someone
-   comments `simdeck run ios` on a pull request.
+You need:
+
+1. A build workflow that uploads a zipped iOS Simulator `.app`.
+2. A comment workflow that starts the SimDeck session when someone comments `simdeck run ios`.
 
 ## Build Workflow
-
-Build your app however your project normally builds a simulator target, then use
-the upload action to package and publish the `.app` artifact:
 
 ```yaml
 name: Build iOS Simulator
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
   pull_request:
 
 permissions:
@@ -43,20 +39,16 @@ jobs:
           app-glob: platforms/ios/build/**/*-iphonesimulator/*.app
 ```
 
-The uploaded artifact name defaults to `ios-simulator-app-<commit-sha>`. For pull
-requests, the SHA is the PR head commit.
+Pin the action to a release tag when you want a stable integration point.
 
 ## Comment Workflow
-
-Add a second workflow that delegates the hosted simulator session to SimDeck:
 
 ```yaml
 name: SimDeck iOS Comment
 
 on:
   issue_comment:
-    types:
-      - created
+    types: [created]
 
 permissions:
   actions: read
@@ -86,22 +78,13 @@ jobs:
           bundle_id: com.example.app
 ```
 
-When triggered, the session action:
+## Pull Request Command
 
-- reacts to the command comment immediately;
-- installs `simdeck` and `cloudflared` on a single macOS runner;
-- starts SimDeck with software encoding and the `tiny` stream profile by default;
-- prefers `iPhone 17 Pro`, then falls back to the newest available iPhone simulator;
-- restores the CoreSimulator device cache when available;
-- posts the first bot comment only after a simulator UDID has been selected,
-  mentioning the requester when `command_comment_author` is set;
-- downloads the simulator app artifact for the PR head commit, installs it, and
-  launches it;
-- stops after 30 minutes by default, or earlier if the simulator shuts down.
+```text
+simdeck run ios
+```
 
-## Comment Flags
-
-The comment can include lightweight flags:
+Optional flags:
 
 ```text
 simdeck run ios no-cache-sim
@@ -111,26 +94,26 @@ simdeck run ios quality=low
 simdeck run ios public-health
 ```
 
-Supported quality values are `tiny`, `low`, `economy`, `fast`, `smooth`,
-`balanced`, `full`, `quality`, and `ci-software`.
+Supported quality values include `tiny`, `low`, `economy`, `fast`, `smooth`, `balanced`, `full`, `quality`, and `ci-software`.
 
-## Inputs
+## Common Inputs
 
-The most common session action inputs are:
+| Input               | Default                   | Purpose                                     |
+| ------------------- | ------------------------- | ------------------------------------------- |
+| `bundle_id`         | empty                     | Bundle ID to launch                         |
+| `build_workflow`    | `build-ios-simulator.yml` | Workflow file that uploads the app artifact |
+| `artifact_prefix`   | `ios-simulator-app`       | Artifact prefix                             |
+| `simdeck_version`   | `latest`                  | npm version or dist-tag                     |
+| `stream_profile`    | `tiny`                    | Default stream quality                      |
+| `simulator_name`    | `iPhone 17 Pro`           | Preferred simulator                         |
+| `keepalive_seconds` | `1800`                    | Session lifetime after launch               |
+| `simulator_cache`   | `true`                    | Restore and save simulator cache            |
 
-| Input                    | Default                   | Purpose                                       |
-| ------------------------ | ------------------------- | --------------------------------------------- |
-| `bundle_id`              | empty                     | Fallback app bundle id to launch.             |
-| `build_workflow`         | `build-ios-simulator.yml` | Workflow file that uploads the app artifact.  |
-| `command_comment_id`     | empty                     | Comment id to react to immediately.           |
-| `command_comment_author` | empty                     | GitHub user to mention when the URL is ready. |
-| `artifact_prefix`        | `ios-simulator-app`       | Prefix used for `<prefix>-<sha>` artifacts.   |
-| `simdeck_version`        | `latest`                  | npm version or dist-tag to install.           |
-| `stream_profile`         | `tiny`                    | Default stream quality profile.               |
-| `simulator_name`         | `iPhone 17 Pro`           | Preferred simulator device name.              |
-| `keepalive_seconds`      | `1800`                    | Session lifetime after app launch.            |
-| `simulator_cache`        | `true`                    | Restore and save CoreSimulator device cache.  |
+## What The Session Does
 
-The caller workflow owns job-level settings such as `runs-on`,
-`timeout-minutes`, permissions, and concurrency. Pin `NativeScript/SimDeck` to a
-release tag instead of `@main` when you want a stable integration point.
+- Installs SimDeck and tunnel tooling on a macOS runner.
+- Picks or creates an iOS Simulator.
+- Downloads the app artifact for the PR head commit.
+- Installs and launches the app.
+- Posts a browser URL back to the pull request.
+- Stops after the configured keepalive window.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,55 +1,45 @@
-# Introduction
+# Overview
 
-SimDeck is a local-first control plane for the iOS Simulator. It bundles a Rust HTTP server, a native Objective-C bridge for CoreSimulator and SimulatorKit APIs, a React browser UI, and a JS/TS test API into one project-local CLI.
+SimDeck is a local tool for viewing, controlling, inspecting, and automating mobile simulators.
 
-The goal is simple: turn a booted Simulator into a streamable, scriptable surface that any tool — a browser, VS Code, a NativeScript runtime, or an automated test — can drive through one local daemon.
+Run `simdeck` from your project. It starts a local server, serves a browser UI, and exposes the same controls through the CLI and HTTP API.
 
-## Why SimDeck?
+## What You Can Do
 
-The default Simulator is great when it sits in front of you. It is much less great when:
+- View a live iOS Simulator or Android emulator in a browser.
+- Tap, swipe, type, press hardware buttons, rotate, and open URLs.
+- Install, launch, uninstall, boot, shut down, and erase devices.
+- Capture screenshots, logs, pasteboard text, and accessibility trees.
+- Inspect app UI through built-in accessibility or optional in-app inspectors.
+- Write JS/TS automation with `simdeck/test`.
+- Share a paired browser session over your LAN.
+- Open the simulator view inside VS Code.
 
-- You want to see your app running while writing code in another window.
-- You want to drive a Simulator from a remote machine on your LAN.
-- You want to build automation around `simctl` without stitching together shell pipelines.
-- You want to inspect a NativeScript or Swift app's view hierarchy without linking the Xcode debugger.
-- You want a project daemon that stays warm instead of cold-starting native simulator control for every command.
+## Daily Workflow
 
-SimDeck addresses all of those with one CLI, one HTTP API, one WebRTC stream path, and one daemon per project.
+```sh
+simdeck
+```
 
-## What's in the box
+Open the local URL, pick a device, and use the toolbar or CLI commands:
 
-SimDeck ships as a single npm package (`simdeck`) that installs:
+```sh
+simdeck list
+simdeck boot <udid>
+simdeck install <udid> /path/to/App.app
+simdeck launch <udid> com.example.App
+simdeck tap <udid> --label "Continue" --wait-timeout-ms 5000
+simdeck describe <udid> --format agent --max-depth 3
+```
 
-1. **A native CLI and project daemon.** Rust + Objective-C, compiled on install. It serves the HTTP API and WebRTC H.264 video.
-2. **A bundled React client.** `simdeck` starts a foreground daemon and prints browser URLs; `simdeck ui --open` starts or reuses a background daemon.
-3. **A JS/TS testing package.** `simdeck/test` gives app tests a small API for launching, tapping, querying accessibility state, batching actions, and taking screenshots.
+Use `simdeck -d` for a detached background daemon, `simdeck -k` to stop it, and `simdeck -r` to restart it.
 
-Optional companion packages:
+## Pick A Page
 
-- [`@nativescript/simdeck-inspector`](/inspector/nativescript) — a debug-only NativeScript inspector runtime.
-- [`react-native-simdeck`](/inspector/react-native) — a debug-only React Native inspector runtime.
-- [`simdeck_flutter_inspector`](/inspector/flutter) — a debug-only Flutter inspector runtime.
-- [`packages/inspector-agent`](/inspector/swift) — a Swift Package you can link from your iOS app to expose its UIKit hierarchy.
-- [`packages/vscode-extension`](/extensions/vscode) — opens the simulator inside a VS Code panel.
-
-## High-level architecture
-
-The repository splits cleanly along the layers SimDeck talks to:
-
-- **`server/`** holds the CLI entrypoint, project daemon, Rust HTTP server, WebRTC transport, inspector hub, and metrics. It serves the REST API at `/api/*`, live video at `/api/simulators/{udid}/webrtc/offer`, and the inspector WebSocket at `/api/inspector/connect`.
-- **`cli/`** holds the Objective-C native bridge that links private `CoreSimulator` and `SimulatorKit` APIs. The Rust server calls into it through a narrow C ABI for boot, frame capture, encode, and HID input.
-- **`client/`** holds the React UI that renders the streamed simulator and the inspector tools.
-- **`packages/`** holds companion packages: NativeScript inspector, React Native inspector, Swift inspector agent, VS Code extension, and `simdeck/test`.
-- **`scripts/`** holds repeatable build entrypoints used both locally and by CI.
-
-For a full breakdown, see [Architecture](/guide/architecture).
-
-## Where to next
-
-- **[Installation](/guide/installation)** — how to install the CLI from npm or build it from source.
-- **[Quick Start](/guide/quick-start)** — boot a simulator and stream it to your browser in under a minute.
-- **[Project Daemon](/guide/daemon)** — how `ui`, `daemon start`, and automatic daemon reuse work.
-- **[Testing](/guide/testing)** — use `simdeck/test` and run the simulator-backed integration suite.
-- **[Architecture](/guide/architecture)** — the layout, data flow, and private-API surface.
-- **[CLI Reference](/cli/commands)** — every command with its flags.
-- **[HTTP API](/api/rest)** — every REST endpoint, with response shapes.
+- [Install](/guide/installation): requirements and setup.
+- [Quick Start](/guide/quick-start): first browser session.
+- [Daemon](/guide/daemon): foreground, detached, and always-on modes.
+- [Video & Streaming](/guide/video): stream quality and codec choices.
+- [LAN Access](/guide/lan-access): pairing and remote browser access.
+- [Testing](/guide/testing): `simdeck/test` and integration tests.
+- [Troubleshooting](/guide/troubleshooting): practical fixes for common failures.

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -1,57 +1,39 @@
-# Installation
+# Install
 
-SimDeck ships as a single npm package that contains the launcher, the client bundle, and the native CLI binary.
+## Requirements
 
-## Prerequisites
+- macOS on Apple Silicon.
+- Xcode with the simulator runtimes you want to use.
+- Node.js 18 or newer.
+- Optional Android SDK tools for Android emulator support.
+- Optional Rust stable when building from source.
 
-SimDeck only runs on macOS. The native bridge links private `CoreSimulator` and `SimulatorKit` frameworks, so it cannot run on Linux or Windows.
-
-| Requirement                        | Why                                                                                                              |
-| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| **macOS 13+**                      | Required for current `CoreSimulator` and Apple's VideoToolbox H.264 encoder.                                     |
-| **Xcode + iOS Simulator runtimes** | The native bridge loads Xcode's private simulator frameworks and invokes `xcrun simctl` for non-boot operations. |
-| **Android SDK tools**              | Optional. Required for Android emulator support (`emulator`, `adb`, and AVD images).                             |
-| **Node.js ≥ 18**                   | The launcher (`bin/simdeck.mjs`) and the bundled client tooling.                                                 |
-| **Rust (stable)**                  | Required only when building from source. Installed via [rustup](https://rustup.rs/).                             |
-
-The package contains a macOS native binary. Non-macOS installs are unsupported.
-
-## Install from npm
-
-The fastest path is the published CLI:
+Check Xcode selection if you have multiple installs:
 
 ```sh
-npm install -g simdeck
+xcode-select -p
 ```
 
-This installs the launcher and bundled native binary to your global `node_modules`. After it finishes:
+## Install From npm
+
+Use `npx` for a quick try:
 
 ```sh
+npx simdeck
+```
+
+Install globally for regular use:
+
+```sh
+npm install -g simdeck@latest
 simdeck
 ```
 
-The foreground command prints local and LAN HTTP URLs and stops its workspace daemon when you press `q` or Ctrl-C. You can select a simulator by name or UDID with `simdeck "iPhone 17 Pro Max"`.
+The package installs the launcher, browser client, and native binary.
 
-The global install prints the next setup steps:
+## Install The Codex Skill
 
-```sh
-simdeck
-npx skills add NativeScript/SimDeck --skill simdeck -a codex -g
-simdeck service on
-```
-
-Install the `nativescript.simdeck` VS Code extension if you want the simulator
-view inside VS Code.
-
-`simdeck service on` is recommended when agents or editor integrations should be
-able to reach SimDeck any time after login. It installs a localhost macOS
-LaunchAgent and can be removed with `simdeck service off`.
-
-## Install the Codex skill
-
-SimDeck includes an agent skill at `skills/simdeck/SKILL.md`. Install it with
-[skills.sh](https://skills.sh/) so Codex can choose the right commands and
-inspection loops automatically:
+For Codex workflows, install the SimDeck skill so agents use the stable commands:
 
 ```sh
 npx skills add NativeScript/SimDeck --skill simdeck -a codex -g
@@ -59,95 +41,45 @@ npx skills add NativeScript/SimDeck --skill simdeck -a codex -g
 
 Restart Codex after installing the skill.
 
-## Install from source
+## VS Code
 
-Clone the repo and install dependencies:
+Install the VS Code extension if you want the simulator inside an editor panel:
+
+```sh
+npm run package:vscode
+npm run install:vscode
+```
+
+From the marketplace, use `nativescript.simdeck-vscode` when available.
+
+## Build From Source
 
 ```sh
 git clone https://github.com/NativeScript/SimDeck.git
-cd simdeck
+cd SimDeck
 npm install
-```
-
-Build the source checkout before running it directly or installing it globally:
-
-```sh
 npm run build
-```
-
-The native CLI build writes:
-
-```text
-build/simdeck
-build/simdeck-bin
-```
-
-You can then run the local checkout directly:
-
-```sh
 ./build/simdeck
 ```
 
-Or install the local checkout globally:
+Useful build scripts:
 
-```sh
-npm install -g .
-```
+| Script                 | What it builds                            |
+| ---------------------- | ----------------------------------------- |
+| `npm run build`        | Native CLI and browser client             |
+| `npm run build:cli`    | Native CLI only                           |
+| `npm run build:client` | Browser client only                       |
+| `npm run build:all`    | CLI, client, inspectors, and test package |
+| `npm run build:docs`   | Documentation site                        |
 
-After a global install you can call `simdeck` from anywhere.
-
-## Build the React client
-
-The client bundle ships pre-built when installed from npm. When working from source, build it explicitly:
-
-```sh
-./scripts/build-client.sh
-```
-
-This calls `npm install` and `npm run build` inside the `client/` workspace and writes the production bundle to `client/dist`. The Rust server serves that bundle at the HTTP root.
-
-## Build from source
-
-The root `package.json` exposes a one-shot app build for the native CLI and browser client:
-
-```sh
-npm run build
-```
-
-This runs:
-
-- `npm run build:cli` — Rust server + Objective-C bridge → `build/simdeck`
-- `npm run build:client` — Vite production build → `client/dist`
-
-Use `npm run build:all` when you also need the companion package outputs:
-
-```sh
-npm run build:all
-```
-
-That adds:
-
-- `npm run build:nativescript-inspector` — TypeScript build of the NativeScript inspector
-- `npm run build:react-native-inspector` — TypeScript build of the React Native inspector
-- `npm run build:simdeck-test` — TypeScript build of `simdeck/test`
-
-Other convenience scripts include `npm run build:docs`, `npm run build:vscode-extension`, `npm run package:vscode`, and `npm run package:all`. You can also run any one of the component scripts on its own.
-
-## Update or uninstall
-
-To update from npm:
+## Update Or Remove
 
 ```sh
 npm install -g simdeck@latest
-```
-
-To remove the global install:
-
-```sh
 npm uninstall -g simdeck
 ```
 
-If a project daemon is running, stop it before uninstalling so your shell does not keep talking to the old binary:
+Stop a running daemon before uninstalling:
 
 ```sh
 simdeck daemon stop

--- a/docs/guide/lan-access.md
+++ b/docs/guide/lan-access.md
@@ -1,105 +1,66 @@
 # LAN Access
 
-SimDeck binds to `127.0.0.1` by default. You can move it to a LAN-reachable interface so other devices on your network — another Mac, an iPad, a phone — can stream the simulator.
+SimDeck binds to `127.0.0.1` by default. Bind to a LAN address when another device needs to open the browser UI.
 
-## Bind to all interfaces
-
-Use `--bind` to listen on a non-loopback address:
-
-```sh
-simdeck ui --port 4310 --bind 0.0.0.0 --open
-```
-
-The HTTP server binds to the requested address. It serves the REST API, browser UI, inspector WebSocket, and WebRTC offer endpoint, so any browser on the LAN can reach SimDeck through `http://<your-mac-ip>:4310`. LAN browsers must enter the pairing code printed by the foreground command or returned by `daemon start` before the API cookie is issued.
-
-## Advertise the right host
-
-By default SimDeck advertises `localhost`, which only works for browsers running on the same Mac. Tell the server what host to print for remote clients:
+## Start A LAN Session
 
 ```sh
 simdeck ui \
-  --port 4310 \
   --bind 0.0.0.0 \
   --advertise-host 192.168.1.50 \
   --open
 ```
 
-The advertised host is used in the printed Network URL and in `daemon start` JSON output.
+Open the printed network URL from the remote browser:
 
-If you skip `--advertise-host` while binding to `0.0.0.0`, the server prints a warning at startup because it will still tell remote clients to dial `localhost`.
+```text
+http://192.168.1.50:4310
+```
 
-## Pick a hostname or IP
+Enter the pairing code printed by the CLI. After pairing, the browser receives the API cookie.
 
-You can advertise either a DNS name (preferred when you have a stable mDNS or DHCP entry) or an IP literal. Examples:
+## Pick The Right Host
+
+Use an IP address or hostname that the remote device can resolve:
 
 ```sh
-simdeck ui --bind 0.0.0.0 --advertise-host my-mac.lan --open
+simdeck ui --bind 0.0.0.0 --advertise-host my-mac.local --open
 simdeck ui --bind 0.0.0.0 --advertise-host 192.168.1.50 --open
-simdeck ui --bind ::      --advertise-host my-mac.local --open
 ```
 
-Whatever you advertise must be resolvable from the remote client.
+If you bind to `0.0.0.0` but advertise `localhost`, remote browsers will try to connect to themselves.
 
-## Health response
+## Direct API Access
 
-`GET /api/health` reports the HTTP port and active video encoder mode:
+Loopback browser sessions are authenticated automatically. Direct API callers should send the token from:
 
-```json
-{
-  "ok": true,
-  "httpPort": 4310,
-  "videoCodec": "auto",
-  "lowLatency": false,
-  "webRtc": {
-    "iceServers": [{ "urls": ["stun:stun.l.google.com:19302"] }],
-    "iceTransportPolicy": "all"
-  }
-}
+```sh
+simdeck daemon status
 ```
 
-Restarting the server rotates the generated API access token. Open clients reconnect automatically after pairing or receiving the loopback cookie again.
-
-## Authentication and security
-
-SimDeck generates an API access token when it starts the project daemon. Loopback browser UI loads receive the token automatically through a strict same-site cookie, so opening `http://127.0.0.1:<port>` remains seamless. Non-loopback LAN browsers do not receive that cookie from the static page; they must submit the six-digit pairing code shown by the CLI before the server sets the cookie.
-
-Direct API callers must send one of:
+Use either header:
 
 ```text
 X-SimDeck-Token: <token>
 Authorization: Bearer <token>
 ```
 
-The foreground `simdeck` command prints an HTTP network URL and a pairing code:
+## Security Checklist
 
-```text
-🚀 SimDeck is ready
+- Use LAN mode only on networks you trust.
+- Treat the daemon token as a secret.
+- Restrict the port with macOS Firewall when needed.
+- Stop the daemon when the shared session is done:
 
-      Local:   http://127.0.0.1:4310
-    Network:   http://192.168.1.50:4310
-       Pair:   123 456
+  ```sh
+  simdeck daemon stop
+  ```
 
-q or ^C to stop server
-```
+## Troubleshooting
 
-Get the token for scripts with:
-
-```sh
-simdeck daemon status
-```
-
-Recommended practice for shared networks:
-
-- Run SimDeck only on networks you control.
-- Treat the token from `daemon status` as a secret for scripted LAN access.
-- Combine with macOS Application Firewall to restrict inbound access to known peers.
-- For shared NativeScript inspectors, set an `authToken` when starting the [Swift in-app agent](/inspector/swift#auth-token) so app-side requests must include the token.
-
-## Quick checklist
-
-To make a SimDeck server reachable from another device:
-
-1. `--bind 0.0.0.0` (or `--bind ::`).
-2. `--advertise-host <reachable-host-or-ip>`.
-3. Allow the chosen port through any firewalls.
-4. Visit `http://<advertise-host>:<port>` from the remote device.
+| Symptom                       | Fix                                                               |
+| ----------------------------- | ----------------------------------------------------------------- |
+| Remote browser cannot connect | Confirm `--bind 0.0.0.0`, firewall rules, and the advertised host |
+| Pairing code is rejected      | Restart the daemon and use the newly printed code                 |
+| Stream connects but stutters  | Use `--stream-quality low` or `--video-codec software`            |
+| API script gets `401`         | Send `X-SimDeck-Token` or `Authorization: Bearer <token>`         |

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -1,95 +1,86 @@
 # Quick Start
 
-This guide walks you from a fresh install to a Simulator streaming in your browser and controllable from the CLI.
-
-## 1. Open The UI
-
-After [installing](/guide/installation), start a foreground SimDeck daemon and open one of the printed browser URLs:
+## 1. Start SimDeck
 
 ```sh
 simdeck
 ```
 
-The command prints local and LAN URLs:
+SimDeck prints a local browser URL, a LAN URL when one is available, and a pairing code for LAN browsers.
 
 ```text
-🚀 SimDeck is ready
+SimDeck is ready
 
-      Local:   http://127.0.0.1:4310
-    Network:   http://192.168.1.50:4310
-       Pair:   123 456
-
-q or ^C to stop server
+Local:   http://127.0.0.1:4310
+Network: http://192.168.1.50:4310
+Pair:    123 456
 ```
 
-This foreground daemon is scoped to the current workspace and exits when the command exits, when you press `q`, or when you press Ctrl-C. Local browsers open without a prompt. LAN browsers pair once with the printed code, then receive the API cookie. Use `simdeck ui --open` or `simdeck daemon start` when you want a reusable background daemon.
+Open the local URL. Press `q` or Ctrl-C in the terminal to stop the foreground server.
 
-For shorthand background lifecycle commands:
-
-```sh
-simdeck -d  # detached start
-simdeck -k  # kill background daemon
-simdeck -r  # restart background daemon
-```
-
-One HTTP listener runs inside the daemon:
-
-- **HTTP** on `--port` (default `4310`) for the REST API, static React client, inspector WebSocket, and WebRTC offer endpoint.
-
-## 2. Pick A Simulator
-
-The opened UI lists every simulator. You can also list and boot from the CLI:
-
-```sh
-simdeck list
-simdeck boot <udid>
-```
-
-To focus a specific simulator by name or UDID at launch:
+To open a specific simulator by name or UDID:
 
 ```sh
 simdeck "iPhone 17 Pro Max"
 simdeck 9750DF52-0471-48FF-B49A-B184C4BD3A3D
 ```
 
-::: tip First-frame delay
-On a cold boot the daemon has to boot the device through private CoreSimulator APIs, attach the private display bridge, and wait for a keyframe before video flows. The first frame typically shows up within a second; subsequent reloads of the same Simulator are near-instant.
-:::
+## 2. Pick Or Boot A Device
 
-## 3. Drive It
-
-The same daemon backs browser controls, CLI commands, and tests:
+The UI lists available iOS Simulators and Android emulators. You can also use the CLI:
 
 ```sh
-simdeck open-url <udid> https://example.com
-simdeck launch <udid> com.apple.Preferences
+simdeck list
+simdeck boot <udid>
+```
+
+Android emulator IDs are prefixed with `android:`.
+
+## 3. Install And Launch An App
+
+```sh
+simdeck install <udid> /path/to/App.app
+simdeck launch <udid> com.example.App
+simdeck open-url <udid> myapp://debug
+```
+
+For Android:
+
+```sh
+simdeck install android:<avd-name> /path/to/app.apk
+simdeck launch android:<avd-name> com.example.app
+```
+
+## 4. Drive The UI
+
+Use coordinates when you know them:
+
+```sh
+simdeck tap <udid> 120 240
+simdeck swipe <udid> 200 700 200 200
+simdeck type <udid> "hello"
+```
+
+Use selectors when you want automation to wait for UI state:
+
+```sh
 simdeck tap <udid> --label "Continue" --wait-timeout-ms 5000
-simdeck describe <udid> --format agent --max-depth 2
+simdeck describe <udid> --format agent --max-depth 3
 ```
 
-Coordinate commands use screen points by default. Pass `--normalized` when sending `0.0..1.0` coordinates:
+## 5. Keep It Running In The Background
 
 ```sh
-simdeck tap <udid> 0.5 0.5 --normalized
+simdeck -d
+simdeck -k
+simdeck -r
 ```
 
-See the full [CLI Reference](/cli/commands) for every command and flag.
+These are shortcuts for detached start, stop, and restart. See [Daemon](/guide/daemon) for details.
 
-## What just happened?
+## Next
 
-When you opened the UI:
-
-1. The browser fetched `/api/health` and confirmed the active H.264 encoder mode.
-2. It posted a WebRTC SDP offer to `/api/simulators/<udid>/webrtc/offer`.
-3. The Rust transport hub asked the native bridge for a fresh keyframe and started writing H.264 samples to the WebRTC video track.
-4. Touch and keyboard events round-trip through `POST /api/simulators/<udid>/touch` and `/key`, which the native bridge replays through HID.
-
-You can read more about the layers involved in [Architecture](/guide/architecture) and [Video Pipeline](/guide/video).
-
-## Common follow-ups
-
-- **Run the server on a LAN-reachable port.** See [LAN Access](/guide/lan-access).
-- **Manage the warm native host explicitly.** See [Project Daemon](/guide/daemon).
-- **Write JS/TS app tests.** See [Testing](/guide/testing).
-- **Stream is choppy or stuck on a black frame.** See [Video Pipeline](/guide/video) and [Troubleshooting](/guide/troubleshooting).
-- **Embed the client in VS Code.** See the [VS Code extension](/extensions/vscode).
+- [CLI commands](/cli/commands)
+- [Video & streaming](/guide/video)
+- [Inspectors](/inspector/)
+- [Troubleshooting](/guide/troubleshooting)

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -1,10 +1,11 @@
 # Testing
 
-SimDeck supports two test layers: a small JS/TS client package for app tests, and a simulator-backed integration suite for the CLI and REST API.
+SimDeck supports two testing workflows:
+
+- App-level JS/TS automation through `simdeck/test`.
+- Repository integration tests that drive real simulators and emulators.
 
 ## App Tests With `simdeck/test`
-
-`simdeck/test` starts or reuses the project daemon and gives tests a typed API for simulator control:
 
 ```ts
 import { connect } from "simdeck/test";
@@ -12,55 +13,46 @@ import { connect } from "simdeck/test";
 const sim = await connect();
 
 try {
-  const devices = await sim.list();
-  await sim.launch("<udid>", "com.example.App");
-  await sim.tap("<udid>", 0.5, 0.5);
-  await sim.waitFor("<udid>", { label: "Continue" });
-  const png = await sim.screenshot("<udid>");
+  const { simulators } = await sim.list();
+  const udid = simulators.find((device) => device.isBooted)?.udid;
+
+  await sim.launch(udid, "com.example.App");
+  await sim.tap(udid, 0.5, 0.5);
+  await sim.waitFor(udid, { label: "Continue" });
+  await sim.screenshot(udid);
 } finally {
   sim.close();
 }
 ```
 
-`connect()` starts the daemon when needed, reuses it when healthy, and only stops daemons it started itself unless `keepDaemon` is set.
+`connect()` starts the project daemon if needed, reuses a healthy daemon, and only stops daemons it started itself.
 
-## Session API
+## Useful Test Methods
 
-The current session object exposes:
+| Method                                          | Purpose                        |
+| ----------------------------------------------- | ------------------------------ |
+| `list()`                                        | Device inventory               |
+| `boot()`, `shutdown()`, `erase()`               | Device lifecycle               |
+| `install()`, `uninstall()`, `launch()`          | App lifecycle                  |
+| `openUrl()`                                     | Universal links and deep links |
+| `tap()`, `tapElement()`, `swipe()`, `gesture()` | UI input                       |
+| `typeText()`, `key()`, `keySequence()`          | Text and keyboard input        |
+| `button()`, `home()`, `appSwitcher()`           | System controls                |
+| `tree()`, `query()`, `waitFor()`, `assert()`    | UI state checks                |
+| `screenshot()`, `logs()`                        | Evidence capture               |
+| `batch()`                                       | Multi-step actions             |
 
-| Method                                 | Purpose                                                           |
-| -------------------------------------- | ----------------------------------------------------------------- |
-| `list()`                               | Fetch simulator inventory from `GET /api/simulators`.             |
-| `boot()`, `shutdown()`, `erase()`      | Manage simulator or Android emulator lifecycle.                   |
-| `install()`, `uninstall()`             | Install or remove an app.                                         |
-| `launch()`                             | Launch an installed bundle ID or Android package.                 |
-| `openUrl()`                            | Open a URL or deep link.                                          |
-| `tap()`, `tapElement()`                | Tap normalized coordinates or a matching accessibility element.   |
-| `touch()`, `swipe()`, `gesture()`      | Send normalized pointer gestures.                                 |
-| `typeText()`, `key()`, `keySequence()` | Send text or HID keyboard input.                                  |
-| `button()`                             | Press a hardware button.                                          |
-| `home()`, `dismissKeyboard()`          | Trigger common system controls.                                   |
-| `appSwitcher()`                        | Open the app switcher.                                            |
-| `rotateLeft()`, `rotateRight()`        | Rotate the simulator display.                                     |
-| `toggleAppearance()`                   | Toggle light/dark appearance.                                     |
-| `pasteboardSet()`, `pasteboardGet()`   | Read or write pasteboard text.                                    |
-| `chromeProfile()`                      | Fetch screen/chrome geometry.                                     |
-| `logs()`                               | Fetch recent simulator or Android log entries.                    |
-| `tree()`                               | Fetch an accessibility hierarchy.                                 |
-| `query()`                              | Return compact matches for a selector.                            |
-| `waitFor()`                            | Poll until a selector appears.                                    |
-| `assert()`                             | Assert a selector is present.                                     |
-| `batch()`                              | Run multiple REST actions through `/api/simulators/{udid}/batch`. |
-| `screenshot()`                         | Return a PNG buffer.                                              |
-| `close()`                              | Stop the daemon if this session started it.                       |
+Selectors can match `id`, `label`, `value`, or `type`.
 
-Selectors can match `id`, `label`, `value`, or `type`. Query options accept `source`, `maxDepth`, and `includeHidden`.
+## Repository Tests
 
-## Repository Integration Suite
+Normal unit and client tests:
 
-The repo includes simulator-backed integration runners. The iOS runner is
-macOS-only; it creates a temporary simulator, builds and installs a small UIKit
-fixture app, then sweeps the CLI and REST control surface.
+```sh
+npm run test
+```
+
+iOS integration test:
 
 ```sh
 npm run build:cli
@@ -69,41 +61,13 @@ npm run test:integration:fixture
 npm run test:integration:cli
 ```
 
-Verbose mode opens Simulator.app and prints each step with timing:
+Verbose iOS run:
 
 ```sh
 npm run test:integration:cli:verbose
 ```
 
-Useful environment variables:
-
-| Variable                                | Purpose                                               |
-| --------------------------------------- | ----------------------------------------------------- |
-| `SIMDECK_INTEGRATION_VERBOSE=1`         | Print commands, outputs, timings, and UI checkpoints. |
-| `SIMDECK_INTEGRATION_TRACE_HTTP=1`      | Print raw HTTP request logs.                          |
-| `SIMDECK_INTEGRATION_SHOW_SIMULATOR=1`  | Open Simulator.app during the run.                    |
-| `SIMDECK_INTEGRATION_KEEP_SIMULATOR=1`  | Leave the temporary simulator after exit.             |
-| `SIMDECK_INTEGRATION_SIMCTL_TIMEOUT_MS` | Override the cold CoreSimulator command timeout.      |
-| `SIMDECK_INTEGRATION_IOS_RUNTIME`       | Force a runtime by version, name, or identifier.      |
-| `SIMDECK_INTEGRATION_DEVICE_TYPE`       | Force an iPhone device type by name or identifier.    |
-
-The integration suite is separate from `npm run test` because it boots and drives a real iOS simulator.
-The UIKit fixture app is cached under `.cache/simdeck/fixture` using a hash
-of its generated source, plist, simulator SDK, Clang version, and host
-architecture.
-
-By default, the integration runner selects the newest available iOS runtime that
-does not exceed the active `iphonesimulator` SDK version, falling back to the
-same major version when needed. This keeps CI off newer installed runtimes that
-do not match the selected Xcode toolchain.
-
-Android coverage is opt-in because it requires a locally installed Android SDK
-and at least one existing AVD. It runs on macOS or Linux. On Linux, SimDeck
-builds the daemon with a native iOS stub and leaves the Android bridge active.
-The runner starts an isolated SimDeck daemon and sweeps the Android CLI and
-`simdeck/test` surface for lifecycle, tree, screenshot, pasteboard behavior,
-app launch, URL opening, touch/swipe/gesture, keyboard, system buttons,
-rotation, appearance, logs, and batch controls:
+Android integration test:
 
 ```sh
 npm run build:cli
@@ -111,32 +75,28 @@ npm run build:simdeck-test
 npm run test:integration:android
 ```
 
-Set `SIMDECK_INTEGRATION_ANDROID_AVD=<avd-name>` to pick a specific AVD. The
-runner expects that emulator to already be booted, which is how the Linux CI job
-uses `reactivecircus/android-emulator-runner`. If no AVD is configured, or a
-local AVD exists but is not running, the Android runner prints a skip message
-and exits successfully. Set `SIMDECK_INTEGRATION_REQUIRE_RUNNING_ANDROID=1` to
-turn that skip into a failure. Set `SIMDECK_INTEGRATION_BOOT_ANDROID=1` to let
-SimDeck cold-boot a local AVD before the suite. Set
-`SIMDECK_INTEGRATION_KEEP_ANDROID=1` to leave an emulator booted when the runner
-started it. Set `SIMDECK_INTEGRATION_STEP_TIMEOUT_MS` to override the per-step
-timeout.
+Android tests require the Android SDK and a running or bootable AVD.
 
-## Stress and Leak Checks
+## Helpful Environment Variables
 
-Use the stress runner against an already-running daemon when you want to shake out
-high-usage reliability issues without adding minutes to every PR:
+| Variable                                        | Purpose                                              |
+| ----------------------------------------------- | ---------------------------------------------------- |
+| `SIMDECK_INTEGRATION_VERBOSE=1`                 | Print commands, outputs, and timings                 |
+| `SIMDECK_INTEGRATION_SHOW_SIMULATOR=1`          | Open Simulator.app during iOS tests                  |
+| `SIMDECK_INTEGRATION_KEEP_SIMULATOR=1`          | Keep the temporary iOS simulator                     |
+| `SIMDECK_INTEGRATION_TRACE_HTTP=1`              | Print HTTP request logs                              |
+| `SIMDECK_INTEGRATION_ANDROID_AVD=<name>`        | Pick an Android AVD                                  |
+| `SIMDECK_INTEGRATION_BOOT_ANDROID=1`            | Let SimDeck boot the Android emulator                |
+| `SIMDECK_INTEGRATION_REQUIRE_RUNNING_ANDROID=1` | Fail instead of skipping when Android is unavailable |
+
+## Stress Test A Running Daemon
 
 ```sh
 npm run test:stress -- --server-url http://127.0.0.1:4310 --iterations 1000 --concurrency 12
 ```
 
-To include simulator-specific refresh traffic and RSS growth checks:
+Include simulator refresh traffic:
 
 ```sh
-npm run test:stress -- --udid <udid> --iterations 2000 --concurrency 16 --max-rss-growth-mb 256
+npm run test:stress -- --udid <udid> --iterations 2000 --concurrency 16
 ```
-
-The runner repeatedly calls health, metrics, simulator listing, stream-quality,
-and optional simulator refresh endpoints. It samples the daemon process RSS with
-`ps` and fails if the peak or growth limits are exceeded.

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -1,133 +1,210 @@
 # Troubleshooting
 
-Most SimDeck issues fall into one of three buckets: simulator boot, video stream, or accessibility/inspector. This page lists the symptoms and fixes for the ones we hit most often.
+Use this page when SimDeck does not start, cannot see a device, shows a bad stream, or falls back to the wrong inspector.
 
-## Server won't start
-
-### `bind HTTP listener on 127.0.0.1:4310`
-
-Another process already owns the HTTP port. Pick a different one:
+## First Checks
 
 ```sh
-simdeck daemon start --port 4320
+simdeck --version
+xcode-select -p
+simdeck daemon status
+simdeck list
 ```
 
-Or find what's holding it:
+If a background daemon may be stale:
+
+```sh
+simdeck daemon stop
+simdeck
+```
+
+## Server Will Not Start
+
+### Port is already in use
+
+```text
+bind HTTP listener on 127.0.0.1:4310
+```
+
+Use another port:
+
+```sh
+simdeck ui --port 4320 --open
+```
+
+Or find the listener:
 
 ```sh
 lsof -nP -iTCP:4310 -sTCP:LISTEN
 ```
 
-If the holder is an old SimDeck daemon for the current project, stop it:
+If it is an old project daemon:
 
 ```sh
 simdeck daemon stop
 ```
 
-### `simdeck native binary is missing`
+### Native binary is missing
 
-The launcher script could not find the native binary. Reinstall the package or run the local build:
-
-```sh
-npm install -g simdeck
-# or, from a checkout:
-./scripts/build-cli.sh
-```
-
-### Native build fails from source
-
-`npm run build:cli` runs `cargo build --release` and Apple's Clang against the Objective-C bridge. The most common failures are:
-
-- **Rust missing.** Install via [rustup](https://rustup.rs/), then reinstall.
-- **Xcode command-line tools missing.** Run `xcode-select --install`.
-- **Sandboxed CI without macOS frameworks.** Build the npm package on macOS so the published tarball contains the native binary.
-
-## Simulator never boots
-
-### Private CoreSimulator boot errors
-
-SimDeck boots devices through private CoreSimulator APIs so it does not launch Simulator.app. If booting fails, the CLI returns that private CoreSimulator error directly and does not fall back to `xcrun simctl boot`. Confirm Xcode selection first:
+Reinstall from npm:
 
 ```sh
-xcode-select -p
-DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer simdeck boot <udid>
+npm install -g simdeck@latest
 ```
 
-If Xcode selection is correct but SimDeck still fails, capture the server log and file an issue. Running `xcrun simctl boot <udid>` can still be useful as a manual comparison, but it may launch Simulator.app and is not SimDeck's fallback path.
+From a source checkout:
 
-### CoreSimulator service unhealthy
+```sh
+npm run build:cli
+```
 
-If `simctl list` itself hangs or returns garbage, the macOS `com.apple.CoreSimulator.CoreSimulatorService` is wedged. Restart it:
+### Source build fails
+
+Check the common prerequisites:
+
+```sh
+xcode-select --install
+rustc --version
+node --version
+```
+
+Builds must run on macOS because SimDeck links macOS simulator frameworks.
+
+## Device Does Not Boot Or List
+
+### `simdeck list` hangs or returns stale data
+
+Restart Apple's simulator service:
 
 ```sh
 simdeck core-simulator restart
+simdeck list
 ```
 
-Re-run `simdeck list` to confirm before retrying.
-
-### Multiple Xcode installs
-
-When more than one Xcode is installed, `xcrun simctl` uses whichever Xcode is selected by `xcode-select`. Pick the one whose runtimes you care about:
+### Wrong Xcode is selected
 
 ```sh
 sudo xcode-select -s /Applications/Xcode.app
+simdeck list
 ```
 
-## Stream is black or stuck
+Or run one command with an explicit developer directory:
 
-### "Timed out waiting for initial simulator keyframe"
+```sh
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer simdeck list
+```
 
-The encoder did not produce a keyframe within 3 seconds. The most common causes:
+### Android emulator is missing
 
-- **VideoToolbox is busy.** macOS screen recording can starve the hardware H.264 encoder. Auto mode detects sustained hardware encode overload and temporarily falls back to software H.264. For a fully software-only run, start with:
+Confirm Android SDK tools are on `PATH`:
 
-  ```sh
-  simdeck daemon stop
-  simdeck daemon start --video-codec software
-  ```
+```sh
+adb devices
+emulator -list-avds
+```
 
-  On virtualized CI Macs where hardware H.264 is unavailable, use
-  `--video-codec software --stream-quality ci-software`. That profile
-  targets a 960-pixel longest edge at 24 fps and lowers bitrate/CPU pressure
-  before backlog turns into visible stream delay.
+Android IDs in SimDeck use `android:<avd-name>`.
 
-- **The Simulator window is minimised or off-screen.** The private display bridge captures from a headless context, so this is rare, but if you see it after waking from sleep, shut the simulator down and boot it again.
-- **The simulator is mid-shutdown.** Wait for `simdeck list` to report `isBooted: true`.
+## Stream Is Black Or Stuck
 
-### Frequent stutter or "Refresh stream" loops
+### Timed out waiting for the first frame
 
-The transport hub forces a keyframe whenever a client falls behind. If `frames_dropped_server` on `/api/metrics` climbs steadily, the bottleneck is between the encoder and the decoder.
+Try software encoding:
 
-- Bring the client closer (LAN with low latency vs Wi-Fi mesh hops).
-- Check `client_streams` in `/api/metrics`. If `decodedFps` is much lower than `packetFps`, the client decoder is the bottleneck.
+```sh
+simdeck daemon restart --video-codec software
+```
 
-## Inspector returns AX instead of NativeScript / UIKit
+For CI or virtualized Macs:
 
-The accessibility tree endpoint blends three inspector sources and falls back to AX snapshot when none of the others are reachable. The response includes both a `source` field and a `fallbackReason` field that explains what happened.
+```sh
+simdeck daemon restart --video-codec software --stream-quality ci-software
+```
 
-Common reasons:
+### Stream stutters or refreshes repeatedly
 
-| `fallbackReason`                                          | Fix                                                                                      |
-| --------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| `The in-app inspector process is not the foreground app.` | Bring the inspector-enabled app to the foreground.                                       |
-| `NativeScript hierarchy is not published by the app.`     | Make sure the app calls `startSimDeckInspector(...)` before bootstrapping.               |
-| `No connected NativeScript inspector ...`                 | The NativeScript inspector hasn't completed its WebSocket handshake yet. Reload the app. |
-| `No in-app inspector found ... on ports 47370-47402`      | The Swift agent isn't listening; confirm the app links and starts the agent in DEBUG.    |
+Lower the quality:
 
-For more on the inspector matrix, see the [Inspector Overview](/inspector/).
+```sh
+simdeck daemon restart --stream-quality low
+```
 
-## NativeScript inspector won't connect
+Check metrics:
 
-- Confirm `startSimDeckInspector({ port: 4310 })` runs in the simulator app's main thread before bootstrap.
-- Confirm the simulator can reach the host: from inside the app, `fetch('http://127.0.0.1:4310/api/health')` should succeed.
-- For Angular apps, make sure `startSimDeckInspector(...)` runs **before** `runNativeScriptAngularApp(...)`.
-- Watch the server log for messages such as `Registered NativeScript inspector for process …`. If you don't see one, the WebSocket never completed.
+```sh
+curl http://127.0.0.1:4310/api/metrics
+```
 
-## Logs
+If `frames_dropped_server` keeps climbing, the client or network cannot keep up. Move closer to the host, reduce quality, or switch to software encoding.
 
-When all else fails, capture the server log:
+### Browser cannot establish WebRTC
 
-- Dev server: read `build/cli.log` when using `npm run dev`.
-- Project daemon: stop and restart it from a terminal when you need foreground logs for a reproduction.
+Force the H.264 WebSocket fallback while testing:
 
-Include both files when filing an issue, along with `simdeck --version`, the macOS version, and the Xcode version.
+```text
+http://127.0.0.1:4310?stream=h264
+```
+
+For routed remote sessions, configure TURN as described in [Video & Streaming](/guide/video#remote-browsers).
+
+## Inspector Looks Wrong
+
+### `describe` returns accessibility instead of framework data
+
+The fallback is expected when no in-app inspector is available. Check:
+
+- The app with the inspector is foregrounded.
+- The app was built in debug mode.
+- The inspector package starts before the app UI boots.
+- The app is pointing at the active SimDeck port.
+
+Use a forced source to see the failure reason:
+
+```sh
+simdeck describe <udid> --source nativescript
+simdeck describe <udid> --source react-native
+simdeck describe <udid> --source flutter
+simdeck describe <udid> --source uikit
+```
+
+### NativeScript inspector does not connect
+
+- Call `startSimDeckInspector({ port: 4310 })` before bootstrap.
+- For Angular, call it before `runNativeScriptAngularApp(...)`.
+- Confirm the simulator app can reach `http://127.0.0.1:4310/api/health`.
+
+### React Native source locations are missing
+
+Use a development build. Production bundles usually strip React debug source metadata.
+
+### Flutter source locations are missing
+
+Run a debug build with widget creation tracking. Flutter enables this by default for normal debug runs.
+
+## LAN Browser Cannot Connect
+
+Start SimDeck with a LAN bind and reachable advertised host:
+
+```sh
+simdeck ui --bind 0.0.0.0 --advertise-host 192.168.1.50 --open
+```
+
+Then check:
+
+- The remote browser opens `http://192.168.1.50:4310`.
+- macOS Firewall allows the port.
+- The pairing code matches the current daemon.
+- API scripts send the daemon token.
+
+See [LAN Access](/guide/lan-access).
+
+## Logs To Include In Issues
+
+Include:
+
+- `simdeck --version`
+- macOS version
+- Xcode version
+- The command you ran
+- Foreground daemon output, or `build/cli.log` when using `npm run dev`
+- `simdeck daemon status` without sharing the token publicly

--- a/docs/guide/video.md
+++ b/docs/guide/video.md
@@ -1,207 +1,123 @@
-# Video Pipeline
+# Video & Streaming
 
-SimDeck streams the iOS Simulator over WebRTC using browser-native H.264 video playout, with H.264 over WebSocket as the fallback for Safari and networks where peer media negotiation fails. This page walks through the encoder choices, fallback transport, keyframe handshake, and metrics you can use to tune them.
+SimDeck streams live device video to the browser. Local sessions default to high quality. Remote or constrained sessions can trade detail for lower CPU and latency.
 
-## Codec selection
+## Pick A Stream Quality
 
-The server can encode the simulator display in three modes, picked at startup with `--video-codec`:
-
-| Value              | Encoder                              | When to use it                                                                              |
-| ------------------ | ------------------------------------ | ------------------------------------------------------------------------------------------- |
-| `auto` _(default)_ | VideoToolbox chooses the encoder     | Normal local and remote preview. Falls back to software when hardware encode is overloaded. |
-| `hardware`         | Required hardware H.264              | Use only when the hardware encoder is known to be available.                                |
-| `software`         | Software-only H.264 via VideoToolbox | Use when hardware encode stalls, is unavailable, or must be avoided.                        |
-
-Restart the daemon to change encoder mode:
+Start with the default:
 
 ```sh
+simdeck
+```
+
+Lower quality when the stream stutters, the machine is under load, or you are using a remote browser:
+
+```sh
+simdeck daemon restart --stream-quality low
+simdeck daemon restart --stream-quality tiny
+simdeck daemon restart --stream-quality ci-software
+```
+
+Common profiles:
+
+| Profile       | Use it for                              |
+| ------------- | --------------------------------------- |
+| `full`        | Local browser on a fast Mac             |
+| `balanced`    | Good local quality with less bandwidth  |
+| `economy`     | Remote browser or busy machine          |
+| `low`         | Slower Wi-Fi or shared hosts            |
+| `tiny`        | Pull request previews and low bandwidth |
+| `ci-software` | Virtualized CI Macs                     |
+
+The browser also has stream controls for transport, resolution, FPS, and refresh.
+
+## Pick A Codec
+
+```sh
+simdeck daemon restart --video-codec auto
+simdeck daemon restart --video-codec hardware
 simdeck daemon restart --video-codec software
 ```
 
-For slower runners, add `--low-latency` with software H.264:
+| Codec      | Use it for                                                            |
+| ---------- | --------------------------------------------------------------------- |
+| `auto`     | Normal use. SimDeck can move between hardware and software as needed. |
+| `hardware` | Dedicated local machines where hardware H.264 is reliable.            |
+| `software` | CI, screen recording conflicts, or hardware encoder stalls.           |
+
+For very constrained software sessions:
 
 ```sh
-simdeck daemon start --video-codec software --low-latency
+simdeck daemon restart --video-codec software --low-latency
 ```
 
-Low-latency mode caps software H.264 at 15 fps, keeps a single in-flight frame,
-scales the longest edge to 1170 pixels, and backs off FPS more aggressively when
-encode pressure rises. WebRTC refresh pacing uses the same 15 fps floor so the
-server does not keep waking capture/encode faster than the stream can consume.
-It is CLI-only because it is meant for less capable machines where freshness
-matters more than maximum smoothness.
+## WebRTC And Fallback
 
-The requested encoder mode is reported to clients in the JSON `videoCodec` field on `GET /api/health`.
-In `auto`, active simulator encoder metrics also report `activeEncoderMode`.
-When the hardware encoder is overloaded, `auto` rebuilds the active compression
-session as software H.264, then periodically retries hardware and stays there
-when the measured encode latency returns to budget.
-If all current browser viewers for a simulator are backgrounded or unfocused,
-the active session also switches to software H.264 until at least one viewer is
-foreground again.
-The browser UI exposes stream controls for encoder, FPS, transport, and resolution. H264 resolution choices are `full` (4096 px at 60 fps), `balanced` (1280 px at 60 fps), `economy` (1080 px at 30 fps), `low` (720 px at 30 fps), and `tiny` (540 px at 30 fps). Local H264 WebSocket sessions default to full resolution at 60 fps. Remote browser sessions default to software H.264, 30 fps, and adaptive quality.
+The browser tries WebRTC first. If WebRTC cannot render a frame, the UI can fall back to H.264 over WebSocket when the browser supports WebCodecs.
 
-## Remote WebRTC ICE
-
-By default SimDeck advertises Google's public STUN server to both the Rust
-WebRTC peer and the browser. For remote browsers, especially Safari connecting
-to a GitHub Actions runner, provide a TURN server and force relay candidates:
-
-```sh
-SIMDECK_WEBRTC_ICE_SERVERS=turns:turn.example.com:5349?transport=tcp \
-SIMDECK_WEBRTC_ICE_USERNAME=simdeck \
-SIMDECK_WEBRTC_ICE_CREDENTIAL=secret \
-SIMDECK_WEBRTC_ICE_TRANSPORT_POLICY=relay \
-simdeck daemon start --video-codec software --low-latency
-```
-
-The browser reads these settings from `GET /api/health` before creating its
-peer connection, so the local and remote peers use the same ICE configuration.
-Use `SIMDECK_WEBRTC_ICE_TRANSPORT_POLICY=all` or leave it unset for local LAN
-and localhost sessions.
-
-## H264 WebSocket fallback
-
-The browser UI defaults to `?stream=auto`: it tries WebRTC first and falls back
-to H264 over WebSocket if a decoded frame still does not render.
-For remote browser sessions, SimDeck also falls back immediately when the
-browser's WebRTC offer contains no local `host` ICE candidates, which covers
-Safari privacy/network settings that suppress direct candidates. The stream
-settings menu includes a transport picker for Auto, WebRTC, and H264 WS. You
-can also force a mode while testing:
+Force a mode while debugging:
 
 ```text
 http://127.0.0.1:4310?stream=webrtc
 http://127.0.0.1:4310?stream=h264
 ```
 
-H264 WS uses the same native H.264 encoder as WebRTC, but sends each encoded
-sample on a binary WebSocket at:
+## Remote Browsers
 
-```http
-GET /api/simulators/{udid}/h264?profile=full&fps=60&videoCodec=auto
+For another browser on the same network, see [LAN Access](/guide/lan-access).
+
+For routed remote access, use a tunnel or relay you trust. If your network requires TURN for WebRTC, set these before starting SimDeck:
+
+```sh
+SIMDECK_WEBRTC_ICE_SERVERS=turns:turn.example.com:5349?transport=tcp \
+SIMDECK_WEBRTC_ICE_USERNAME=simdeck \
+SIMDECK_WEBRTC_ICE_CREDENTIAL=secret \
+SIMDECK_WEBRTC_ICE_TRANSPORT_POLICY=relay \
+simdeck daemon start --video-codec software --stream-quality low
 ```
 
-Each message starts with a compact SimDeck header, followed by optional AVC
-decoder config and the encoded sample bytes. The browser decodes with
-WebCodecs, keeps only the latest decoded frame, and paints on
-`requestAnimationFrame` so stale frames do not build latency. Input stays on
-the separate `/api/simulators/{udid}/input` WebSocket so large video frames do
-not block touch and keyboard messages. Stream-quality updates and client stats
-use the WebRTC data channel or the H264 WS video socket instead of repeatedly
-posting REST requests. H264 WS defaults to the `full` profile on loopback and
-`auto` quality for remote sessions. H264 `Auto` starts at `full` on loopback;
-remote `Auto` starts lower but can climb through the internal `smooth` step
-(1170 px), `balanced`, and `full` after sustained low decode/render pressure.
+## Stream Diagnostics
 
-```http
-GET /api/simulators/{udid}/input
+Check health:
+
+```sh
+curl http://127.0.0.1:4310/api/health
 ```
 
-That WebSocket accepts the same normalized control JSON used by the WebRTC data
-channel and coalesces high-frequency touch `moved` events.
+Check counters:
 
-## Keyframe handshake
-
-When a browser connects through `/api/simulators/{udid}/webrtc/offer`:
-
-1. The server ensures the `SimulatorSession` is started and asks the encoder for an immediate refresh.
-2. It waits up to 3 seconds for the next keyframe.
-3. As soon as a keyframe arrives, it answers the browser's SDP offer and starts writing H.264 samples to a WebRTC video track.
-4. Subsequent frames stream until the peer connection closes.
-
-If the encoder cannot deliver a keyframe within 3 seconds, the server tears the session down with a clear error so the client can retry. This usually happens only when CoreSimulator is itself stuck.
-
-## Drop and lag handling
-
-The transport hub uses a tokio broadcast channel to fan out frames. If a slow client misses frames the hub:
-
-1. Increments `frames_dropped_server` on the metrics counter.
-2. Sets a "waiting for keyframe" flag and skips non-keyframes until a fresh one arrives.
-3. Calls `request_refresh()` on the session so the encoder forces a keyframe.
-
-The WebRTC path favors freshness: stale frames are dropped and the sender requests a new keyframe after discontinuities.
-
-## Picking a codec
-
-A few practical guidelines:
-
-- **Start on the default for local preview.** Browser realtime mode uses VideoToolbox H.264 with full resolution at 60 fps. Auto mode moves active sessions to software when hardware H.264 is overloaded, then retries hardware after a cooldown.
-- **Backgrounded web clients use software.** The browser sends page visibility/focus over the stream control channel. If every active viewer for a simulator is hidden or unfocused, the native session uses software H.264 until a viewer returns foreground.
-- **Use `--local-stream-fps` above 60 only for local high-refresh testing.** The local quality stream defaults to 60 fps; higher targets pace both capture refresh and hardware encode submission so the stream does not build delay by pushing unbounded frames.
-- **Switch to `software` when the hardware encoder stalls or is unavailable.** The encoder scales the longest edge to 1600 pixels, can climb toward 60 fps, and backs off dynamically under encode latency.
-- **Studio providers default to software H.264 plus `--stream-quality smooth`.** `smooth` is an internal/provider profile, not a browser picker item. It uses a 1170-pixel longest edge, allows up to 60 fps, raises the bitrate budget to reduce compression artifacts, and lets multiple provider sessions share CPU cores without depending on one hardware encoder.
-- **The remote browser renders WebRTC as a native `<video>` element and H264 WS through WebCodecs.** The canvas remains for input geometry and WebCodecs presentation, and fallback mode keeps simulator controls on the WebSocket input channel.
-- **Use `--stream-quality ci-software` for denser virtualized CI Macs.** This profile uses software H.264 at a 960-pixel longest edge, targets 24 fps, lowers bitrate pressure, and favors fresh frames over full-resolution sharpness.
-- **Use `simdeck studio expose --video-codec hardware` only when a dedicated hardware encoder is preferable.** The normal Studio default stays on software H.264 so future multi-simulator provider hosts can scale across CPU cores.
-- **Use `software --low-latency` only when you need the older extra-conservative software profile.** It caps at 15 fps, uses a single pending frame, reduces the longest edge to 1170 pixels, and backs off before software encode latency turns into seconds of stream delay.
-
-## Tuning with metrics
-
-`GET /api/metrics` returns a snapshot of every counter the server keeps:
-
-```json
-{
-  "frames_encoded": 12039,
-  "keyframes_encoded": 17,
-  "frames_sent": 11982,
-  "frames_dropped_server": 21,
-  "keyframe_requests": 4,
-  "active_streams": 1,
-  "subscribers_connected": 3,
-  "subscribers_disconnected": 2,
-  "max_send_queue_depth": 1,
-  "latest_first_frame_ms": 412
-}
+```sh
+curl http://127.0.0.1:4310/api/metrics
 ```
 
-Useful signals:
+Signals worth watching:
 
-| Counter                 | What to look at                                                                   |
-| ----------------------- | --------------------------------------------------------------------------------- |
-| `latest_first_frame_ms` | First-frame latency for the most recent connect. Should be a few hundred ms.      |
-| `frames_dropped_server` | If this climbs while a stream is open, the client cannot keep up.                 |
-| `keyframe_requests`     | Goes up every time the server forces a refresh. Frequent spikes mean rough seeks. |
-| `active_streams`        | Number of WebRTC streams currently subscribed.                                    |
+| Signal                             | Meaning                                                    |
+| ---------------------------------- | ---------------------------------------------------------- |
+| `latest_first_frame_ms`            | How long the most recent viewer waited for the first frame |
+| `frames_dropped_server`            | The server skipped frames to keep the stream fresh         |
+| `keyframe_requests`                | The client or server requested stream recovery             |
+| `encoders[].encoder.overloadState` | Encoder pressure: `nominal`, `strained`, or `overloaded`   |
 
-`encoders[].encoder.overloadState` reports native encoder pressure for each
-active simulator session. `strained` means encode latency is approaching the
-active frame budget; `overloaded` means smoothed latency is over budget or
-multiple frames in a row exceeded the budget. For hardware H.264 this usually
-means the shared VideoToolbox encoder is saturated; lower resolution/FPS or
-switch to software H.264. In `auto`, `activeEncoderMode`,
-`autoSoftwareFallbackActive`, `autoSoftwareFallbacks`, and
-`autoHardwareRetries` show whether the active session is temporarily using
-software H.264 while the hardware path cools down. `clientForeground` shows
-whether any current browser viewer is visible and focused; when it is `false`,
-the active encoder is software regardless of the requested mode.
+## Stuck Stream Checklist
 
-Clients can also push their decoder/renderer stats back to the server. Browser
-clients normally send these over the WebRTC telemetry data channel or the H264
-WS stream socket; REST remains available for simple clients:
+1. Click refresh in the browser toolbar.
+2. Restart with software encoding:
 
-```http
-POST /api/client-stream-stats
-Content-Type: application/json
+   ```sh
+   simdeck daemon restart --video-codec software
+   ```
 
-{
-  "clientId": "browser-ABC",
-  "kind": "viewport",
-  "codec": "h264",
-  "decodedFps": 59.7,
-  "droppedFps": 0.1,
-  "latestRenderMs": 6.2
-}
-```
+3. Lower stream quality:
 
-The server keeps the last 48 entries per `(clientId, kind)` pair and returns them from `GET /api/client-stream-stats`. The browser client uses these to render the in-app diagnostics overlay.
+   ```sh
+   simdeck daemon restart --stream-quality low
+   ```
 
-## Refreshing a stuck stream
+4. Restart Apple's simulator service:
 
-If a client suspects it has fallen too far behind, it can call:
+   ```sh
+   simdeck core-simulator restart
+   ```
 
-```http
-POST /api/simulators/{udid}/refresh
-```
-
-The server starts the session if needed and asks the encoder to emit a keyframe immediately. The browser client wires this to a "Refresh stream" affordance in its toolbar.
+5. See [Troubleshooting](/guide/troubleshooting#stream-is-black-or-stuck).

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,70 +3,73 @@ layout: home
 
 hero:
   name: SimDeck
-  text: Simulator control panel
-  tagline: Stream simulator from your favorite IDE, with built-in tools to enhance DX for developing mobile apps
+  text: Simulator control in your browser
+  tagline: Stream, inspect, and automate iOS Simulators and Android emulators from one local tool.
   actions:
     - theme: brand
-      text: Get Started
+      text: Quick Start
       link: /guide/quick-start
     - theme: alt
-      text: Why SimDeck?
-      link: /guide/
+      text: Install
+      link: /guide/installation
     - theme: alt
-      text: View on GitHub
-      link: https://github.com/NativeScript/SimDeck
+      text: CLI Reference
+      link: /cli/
 
 features:
   - icon:
       src: /icons/monitor-smartphone.svg
       width: 28
       height: 28
-    title: Browser-first simulator
-    details: "`simdeck` starts a foreground project daemon and prints local/LAN URLs for a client live WebRTC H.264 video & low-latency input."
+    title: Browser simulator view
+    details: Run `simdeck`, open the printed URL, and control the device from a local or LAN browser.
   - icon:
       src: /icons/zap.svg
       width: 28
       height: 28
-    title: Native macOS performance
-    details: "A Rust HTTP server fronts an Objective-C bridge that talks to CoreSimulator, SimulatorKit, private display APIs."
-  - icon:
-      src: /icons/network.svg
-      width: 28
-      height: 28
-    title: Streaming remote
-    details: "WebRTC/WebSocket transports allow remote streaming/tunneling the simulator stream efficiently. Share your simulator streams with coworkers, or use in CI."
+    title: Fast local control
+    details: Boot devices, install apps, open URLs, type, tap, swipe, rotate, capture screenshots, and read logs from the CLI.
   - icon:
       src: /icons/scan-search.svg
       width: 28
       height: 28
-    title: First-class inspectors
-    details: "`describe` and the UI prefer NativeScript, React Native, UIKit, SwiftUI in-app inspectors when available, fall back to accessibility tree."
+    title: Useful inspection
+    details: Use accessibility, NativeScript, React Native, Flutter, Swift, UIKit, SwiftUI, WebKit, and DevTools views when available.
   - icon:
       src: /icons/puzzle.svg
       width: 28
       height: 28
-    title: Built-in extension
-    details: "VS Code extension opens the simulator inside the editor, and `simdeck/test` gives JS/TS tests a fast API for app automation."
+    title: Tests and editor workflows
+    details: Use `simdeck/test` for JS/TS automation and the VS Code extension to keep a simulator panel inside the editor.
+  - icon:
+      src: /icons/network.svg
+      width: 28
+      height: 28
+    title: Local first, shareable
+    details: Bind to localhost for daily use, or expose a paired LAN session when another device or teammate needs access.
   - icon:
       src: /icons/shield-check.svg
       width: 28
       height: 28
-    title: Remote streaming
-    details: "Local first but simulator streams can be shared using tools like Cloudflare Tunnel."
+    title: Built for agents
+    details: Compact `describe` output, selector-based input, batch commands, and clear JSON errors keep automation predictable.
 ---
 
 <div class="vp-doc" style="max-width: 1152px; margin: 4rem auto 0; padding: 0 24px;">
 
-## What you can do with SimDeck
+## Start here
 
-SimDeck packages a full simulator workflow into one cross-tool surface:
+```sh
+npx simdeck
+```
 
-- **Stream a Simulator into a browser tab.** Run `simdeck` and open one of the printed URLs, or use `simdeck ui --open` for a reusable background daemon.
-- **Debug view hierarchy.** Integrates with NativeScript, React Native, UIKit, SwiftUI and Flutter and allows debugging views/layout.
-- **Drive Simulators from JavaScript.** `simdeck/test` can launch apps, tap, wait for accessibility state, batch steps, and capture screenshots.
-- **Embed a Simulator in your editor.** The bundled VS Code extension opens the same surface inside a panel.
-- **Replace ad-hoc `simctl` scripts.** A single CLI handles `boot`, `shutdown`, app install/launch, URL opening, pasteboard, logs, screenshots, and UI input.
+That starts a foreground SimDeck server for the current workspace and prints browser URLs. Open the local URL to view and control the simulator. Press `q` or Ctrl-C to stop it.
 
-Read [Architecture](/guide/architecture) for a deeper tour, or jump straight into [Quick Start](/guide/quick-start).
+Common next steps:
+
+- [Install the CLI](/guide/installation) for repeated use.
+- [Open a simulator in the browser](/guide/quick-start).
+- [Drive a simulator from the CLI](/cli/commands).
+- [Troubleshoot startup, stream, or inspector issues](/guide/troubleshooting).
 
 </div>

--- a/docs/inspector/accessibility.md
+++ b/docs/inspector/accessibility.md
@@ -1,34 +1,35 @@
 # Accessibility
 
-SimDeck's universal fallback inspector uses the private iOS Simulator accessibility APIs. It works against any simulator app — no SDK linking required — but only reports what the system accessibility stack exposes.
+Accessibility is SimDeck's universal inspector. It works with any simulator app and requires no app changes.
 
-## Coverage
+## What It Shows
 
-It reports anything the app publishes through the accessibility tree:
+- Accessibility label, identifier, value, hint, role, and actions.
+- Bounds and frames in screen points.
+- Enough structure for selector-based taps, waits, and assertions.
 
-- `AXLabel`, `AXIdentifier`, `AXValue`, `help` (hint).
-- `bounds` and `frameInScreen` in UIKit screen points.
-- Role, sub-role, and the small set of custom accessibility actions a view exposes.
+Use it from the CLI:
 
-It does **not** see:
+```sh
+simdeck describe <udid> --source native-ax
+simdeck tap <udid> --label "Continue" --wait-timeout-ms 5000
+```
 
-- SwiftUI value-tree internals unless the app links the Swift agent and attaches the SwiftUI root publisher.
-- NativeScript logical tree nodes.
-- UIView properties that aren't part of the accessibility surface.
+## What It Cannot Show
 
-For those, you need to link the [Swift in-app agent](/inspector/swift), attach the SwiftUI root publisher, or use a framework runtime inspector such as [NativeScript](/inspector/nativescript), [React Native](/inspector/react-native), or [Flutter](/inspector/flutter).
+- Internal SwiftUI value trees.
+- NativeScript, React Native, or Flutter component/widget structure.
+- UIKit properties that are not exposed through accessibility.
+- Source locations.
 
-## When AX is the right call
+Use an in-app inspector when you need those details.
 
-- You're inspecting an app you do not control (a system app, a third-party binary).
-- You only need to find an element by label or ID and tap it.
-- You're building accessibility QA workflows where the accessibility surface is the actual surface you care about.
+## Good Uses
 
-## Limitations and gotchas
+- Testing labels, identifiers, and accessibility quality.
+- Driving apps you do not control.
+- Building stable selector-based automation.
 
-- **Foreground app only.** Like the iOS accessibility stack, AX snapshot sees the foreground app at the time of the call. If you switch apps mid-call, the snapshot may straddle two processes.
-- **Coordinates are in UIKit points.** Multiply by `displayScale` (from the inspector metadata or the simulator's device profile) when correlating with pixel-space frames.
+## Coordinate Note
 
-## Combining with in-app inspectors
-
-When both AX and an in-app inspector are available, the response includes both in `availableSources`. The browser client offers a source selector so you can compare the trees side by side. This is especially useful when you suspect a NativeScript element is not making it into the accessibility tree the way you expect.
+Frames are in screen points, not pixels. Use the simulator scale or inspector metadata if you need pixel coordinates.

--- a/docs/inspector/flutter.md
+++ b/docs/inspector/flutter.md
@@ -1,8 +1,8 @@
-# Flutter Runtime Inspector
+# Flutter Inspector
 
-`simdeck_flutter_inspector` is a debug-only Flutter iOS plugin that publishes the live Flutter widget hierarchy to SimDeck. It uses the same [Inspector Protocol](/api/inspector-protocol) as the Swift, NativeScript, and React Native inspectors, and connects outbound to the SimDeck server over WebSocket.
+`simdeck_flutter_inspector` publishes a Flutter widget tree to SimDeck in debug builds.
 
-The package source lives at `packages/flutter-inspector/` in this repo.
+Use it when accessibility does not show enough widget, render, semantics, or source-location data.
 
 ## Install
 
@@ -10,9 +10,7 @@ The package source lives at `packages/flutter-inspector/` in this repo.
 flutter pub add simdeck_flutter_inspector
 ```
 
-## Start the inspector
-
-Start the inspector during app startup in debug builds:
+## Start It
 
 ```dart
 import 'package:flutter/foundation.dart';
@@ -30,30 +28,41 @@ void main() {
 }
 ```
 
-`port` is the SimDeck server port. Flutter apps do not need to choose a local inspector port.
+`port` is the SimDeck server port.
 
-## What it exposes
+## Inspect
 
-`View.getHierarchy` returns the Flutter widget tree. Each node may include:
+```sh
+simdeck describe <udid> --source flutter --format agent
+```
 
-- `type` and `displayName` — the widget runtime type.
-- `title` — derived from semantics labels, common widget diagnostics, text, tooltip, value, or key.
-- `frame` and `frameInScreen` — RenderObject bounds in logical screen points.
-- `flutter` — widget, element, state type, key, and depth metadata.
-- `semantics` — label, value, hint, identifier, role, flags, and supported semantics actions.
-- `sourceLocation` — file, line, and column from Flutter widget creation tracking.
+Nodes may include:
 
-Source locations require debug builds with `--track-widget-creation`, which Flutter enables by default for debug runs.
+- Widget, element, and state type.
+- Text, keys, tooltips, labels, values, and semantics roles.
+- RenderObject bounds in logical screen points.
+- Semantics actions.
+- Source locations from Flutter widget creation tracking.
 
-## Debug actions
+Flutter enables widget creation tracking for normal debug runs.
 
-The Flutter runtime supports `View.getProperties`, `View.listActions`, and `View.perform`.
+## Debug Actions
 
-`View.perform` is best-effort and uses Flutter's own runtime APIs:
+The runtime supports best-effort actions such as:
 
-- `tap`, `longPress`, `increase`, and `decrease` dispatch matching semantics actions.
-- `focus` and `resignFirstResponder` use Flutter focus scopes.
-- `setText` updates the nearest `EditableText`.
-- `scrollBy` and `scrollTo` drive the nearest `Scrollable`.
+- `tap`
+- `longPress`
+- `focus`
+- `setText`
+- `scrollBy`
+- `scrollTo`
+- semantics `increase` and `decrease`
 
-Flutter widgets are immutable, so `View.setProperty` returns an unsupported-method error. Runtime interactions should go through `View.perform`, while persistent visual changes should still be made in app source.
+Flutter widgets are immutable, so persistent visual changes should still be made in app source.
+
+## Troubleshooting
+
+- Use a debug build.
+- Bring the app to the foreground.
+- Confirm the app can reach the SimDeck server port.
+- Force `--source flutter` to read the fallback reason.

--- a/docs/inspector/index.md
+++ b/docs/inspector/index.md
@@ -1,112 +1,62 @@
-# Inspector Overview
+# Inspectors
 
-SimDeck blends three different ways to inspect what an iOS app is rendering:
+SimDeck can show what an app is rendering, not just the pixels on screen.
 
-| Source                   | Coverage                                                                                                                 | When to use it                                                                                     |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
-| **Native AX**            | Any simulator app via the Simulator accessibility stack.                                                                 | Default fallback.                                                                                  |
-| **Swift in-app agent**   | Apps that link `SimDeckInspectorAgent` in DEBUG.                                                                         | Best for native iOS apps you control.                                                              |
-| **NativeScript runtime** | NativeScript apps that import `@nativescript/simdeck-inspector`.                                                         | Best for NativeScript apps — exposes the logical view tree, not just UIKit.                        |
-| **React Native runtime** | React Native apps that import `react-native-simdeck`.                                                                    | Best for React Native apps — exposes components and Metro source locations.                        |
-| **Flutter runtime**      | Flutter apps that import `simdeck_flutter_inspector`.                                                                    | Best for Flutter apps — exposes widgets, render frames, semantics actions, and creation locations. |
-| **DevTools panel**       | Safari/WebKit targets, Metro React Native targets, Chrome Inspector targets, and SimDeck app runtime inspector sessions. | Best when you want a familiar browser inspector for app runtimes or web content.                   |
+Use the built-in accessibility fallback for any app. Add an in-app inspector when you want framework-level trees, source locations, and debug actions.
 
-The HTTP API picks the most specific source available, falls back to the next one when something goes wrong, and tells the client which sources were available so the UI can offer a switch.
+## Sources
 
-## How the server picks a source
+| Source        | Best for                                      | Setup                                     |
+| ------------- | --------------------------------------------- | ----------------------------------------- |
+| Accessibility | Any app                                       | None                                      |
+| Swift agent   | UIKit and SwiftUI apps you control            | Add the Swift package in debug builds     |
+| NativeScript  | NativeScript apps                             | Install `@nativescript/simdeck-inspector` |
+| React Native  | React Native apps                             | Import `react-native-simdeck/auto`        |
+| Flutter       | Flutter apps                                  | Start `simdeck_flutter_inspector`         |
+| DevTools      | WebKit, Metro, Chrome Inspector, app runtimes | Use the browser DevTools panel            |
 
-`GET /api/simulators/{udid}/accessibility-tree` accepts a `source` query parameter:
+## Use From The CLI
 
-| `source`                     | Behaviour                                                                                              |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `auto` _(default)_ / unset   | Use the most accurate source available, falling back to AX.                                            |
-| `nativescript` / `ns`        | Force the NativeScript logical tree if a NativeScript inspector is connected for the foreground app.   |
-| `react-native` / `rn`        | Force the React Native component tree if a React Native inspector is connected for the foreground app. |
-| `flutter` / `fl`             | Force the Flutter widget tree if a Flutter inspector is connected for the foreground app.              |
-| `swiftui` / `swift-ui`       | Force the published SwiftUI logical tree if the Swift agent root publisher is installed in the app.    |
-| `uikit` / `in-app-inspector` | Force the raw UIKit hierarchy from any in-app inspector (NativeScript or Swift agent).                 |
-| `native-ax` / `ax`           | Always use the native accessibility snapshot.                                                          |
-
-The server resolves which inspector belongs to the simulator by:
-
-1. Checking every connected WebSocket runtime inspector for a process running on the target UDID.
-2. Reading `~/.simdeck/inspectors.json` for inspectors published by other SimDeck daemons, validating the process against the target UDID, and relaying requests through the owning daemon.
-3. Probing TCP `47370–47402` on `127.0.0.1` for a Swift inspector agent and matching its `processIdentifier` against the UDID's processes via `ps`.
-4. Falling back to AX when none match.
-
-Every accessibility tree response includes:
-
-```json
-{
-  "source": "nativescript|react-native|flutter|swiftui|in-app-inspector|native-ax",
-  "availableSources": [
-    "nativescript",
-    "react-native",
-    "flutter",
-    "swiftui",
-    "in-app-inspector",
-    "native-ax"
-  ],
-  "fallbackReason": "...",
-  "inspector": { "bundleIdentifier": "...", "processIdentifier": 73214 }
-}
+```sh
+simdeck describe <udid>
+simdeck describe <udid> --format agent --max-depth 3
+simdeck describe <udid> --source native-ax
+simdeck describe <udid> --source react-native
 ```
 
-`fallbackReason` only appears when the requested source could not be honoured. The browser client uses it to render a banner explaining what happened.
+`auto` source selection uses the best available source and falls back to accessibility.
 
-## Choosing the right inspector
+## Use From The Browser
 
-- **You own the iOS app and write Swift / Objective-C.** Link the [Swift in-app agent](/inspector/swift). It exposes the most semantic data — UIView properties, SwiftUI view trees/probes, custom actions — and lets the browser client edit values in place.
-- **You ship a NativeScript app.** Use the [NativeScript runtime inspector](/inspector/nativescript). It connects outbound to the SimDeck server and publishes both the NativeScript logical tree and the underlying UIKit hierarchy.
-- **You ship a React Native app.** Use the [React Native runtime inspector](/inspector/react-native). It connects outbound to the SimDeck server and publishes the React component tree with dev-mode source locations.
-- **You want DevTools for React Native, Safari/WebKit, Chrome Inspector, or a connected app runtime.** Use the DevTools toolbar toggle. It shows one target list for WebKit Remote Inspector targets, Metro React Native targets, local Chrome Inspector ports, and connected React Native or NativeScript SimDeck inspector sessions.
-- **You ship a Flutter app.** Use the [Flutter runtime inspector](/inspector/flutter). It connects outbound to the SimDeck server and publishes the Flutter widget tree with render frames, semantics metadata, and debug creation locations.
-- **You can't link anything into the app.** Stick with [AX snapshot](/inspector/accessibility). It only sees what the iOS accessibility stack exposes, but it works for every app.
+Open the SimDeck UI and select a device. The inspector pane shows the active tree source and any fallback reason. When multiple sources are available, switch sources from the inspector controls.
 
-## Editing properties
+The DevTools panel can open:
 
-When the in-app inspector is reachable, the browser client can:
+- Safari and inspectable `WKWebView` targets.
+- React Native Metro targets.
+- Local Chrome Inspector targets.
+- Connected app runtime inspector targets.
 
-- List actions a view supports (`tap`, `setText`, `scrollBy`, …) and trigger them.
-- Read editable runtime properties (`alpha`, `backgroundColor`, `clipsToBounds`, `text`, …).
-- Set those properties live, with structured value coercion for `UIColor`, `CGRect`, `CGPoint`, `CGSize`, and `UIEdgeInsets`.
+For app-owned `WKWebView` on iOS 16.4 or newer, set `isInspectable = true`.
 
-These calls go through the HTTP proxy at `POST /api/simulators/{udid}/inspector/request`, which only accepts a small allow-list of methods. Direct TCP and WebSocket clients can use the full method list documented in the [Inspector Protocol](/api/inspector-protocol).
+## Choosing A Source
 
-## WebKit targets
+- Use **Accessibility** when you cannot modify the app or when accessibility is the thing you are testing.
+- Use **Swift** for UIKit properties, SwiftUI publishing, or debug view edits.
+- Use **NativeScript**, **React Native**, or **Flutter** when you want framework names and source locations.
+- Use **DevTools** for web content, Metro debugging, console evaluation, or familiar browser inspection.
 
-WebKit inspection is separate from the accessibility tree. The server discovers
-inspectable targets through the simulator's `webinspectord` socket:
+## Troubleshooting
 
-```http
-GET /api/simulators/{udid}/webkit/targets
-```
+If SimDeck falls back to accessibility:
 
-Each target includes an `inspectorUrl` that opens WebInspectorUI through SimDeck.
-The browser client also exposes the same flow through the unified DevTools
-toolbar toggle, which opens a resizeable right-side panel and attaches to the
-first discovered target by default.
-This only finds WebKit content that WebKit exposes to the Remote Inspector. On
-iOS 16.4 and newer, app-owned `WKWebView` instances must set
-`isInspectable = true`; otherwise AX may show the web area, but WebInspectorUI
-cannot attach to it.
+1. Make sure the app is foregrounded.
+2. Confirm the inspector starts in debug builds.
+3. Confirm the app points at the active SimDeck port.
+4. Force the source from the CLI to see the fallback reason:
 
-## Chrome DevTools targets
+   ```sh
+   simdeck describe <udid> --source react-native
+   ```
 
-Chrome DevTools inspection is also separate from the accessibility tree. The
-server exposes Metro React Native DevTools pages, local Chrome Inspector targets,
-and connected React Native or NativeScript runtimes as Chrome DevTools targets:
-
-```http
-GET /api/simulators/{udid}/devtools/targets
-```
-
-Metro targets are discovered from common Metro ports plus matching local
-Node/React Native listener ports, then matched to the selected simulator by
-device name. Generic Chrome Inspector targets are discovered from common
-Inspector ports such as `9222-9230` plus matching local Chrome/Node listener
-ports. SimDeck proxies target WebSockets so the embedded frontend connects back
-to the SimDeck server instead of opening cross-origin browser sockets. Each
-target includes a `devtoolsFrontendUrl` that opens the bundled Chrome DevTools UI
-through SimDeck. The browser client exposes these targets in the same DevTools
-panel as WebKit inspection.
+See [Troubleshooting](/guide/troubleshooting#inspector-looks-wrong).

--- a/docs/inspector/nativescript.md
+++ b/docs/inspector/nativescript.md
@@ -1,8 +1,8 @@
-# NativeScript Runtime Inspector
+# NativeScript Inspector
 
-`@nativescript/simdeck-inspector` is the runtime that connects a NativeScript app's view hierarchy to the SimDeck server without linking the Swift inspector framework. It implements the same [Inspector Protocol](/api/inspector-protocol) as the Swift agent but ships as a TypeScript package and runs entirely inside the NativeScript runtime.
+`@nativescript/simdeck-inspector` publishes a NativeScript app's logical view tree to SimDeck.
 
-The package source lives at `packages/nativescript-inspector/` in this repo.
+Use it when accessibility does not show enough framework context or when you want source locations.
 
 ## Install
 
@@ -10,13 +10,9 @@ The package source lives at `packages/nativescript-inspector/` in this repo.
 npm install @nativescript/simdeck-inspector
 ```
 
-The package is `darwin`-friendly because the underlying NativeScript runtime is iOS-only; it works fine in NativeScript-iOS builds.
+## Start It
 
-## Start the inspector
-
-Call `startSimDeckInspector(...)` as early as possible in app startup, ideally before any view is bootstrapped.
-
-### NativeScript Core
+Call it before app bootstrap in debug builds:
 
 ```ts
 import { startSimDeckInspector } from "@nativescript/simdeck-inspector";
@@ -26,13 +22,9 @@ if (__DEV__) {
 }
 ```
 
-::: tip Port semantics
-`port` here is the **SimDeck server port**, not a per-app inspector port. NativeScript apps do not need to choose a unique local inspector port — they connect outbound to the server's WebSocket hub.
-:::
+`port` is the SimDeck server port.
 
-### NativeScript + Angular
-
-For Angular NativeScript apps, call `startSimDeckInspector()` **before** `runNativeScriptAngularApp()`:
+For Angular NativeScript apps, start the inspector before `runNativeScriptAngularApp(...)`:
 
 ```ts
 import { startSimDeckInspector } from "@nativescript/simdeck-inspector";
@@ -40,52 +32,35 @@ import { startSimDeckInspector } from "@nativescript/simdeck-inspector";
 startSimDeckInspector({ port: 4310 });
 
 runNativeScriptAngularApp({
-  appModuleBootstrap: () =>
-    bootstrapApplication(AppComponent, {
-      providers: [
-        provideNativeScriptHttpClient(withInterceptorsFromDi()),
-        provideNativeScriptRouter(routes),
-      ],
-    }),
+  appModuleBootstrap: () => bootstrapApplication(AppComponent),
 });
 ```
 
-The package installs a small compatibility shim for Angular 20 dev-mode template source locations on NativeScript views.
+## What You Get
 
-## What it exposes
+NativeScript hierarchy nodes can include:
 
-`View.getHierarchy` returns the NativeScript logical tree by default — the actual `View` nodes you wrote, not just their UIKit backings. Pass `"source": "uikit"` to force the raw UIKit hierarchy.
+- NativeScript view type.
+- Text, labels, IDs, CSS classes, and bindings.
+- Screen-point frames.
+- Underlying UIKit view information.
+- Source locations when available.
 
-Each NativeScript node carries:
+Inspect it:
 
-- `type` — the view's class name (`Label`, `StackLayout`, `GridLayout`, …).
-- `title` — derived text content or accessibility label when available.
-- `bounds` and `frameInScreen` — UIKit screen points.
-- `nativeScript` — NativeScript-specific metadata (CSS class names, IDs, bindings).
-- `sourceLocation` — file/line/column when source maps are available.
-
-When the in-app NativeScript inspector is the source, the SimDeck server returns `"source": "nativescript"` on the accessibility tree response and surfaces the matching `bundleIdentifier`, `processIdentifier`, and `displayScale` in the `inspector` block.
-
-## Connection model
-
-The runtime opens a WebSocket from the simulator app to the SimDeck server:
-
-```text
-ws://127.0.0.1:4310/api/inspector/connect
+```sh
+simdeck describe <udid> --source nativescript --format agent
 ```
 
-After the WebSocket is up, the server sends `Inspector.getInfo` and the runtime responds with the protocol version, `processIdentifier`, bundle metadata, and the available hierarchy sources. The server registers the runtime under that PID and prefers it over any TCP-based inspector for the same process.
+Force UIKit instead:
 
-If the WebSocket transport is not available, the runtime falls back to long-polling:
+```sh
+simdeck describe <udid> --source uikit --format agent
+```
 
-- `GET /api/inspector/poll?processIdentifier=<pid>` — waits for the next request from the server.
-- `POST /api/inspector/response` — sends the response back.
+## Angular Source Locations
 
-Both transports speak the same envelope, so the same JS code handles them.
-
-## Source locations from Angular templates
-
-The NativeScript runtime can attach `sourceLocation` metadata to individual nodes when Angular dev-mode template source locations are enabled. Wire up your NativeScript webpack config:
+Enable Angular template source locations in your NativeScript webpack config when you want nodes to point back to templates:
 
 ```js
 const webpack = require("@nativescript/webpack");
@@ -120,23 +95,7 @@ module.exports = (env) => {
 };
 ```
 
-With that in place, hierarchy nodes carry entries like:
-
-```json
-{
-  "type": "Label",
-  "sourceLocation": {
-    "file": "src/app/home.component.html",
-    "line": 12,
-    "column": 5,
-    "offset": 238
-  }
-}
-```
-
-The SimDeck browser client renders the file path inline so you can jump straight to source.
-
-## Stopping the inspector
+## Stop It
 
 ```ts
 import { stopSimDeckInspector } from "@nativescript/simdeck-inspector";
@@ -144,8 +103,9 @@ import { stopSimDeckInspector } from "@nativescript/simdeck-inspector";
 stopSimDeckInspector();
 ```
 
-This closes the WebSocket and stops responding to inspector requests. Subsequent calls to `startSimDeckInspector(...)` will spin a fresh runtime.
+## Troubleshooting
 
-## Coexistence with the Swift agent
-
-If both the Swift in-app inspector agent and the NativeScript runtime are present in the same app, the SimDeck server prefers the NativeScript runtime because it can publish the framework-level hierarchy. Direct TCP clients of the Swift agent are unaffected.
+- Start the inspector before bootstrap.
+- Confirm the app can reach `http://127.0.0.1:4310/api/health`.
+- Bring the app to the foreground before calling `describe`.
+- Force `--source nativescript` to read the fallback reason.

--- a/docs/inspector/react-native.md
+++ b/docs/inspector/react-native.md
@@ -1,8 +1,8 @@
-# React Native Runtime Inspector
+# React Native Inspector
 
-`react-native-simdeck` is a debug-only React Native iOS package that publishes the React component tree to SimDeck. It uses the same [Inspector Protocol](/api/inspector-protocol) as the Swift and NativeScript inspectors, but connects outbound to the SimDeck server over WebSocket.
+`react-native-simdeck` publishes a React Native component tree to SimDeck in development builds.
 
-The package source lives at `packages/react-native-inspector/` in this repo.
+Use it when you want component names, host tags, `testID`/`nativeID`, source locations, and best-effort debug actions.
 
 ## Install
 
@@ -11,16 +11,18 @@ npm install react-native-simdeck
 cd ios && pod install
 ```
 
-## Start the inspector
+## Start It
 
-Import the auto entrypoint before `AppRegistry.registerComponent(...)` so the package can install the React Fiber hook before the app's first render. For Expo Router, import it before `expo-router/entry`.
+Import the auto entrypoint before the app registers.
+
+Expo Router:
 
 ```ts
 import "react-native-simdeck/auto";
 import "expo-router/entry";
 ```
 
-For manual React Native entrypoints:
+Manual entrypoint:
 
 ```ts
 import "react-native-simdeck/auto";
@@ -30,40 +32,40 @@ import App from "./App";
 AppRegistry.registerComponent("Example", () => App);
 ```
 
-The auto entrypoint no-ops outside development, reads `EXPO_PUBLIC_SIMDECK_PORT` when present, and otherwise scans common SimDeck daemon ports.
-
-If you need explicit options, call `startSimDeckReactNativeInspector(...)` before registering the app:
+Explicit options:
 
 ```ts
-import { AppRegistry } from "react-native";
 import { startSimDeckReactNativeInspector } from "react-native-simdeck";
-import App from "./App";
 
 if (__DEV__) {
   startSimDeckReactNativeInspector({ port: 4310 });
 }
-
-AppRegistry.registerComponent("Example", () => App);
 ```
 
-`port` is the SimDeck server port. React Native apps do not need to choose a local inspector port.
+`port` is the SimDeck server port.
 
-## What it exposes
+## Inspect
 
-`View.getHierarchy` returns the React component hierarchy by default. Each node may include:
+```sh
+simdeck describe <udid> --source react-native --format agent
+```
 
-- `type` — the component or host component name.
-- `title` — derived from accessibility label, `testID`, `nativeID`, or text children.
-- `frame` and `frameInScreen` — measured screen-point bounds when the node resolves to a native host tag.
-- `reactNative` — React Native metadata such as host tag, `testID`, and `nativeID`.
-- `sourceLocation` — Metro dev-mode file/line/column data from React's `_debugSource` metadata.
+Nodes may include:
 
-Source locations depend on development builds. Production bundles normally strip this metadata.
+- Component or host component name.
+- Accessibility label, `testID`, `nativeID`, and text.
+- Screen-point frames when the component resolves to a native host.
+- Metro dev-mode source locations.
 
-## Debug edits and JS execution
+## Debug Edits
 
-The package supports the standard `View.getProperties`, `View.setProperty`, and `View.evaluateScript` methods.
+`View.setProperty` is best-effort. If the node resolves to a native host instance, the runtime calls `setNativeProps(...)`. The app's next React render can overwrite the edit.
 
-`View.setProperty` is best-effort: when the selected node resolves to a native host instance, it calls `setNativeProps(...)`. It cannot rewrite immutable React component props, and the app's next render can override debug edits.
+`View.evaluateScript` runs with useful React Native objects in scope for diagnostics.
 
-`View.evaluateScript` runs with `fiber`, `props`, `instance`, and `ReactNative` in scope.
+## Troubleshooting
+
+- Import the auto entrypoint before app registration.
+- Use a development build for source locations.
+- Set `EXPO_PUBLIC_SIMDECK_PORT=4310` if auto port scanning cannot find the daemon.
+- Bring the app to the foreground before inspecting.

--- a/docs/inspector/swift.md
+++ b/docs/inspector/swift.md
@@ -1,24 +1,20 @@
-# Swift In-App Inspector Agent
+# Swift Inspector
 
-`SimDeckInspectorAgent` is a debug-only iOS Swift package that exposes a UIKit hierarchy and live property edits through the [`SDI/0.1`](/api/inspector-protocol) protocol. Apps that link it for `Debug` builds can be inspected from the SimDeck browser client without going through the system accessibility stack.
+`SimDeckInspectorAgent` is a debug-only Swift package for UIKit and SwiftUI apps. It exposes richer hierarchy data and debug actions than accessibility alone.
 
-The package source lives at `packages/inspector-agent/` in this repo.
+## Add The Package
 
-## Install
-
-Add the local Swift package to your app:
+Add this local Swift package to your app:
 
 ```text
 packages/inspector-agent
 ```
 
-Then link the `SimDeckInspectorAgent` product into your app target for `Debug` configurations only.
+Link the `SimDeckInspectorAgent` product only in debug builds.
 
-## Start the agent
+## Start It
 
-Call the initializer early in app startup, behind a `#if DEBUG` guard.
-
-### SwiftUI
+SwiftUI:
 
 ```swift
 #if DEBUG
@@ -41,7 +37,7 @@ struct DemoApp: App {
 }
 ```
 
-### UIKit
+UIKit:
 
 ```swift
 func application(
@@ -55,32 +51,9 @@ func application(
 }
 ```
 
-## How discovery works
+## SwiftUI Trees
 
-The agent listens on TCP `127.0.0.1:47370` by default. If that port is already in use it tries the next 32 ports and listens on the first free one. It also advertises Bonjour service type `_simdeckinspector._tcp` so other tools can find it without probing.
-
-The SimDeck server discovers the agent for a given simulator by:
-
-1. Probing TCP `47370–47402` on `127.0.0.1`.
-2. Calling `Inspector.getInfo` to read the agent's `processIdentifier`.
-3. Running `ps -p <pid> -o command=` and matching the simulator's UDID against the process command line.
-
-This lets multiple inspector-enabled apps run side by side without colliding.
-
-## Talking to the agent directly
-
-The protocol is newline-delimited JSON over TCP — convenient enough for `nc`:
-
-```sh
-printf '{"id":1,"method":"Inspector.getInfo"}\n' | nc 127.0.0.1 47370
-printf '{"id":2,"method":"View.getHierarchy","params":{"maxDepth":4}}\n' | nc 127.0.0.1 47370
-```
-
-For the full envelope shape and method list, see the [Inspector Protocol](/api/inspector-protocol).
-
-## SwiftUI view tree
-
-For SwiftUI apps you control, attach the root publisher to the top of your scene. The agent reflects the current SwiftUI value/body tree and publishes it as the `swiftui` hierarchy source while keeping the raw UIKit host tree available as `uikit`.
+Publish a SwiftUI root when you want the declared SwiftUI tree instead of only the backing UIKit views:
 
 ```swift
 WindowGroup {
@@ -89,95 +62,43 @@ WindowGroup {
 }
 ```
 
-`View.getHierarchy` returns the published SwiftUI tree by default. Pass `"source": "uikit"` to inspect the backing hosting views instead.
-
-This is a debug aid built on Swift reflection. It can show the declared view/body structure, including custom subviews, containers, labels, modifier names, active conditional branches, and `ForEach` rows whose data and content builder are available through SwiftUI's public API. Private/custom containers may still be opaque when they do not expose a child view value or content builder.
-
-## Experimental SwiftUI preview runner
-
-The repo includes a hacky local preview runner that extracts a `#Preview { ... }` block from a Swift file, builds it into a versioned iOS Simulator dylib, and asks a tiny installed host app to `dlopen` it. The host is rebuilt and reinstalled with `--rebuild-host`; cached runs send the new dylib over a localhost TCP reload socket so the simulator does not need a new app install.
-
-```sh
-npm run preview:swiftui -- \
-  --udid <booted-simulator-udid> \
-  --file Sources/MyFeature/MyView.swift \
-  --preview "Default" \
-  --watch
-```
-
-If `--udid` is omitted, the first booted simulator is used. Extra local source files can be passed with repeated `--extra-swift` flags, and raw compiler flags can be passed with repeated `--swiftc-arg` flags.
-
-Useful speed flags:
-
-- `--skip-codesign` skips ad-hoc signing for simulator reload dylibs. This worked in local simulator smoke tests and removed roughly 170-205ms.
-- `--split-compile` caches the preview source without its `#Preview` blocks as a testable Swift module. When only the preview body changes, reloads compile a tiny wrapper and link against the cached object.
-- `--profile` prints reload-stage timings so changes can be compared without Instruments.
-
-For a closer Xcode-compatible path, point the runner at the app workspace/project and scheme:
-
-```sh
-npm run preview:swiftui -- \
-  --workspace MyApp.xcworkspace \
-  --scheme MyApp \
-  --configuration Debug \
-  --udid <booted-simulator-udid> \
-  --file MyApp/Features/Profile/ProfileView.swift \
-  --preview "Default" \
-  --watch
-```
-
-In that mode the runner asks `xcodebuild` for the target build settings, does one warm app build, copies the app bundle's resources/frameworks into the preview host, and links reload dylibs against the target's Xcode-built debug dylib. Reloads then compile the edited preview source plus a tiny wrapper instead of rebuilding and reinstalling the whole app target. For the fastest loop after a warm build, pass `--skip-xcode-build --skip-codesign --split-compile`.
-
-The host listens on local TCP ports `47440-47455`. The preferred protocol streams the dylib bytes directly into the app's Documents directory and waits for a tiny `OK` acknowledgement. If that fails, the runner falls back to copying into the app container and notifying via TCP path reload, then to `simctl openurl`.
-
-When `--skip-xcode-build` is used, the runner also reuses a cached Xcode build context under `--build-root` after the first successful settings lookup. Delete that build root or run without `--skip-xcode-build` after changing schemes, destinations, package resolution, or major build settings.
-
-This is intentionally still not full Xcode Preview compatibility. It is best for simulator-debuggable app targets with Swift modules and a `.debug.dylib` available in DerivedData. Project dependencies and assets are reused from the warm Xcode build, but complex preview setup, generated sources that changed after the warm build, or build systems with unusual output layouts may still need `--extra-swift`, `--swiftc-arg`, or another warm `xcodebuild`.
-
-## SwiftUI tagging
-
-The agent also reports SwiftUI hosting and bridge `UIView`s in the UIKit tree. To make specific SwiftUI elements addressable in the raw UIKit hierarchy, tag them in source:
+Tag important SwiftUI views so they are easy to find:
 
 ```swift
 Text("Continue")
     .simDeckInspectorTag("continue-label", id: "onboarding.continue.label")
 ```
 
-Tagged SwiftUI views appear as lightweight, non-interactive probe `UIView`s in the hierarchy with `swiftUI.isProbe = true`. The browser client surfaces them in the inspector pane.
+Then inspect:
 
-## Publishing a framework hierarchy
-
-Frameworks with their own logical tree can publish that tree into the agent. When a published snapshot exists, `View.getHierarchy` returns it by default; pass `"source": "uikit"` to force the raw UIKit tree.
-
-```swift
-try? SimDeckInspectorAgent.shared.publishHierarchySnapshot(
-    source: "nativescript",
-    snapshotJSON: #"{"source":"nativescript","roots":[]}"#
-)
+```sh
+simdeck describe <udid> --source swiftui --format agent
+simdeck describe <udid> --source uikit --format agent
 ```
 
-This is exactly how the [NativeScript runtime inspector](/inspector/nativescript) exposes its logical tree.
+## Debug Actions
 
-Framework snapshots can attach source locations to individual nodes:
+When the selected view supports it, the browser can:
 
-```json
-{
-  "type": "Label",
-  "title": "Continue",
-  "sourceLocation": {
-    "file": "src/app/home.component.html",
-    "line": 12,
-    "column": 5,
-    "offset": 238
-  }
-}
+- Read runtime properties.
+- Set simple UIKit properties for debugging.
+- Perform actions such as tap, focus, set text, or scroll.
+
+These edits are temporary and meant for debugging, not persistent app state.
+
+## Direct Protocol Check
+
+The Swift agent listens on `127.0.0.1:47370` and tries nearby ports if needed.
+
+```sh
+printf '{"id":1,"method":"Inspector.getInfo"}\n' | nc 127.0.0.1 47370
 ```
 
-The browser client uses these to jump from the hierarchy back to source.
+For protocol details, see [Inspector Protocol](/api/inspector-protocol).
 
-## Auth token
+## Shared Hosts
 
-For shared-network simulator sessions, start the agent with a token and require every request to include a top-level `token`:
+For shared or remote hosts, bind deliberately and set an auth token:
 
 ```swift
 try? SimDeckInspectorAgent.shared.start(
@@ -189,20 +110,18 @@ try? SimDeckInspectorAgent.shared.start(
 )
 ```
 
-When a token is set, requests without a matching `token` field are rejected with `error.code = -32401`.
+Keep the default localhost binding for normal local development.
 
-## Recommended configuration
+## SwiftUI Preview Runner
 
-For most apps the defaults are correct:
+This repo also includes an experimental preview runner for local development:
 
-- Bind to `127.0.0.1` only.
-- Listen on `47370` (with auto-fallback if busy).
-- No auth token.
+```sh
+npm run preview:swiftui -- \
+  --udid <booted-simulator-udid> \
+  --file Sources/MyFeature/MyView.swift \
+  --preview "Default" \
+  --watch
+```
 
-For multi-user development setups (shared simulator hosts on a LAN, CI rigs), set `bindToLocalhostOnly: false` plus an auth token and forward the inspector port through your VPN or SSH tunnel of choice.
-
-## Compatibility with the NativeScript inspector
-
-The Swift agent and the NativeScript runtime inspector implement the same protocol on different transports. Anything that can talk `SDI/0.1` over TCP can also talk it over the SimDeck WebSocket hub, and vice versa.
-
-The SimDeck server prefers connected NativeScript inspectors over Swift TCP agents when both are present for the same process. Direct TCP clients can pick whichever transport they prefer.
+It is intended for simulator-debuggable app targets and may need extra flags for complex projects.


### PR DESCRIPTION
## Summary
- Rewrote the docs around install, quick start, daily usage, troubleshooting, and inspector workflows
- Simplified the homepage and navigation to emphasize core features instead of internals
- Condensed CLI, API, extension, and contributor pages into shorter reference-style docs
- Kept the public routes and command surface aligned with the current implementation

## Testing
- `npm run docs:build` passed
- `npx prettier --check docs` passed