### PR TITLE
fix(webkit): stabilize inspector connections and disconnected states

### DIFF
--- a/client/src/api/types.ts
+++ b/client/src/api/types.ts
@@ -57,6 +57,8 @@ export interface WebKitTarget {
   id: string;
   appId: string;
   appName?: string | null;
+  appActive?: boolean;
+  pageActive?: boolean;
   pageId: number;
   title?: string | null;
   url?: string | null;

--- a/client/src/app/AppShell.tsx
+++ b/client/src/app/AppShell.tsx
@@ -367,6 +367,7 @@ export function AppShell({
     refresh,
     simulators,
   } = useSimulatorList({ remote: remoteStream });
+  const providerDisconnected = isProviderDisconnected(listError);
   const [debugVisible, setDebugVisible] = useState(() =>
     readStoredFlag(DEBUG_VISIBLE_STORAGE_KEY),
   );
@@ -1019,6 +1020,17 @@ export function AppShell({
       return;
     }
 
+    if (providerDisconnected) {
+      setAccessibilityRoots([]);
+      setAccessibilitySelectedId("");
+      setAccessibilityHoveredId(null);
+      setAccessibilityAvailableSources([]);
+      setAccessibilitySource("");
+      setAccessibilityError("Not connected");
+      setAccessibilityLoading(false);
+      return;
+    }
+
     if (!selectedSimulator?.isBooted) {
       setAccessibilityRoots([]);
       setAccessibilitySelectedId("");
@@ -1034,7 +1046,9 @@ export function AppShell({
     accessibilityRequestIdRef.current = requestId;
     accessibilityLoadingRef.current = true;
     setAccessibilityLoading(true);
-    setAccessibilityError("");
+    setAccessibilityError((current) =>
+      current === "Not connected" ? current : "",
+    );
 
     try {
       const snapshot = await fetchAccessibilityTree(
@@ -1098,7 +1112,7 @@ export function AppShell({
         setAccessibilityLoading(false);
       }
     }
-  }, [accessibilityPreferredSource, selectedSimulator]);
+  }, [accessibilityPreferredSource, providerDisconnected, selectedSimulator]);
 
   const changeAccessibilitySource = useCallback(
     (source: AccessibilitySource) => {
@@ -2191,6 +2205,7 @@ export function AppShell({
         accessibilityPanel={
           <AccessibilityInspector
             availableSources={accessibilityAvailableSources}
+            disconnected={providerDisconnected}
             error={accessibilityError}
             isLoading={accessibilityLoading}
             onHover={setAccessibilityHoveredId}
@@ -2291,6 +2306,7 @@ export function AppShell({
         viewMode={viewMode}
         devtoolsPanel={
           <DevToolsPanel
+            disconnected={providerDisconnected}
             onClose={() => setDevToolsVisible(false)}
             overviewRequestKey={devToolsOverviewRequestKey}
             selectedSimulator={selectedSimulator}
@@ -2497,6 +2513,9 @@ function userFacingAccessibilityError(message: string): string {
   }
 
   const lower = normalized.toLowerCase();
+  if (isProviderDisconnected(normalized)) {
+    return "Not connected";
+  }
   if (
     lower.includes("no app inspector found") ||
     lower.includes("no connected websocket inspector found") ||
@@ -2508,6 +2527,20 @@ function userFacingAccessibilityError(message: string): string {
   }
 
   return normalized;
+}
+
+function isProviderDisconnected(message: string): boolean {
+  const lower = message.trim().toLowerCase();
+  if (!lower || lower === AUTH_REQUIRED_MESSAGE.toLowerCase()) {
+    return false;
+  }
+  return (
+    lower.includes("failed to fetch") ||
+    lower.includes("load failed") ||
+    lower.includes("networkerror") ||
+    lower.includes("network error") ||
+    lower.includes("timed out waiting for provider")
+  );
 }
 
 function mergeStreamQualityResponse(

--- a/client/src/app/AppShell.tsx
+++ b/client/src/app/AppShell.tsx
@@ -116,6 +116,7 @@ const DEFAULT_ACCESSIBILITY_MAX_DEPTH = 10;
 const LOGICAL_INSPECTOR_MAX_DEPTH = 80;
 const FLUTTER_INSPECTOR_MAX_DEPTH = 48;
 const AUTH_REQUIRED_MESSAGE = "SimDeck API access token is required.";
+const NOT_CONNECTED_MESSAGE = "Not connected";
 const LOCAL_STREAM_DEFAULTS: StreamConfig = {
   encoder: "auto",
   fps: 60,
@@ -691,6 +692,16 @@ export function AppShell({
     streamConfigApplyKey,
     streamTransport,
   });
+
+  useEffect(() => {
+    if (
+      streamStatus.state !== "error" ||
+      !isStreamProviderDisconnectError(streamStatus.error)
+    ) {
+      return;
+    }
+    void refreshRef.current();
+  }, [streamStatus.error, streamStatus.state]);
 
   const updateStreamEncoder = useCallback((encoder: StreamEncoder) => {
     streamConfigUserTouchedRef.current = true;
@@ -1434,8 +1445,9 @@ export function AppShell({
     pairingEnabled &&
     listError === AUTH_REQUIRED_MESSAGE &&
     !accessTokenFromLocation();
-  const visibleListError =
-    remoteStream && listError === AUTH_REQUIRED_MESSAGE
+  const visibleListError = providerDisconnected
+    ? NOT_CONNECTED_MESSAGE
+    : remoteStream && listError === AUTH_REQUIRED_MESSAGE
       ? ""
       : selectedSimulator
         ? friendlyClientError(listError)
@@ -1471,11 +1483,13 @@ export function AppShell({
     streamStatusState: streamStatus.state,
   });
   const viewportStatusOverlayLabel =
+    (providerDisconnected ? NOT_CONNECTED_MESSAGE : "") ||
     simulatorStatusOverlayLabel ||
     streamStatusMessage ||
     (browserFramePending ? "Stream connected, browser frame pending" : "") ||
     (selectedSimulator ? visibleListError : "");
   const viewportHasStreamError = Boolean(
+    providerDisconnected ||
     streamStatus.state === "error" ||
     visibleStreamError ||
     (selectedSimulator && visibleListError),
@@ -2436,6 +2450,14 @@ function friendlyStreamError(
   return friendlyClientError(normalized);
 }
 
+function isStreamProviderDisconnectError(message: string | undefined): boolean {
+  const lower = message?.trim().toLowerCase() ?? "";
+  return (
+    lower.includes("websocket stream closed") ||
+    lower.includes("websocket stream failed")
+  );
+}
+
 function streamAgentStatusLabel({
   hasFrame,
   simulator,
@@ -2514,7 +2536,7 @@ function userFacingAccessibilityError(message: string): string {
 
   const lower = normalized.toLowerCase();
   if (isProviderDisconnected(normalized)) {
-    return "Not connected";
+    return NOT_CONNECTED_MESSAGE;
   }
   if (
     lower.includes("no app inspector found") ||

--- a/client/src/features/accessibility/AccessibilityInspector.tsx
+++ b/client/src/features/accessibility/AccessibilityInspector.tsx
@@ -26,6 +26,7 @@ import { usePanelPresence } from "../../shared/hooks/usePanelPresence";
 
 interface AccessibilityInspectorProps {
   availableSources: AccessibilitySource[];
+  disconnected: boolean;
   error: string;
   isLoading: boolean;
   onHover: (id: string | null) => void;
@@ -44,6 +45,7 @@ type InspectorTab = "console" | "inspector" | "performance";
 
 export function AccessibilityInspector({
   availableSources,
+  disconnected,
   error,
   isLoading,
   onHover,
@@ -210,6 +212,7 @@ export function AccessibilityInspector({
     ? findAccessibilityItem(tree, selectedId)
     : null;
   const sourceOptions = hierarchySourceOptions(availableSources, source);
+  const effectivelyDisconnected = disconnected || error === "Not connected";
 
   return (
     <aside
@@ -256,7 +259,11 @@ export function AccessibilityInspector({
           <PerformanceIcon />
         </button>
       </div>
-      {activeTab === "console" ? (
+      {effectivelyDisconnected ? (
+        <div className="hierarchy-tree">
+          <div className="hierarchy-empty">Not connected</div>
+        </div>
+      ) : activeTab === "console" ? (
         <ConsolePanel
           accessibilityRoots={roots}
           selectedSimulator={selectedSimulator}

--- a/client/src/features/accessibility/AccessibilityInspector.tsx
+++ b/client/src/features/accessibility/AccessibilityInspector.tsx
@@ -306,11 +306,11 @@ export function AccessibilityInspector({
             </div>
           ) : error ? (
             <div className="hierarchy-empty error">{error}</div>
-          ) : visibleItems.length === 0 && isLoading ? (
+          ) : visibleItems.length === 0 && isLoading && !source ? (
             <div className="hierarchy-empty">Reading accessibility tree...</div>
           ) : visibleItems.length === 0 ? (
             <div className="hierarchy-empty">
-              No accessibility snapshot yet.
+              {emptyAccessibilityMessage(source)}
             </div>
           ) : (
             visibleItems.map((item) => {
@@ -838,6 +838,15 @@ function sourceLabel(source: AccessibilitySource): string {
     return "Android";
   }
   return source === "in-app-inspector" ? "UIKit" : "Native AX";
+}
+
+function emptyAccessibilityMessage(
+  source: AccessibilityTreeResponse["source"] | "",
+): string {
+  if (source === "native-ax") {
+    return "No native accessibility elements available.";
+  }
+  return "No accessibility snapshot available.";
 }
 
 function objectClassName(value: Record<string, unknown> | null | undefined) {

--- a/client/src/features/accessibility/PerformancePanel.tsx
+++ b/client/src/features/accessibility/PerformancePanel.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from "react";
-import type { CSSProperties, PointerEvent } from "react";
+import { useEffect, useId, useMemo, useState } from "react";
+import type { CSSProperties, ChangeEvent, PointerEvent } from "react";
 
 import {
   fetchSimulatorPerformance,
@@ -97,14 +97,36 @@ export function PerformancePanel({
     visible,
   ]);
 
+  const processes = performance?.processes ?? [];
+  const selectedPidValue = selectedPid ?? performance?.selectedPid ?? null;
+  const selectedPidInList =
+    selectedPidValue == null ||
+    processes.some((process) => process.pid === selectedPidValue);
   const current = performance?.current ?? null;
   const selectedProcess = useMemo(
-    () =>
-      performance?.processes.find(
-        (process) => process.pid === (selectedPid ?? performance.selectedPid),
-      ) ?? null,
-    [performance, selectedPid],
+    () => processes.find((process) => process.pid === selectedPidValue) ?? null,
+    [processes, selectedPidValue],
   );
+
+  function selectProcess(event: ChangeEvent<HTMLSelectElement>) {
+    const nextPid = Number(event.currentTarget.value);
+    if (!Number.isInteger(nextPid)) {
+      return;
+    }
+    setFollowForeground(false);
+    setSelectedPid(nextPid);
+    setSample(null);
+  }
+
+  function followFrontmostProcess() {
+    setFollowForeground(true);
+    setSelectedPid(
+      performance?.foregroundProcess?.processIdentifier ??
+        performance?.selectedPid ??
+        null,
+    );
+    setSample(null);
+  }
 
   async function runSample() {
     const pid = selectedPid ?? performance?.selectedPid ?? null;
@@ -133,27 +155,36 @@ export function PerformancePanel({
 
   return (
     <div className="performance-panel">
-      <div className="performance-process-list">
-        {performance?.processes.length ? (
-          performance.processes.map((process) => (
-            <ProcessButton
-              key={process.pid}
-              onSelect={() => {
-                setSelectedPid(process.pid);
-                setFollowForeground(process.isForeground);
-                setSample(null);
-              }}
-              process={process}
-              selected={
-                process.pid === (selectedPid ?? performance.selectedPid)
-              }
-            />
-          ))
-        ) : (
-          <div className="performance-empty compact">
-            {error || "Waiting for an app process."}
-          </div>
-        )}
+      <div className="performance-target-bar">
+        <div className="performance-process-select-wrap">
+          <select
+            aria-label="Performance process"
+            className="performance-process-select"
+            disabled={!processes.length}
+            onChange={selectProcess}
+            value={selectedPidValue == null ? "" : String(selectedPidValue)}
+          >
+            {processes.length ? null : (
+              <option value="">Waiting for an app process</option>
+            )}
+            {selectedPidValue != null && !selectedPidInList ? (
+              <option value={selectedPidValue}>PID {selectedPidValue}</option>
+            ) : null}
+            {processes.map((process) => (
+              <option key={process.pid} value={process.pid}>
+                {processOptionLabel(process)}
+              </option>
+            ))}
+          </select>
+        </div>
+        <button
+          className={`performance-follow-button ${followForeground ? "active" : ""}`}
+          disabled={!performance?.foregroundProcess}
+          onClick={followFrontmostProcess}
+          type="button"
+        >
+          Follow Frontmost
+        </button>
       </div>
 
       {error && performance?.processes.length ? (
@@ -295,34 +326,22 @@ export function PerformancePanel({
             )}
           </section>
         </>
-      ) : null}
+      ) : (
+        <div className="performance-empty compact">
+          {error || "Collecting performance metrics."}
+        </div>
+      )}
     </div>
   );
 }
 
-function ProcessButton({
-  onSelect,
-  process,
-  selected,
-}: {
-  onSelect: () => void;
-  process: PerformanceProcess;
-  selected: boolean;
-}) {
-  return (
-    <button
-      className={`performance-process ${selected ? "selected" : ""}`}
-      onClick={onSelect}
-      title={process.command}
-      type="button"
-    >
-      <span className="performance-process-name">{process.process}</span>
-      <span className="performance-process-meta">
-        {process.pid} / {process.role}
-        {process.isForeground ? " / frontmost" : ""}
-      </span>
-    </button>
-  );
+function processOptionLabel(process: PerformanceProcess): string {
+  const name = process.appName || process.process;
+  const parts = [`${name} (${process.pid})`, process.role];
+  if (process.isForeground) {
+    parts.push("frontmost");
+  }
+  return parts.join(" / ");
 }
 
 function Metric({ label, value }: { label: string; value: string }) {
@@ -345,6 +364,7 @@ function Timeline({
   value: (sample: PerformanceSample) => number;
   valueLabel: (value: number | null | undefined) => string;
 }) {
+  const gradientId = useId().replace(/:/g, "");
   const [hoverIndex, setHoverIndex] = useState<number | null>(null);
   const values = samples.map(value);
   const latest = values.at(-1) ?? 0;
@@ -353,9 +373,13 @@ function Timeline({
     x: values.length <= 1 ? 0 : (index / (values.length - 1)) * 100,
     y: 42 - (Math.max(0, item) / max) * 36,
   }));
-  const points = coordinates
-    .map((point) => `${round(point.x)},${round(point.y)}`)
+  const linePath = coordinates
+    .map(
+      (point, index) =>
+        `${index === 0 ? "M" : "L"} ${round(point.x)} ${round(point.y)}`,
+    )
     .join(" ");
+  const areaPath = linePath ? `${linePath} L 100 42 L 0 42 Z` : "";
   const activeIndex =
     hoverIndex == null || hoverIndex >= samples.length ? null : hoverIndex;
   const activePoint = activeIndex == null ? null : coordinates[activeIndex];
@@ -385,8 +409,32 @@ function Timeline({
         preserveAspectRatio="none"
         viewBox="0 0 100 44"
       >
-        <line x1="0" x2="100" y1="42" y2="42" />
-        {points ? <polyline points={points} /> : null}
+        <defs>
+          <linearGradient id={gradientId} x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stopColor="var(--accent)" stopOpacity="0.26" />
+            <stop offset="100%" stopColor="var(--accent)" stopOpacity="0.02" />
+          </linearGradient>
+        </defs>
+        {[6, 18, 30, 42].map((y) => (
+          <line
+            className="performance-chart-grid"
+            key={y}
+            x1="0"
+            x2="100"
+            y1={y}
+            y2={y}
+          />
+        ))}
+        {areaPath ? (
+          <path
+            className="performance-chart-area"
+            d={areaPath}
+            fill={`url(#${gradientId})`}
+          />
+        ) : null}
+        {linePath ? (
+          <path className="performance-chart-line" d={linePath} />
+        ) : null}
         {activePoint ? (
           <>
             <line
@@ -456,13 +504,13 @@ function formatRate(value: number | null | undefined): string {
 
 function hangLabel(state: string): string {
   if (state === "busy") {
-    return "Busy";
+    return "Potential hang";
   }
   if (state === "quiet") {
-    return "Quiet";
+    return "No frame updates";
   }
   if (state === "responsive") {
-    return "Responsive";
+    return "Rendering OK";
   }
   return "Unknown";
 }

--- a/client/src/features/devtools/DevToolsPanel.tsx
+++ b/client/src/features/devtools/DevToolsPanel.tsx
@@ -38,8 +38,10 @@ const DEVTOOLS_PANEL_DEFAULT_WIDTH = 720;
 const DEVTOOLS_PANEL_MIN_WIDTH = 420;
 const DEVTOOLS_PANEL_MIN_VIEWPORT_WIDTH = 340;
 const DEVTOOLS_PANEL_WIDTH_STEP = 40;
+const NOT_CONNECTED_MESSAGE = "Not connected";
 
 interface DevToolsPanelProps {
+  disconnected: boolean;
   onClose: () => void;
   overviewRequestKey: number;
   selectedSimulator: SimulatorMetadata | null;
@@ -73,8 +75,16 @@ interface DevToolsDiscovery {
 type ChromeDiscoveryResult =
   PromiseSettledResult<ChromeDevToolsTargetDiscovery>;
 type WebKitDiscoveryResult = PromiseSettledResult<WebKitTargetDiscovery>;
+type WebKitSocketState =
+  | ""
+  | "connecting"
+  | "connected"
+  | "reconnecting"
+  | "disconnected"
+  | "failed";
 
 export function DevToolsPanel({
+  disconnected,
   onClose,
   overviewRequestKey,
   selectedSimulator,
@@ -89,6 +99,8 @@ export function DevToolsPanel({
   const [error, setError] = useState("");
   const [frameLoaded, setFrameLoaded] = useState(false);
   const [overviewVisible, setOverviewVisible] = useState(false);
+  const [webKitSocketState, setWebKitSocketState] =
+    useState<WebKitSocketState>("");
   const discoveryRef = useRef<DevToolsDiscovery | null>(null);
   const frameRef = useRef<HTMLIFrameElement | null>(null);
   const loadingTargetsRef = useRef(false);
@@ -142,6 +154,15 @@ export function DevToolsPanel({
       return;
     }
 
+    if (disconnected) {
+      applyDiscovery(null);
+      applySelectedTargetId("");
+      setError("");
+      setIsLoading(false);
+      setIsWebKitLoading(false);
+      return;
+    }
+
     if (!selectedSimulator) {
       applyDiscovery(null);
       applySelectedTargetId("");
@@ -160,7 +181,7 @@ export function DevToolsPanel({
     }
     const requestId = ++requestIdRef.current;
     setIsLoading(true);
-    setError("");
+    setError((current) => (current === NOT_CONNECTED_MESSAGE ? current : ""));
     try {
       const chromeTargets = requestWithTimeout(
         (signal) =>
@@ -350,6 +371,7 @@ export function DevToolsPanel({
   }, [
     applyDiscovery,
     applySelectedTargetId,
+    disconnected,
     selectedSimulator?.isBooted,
     selectedSimulator?.udid,
   ]);
@@ -369,7 +391,23 @@ export function DevToolsPanel({
     setIsLoading(false);
     setIsWebKitLoading(false);
     setOverviewVisible(false);
+    setWebKitSocketState("");
   }, [applyDiscovery, applySelectedTargetId, selectedSimulator?.udid]);
+
+  useEffect(() => {
+    if (!disconnected) {
+      return;
+    }
+    requestIdRef.current += 1;
+    applyDiscovery(null);
+    applySelectedTargetId("");
+    setError("");
+    setFrameLoaded(false);
+    setIsLoading(false);
+    setIsWebKitLoading(false);
+    setOverviewVisible(false);
+    setWebKitSocketState("");
+  }, [applyDiscovery, applySelectedTargetId, disconnected]);
 
   useEffect(() => {
     if (!visible) {
@@ -384,7 +422,37 @@ export function DevToolsPanel({
 
   useEffect(() => {
     setFrameLoaded(false);
+    setWebKitSocketState("");
   }, [frameUrl]);
+
+  useEffect(() => {
+    function handleWebKitSocketState(event: MessageEvent) {
+      if (frameRef.current?.contentWindow !== event.source) {
+        return;
+      }
+      const data = event.data;
+      if (
+        !data ||
+        typeof data !== "object" ||
+        data.type !== "simdeck:webkit-inspector:socket"
+      ) {
+        return;
+      }
+      const state = data.state;
+      if (
+        state === "connecting" ||
+        state === "connected" ||
+        state === "reconnecting" ||
+        state === "disconnected" ||
+        state === "failed"
+      ) {
+        setWebKitSocketState(state);
+      }
+    }
+
+    window.addEventListener("message", handleWebKitSocketState);
+    return () => window.removeEventListener("message", handleWebKitSocketState);
+  }, []);
 
   useEffect(() => {
     if (overviewRequestKey <= 0) {
@@ -518,20 +586,34 @@ export function DevToolsPanel({
   }
 
   const isDiscoveringTargets = isLoading || isWebKitLoading;
-  const statusMessage =
-    error ||
-    (!selectedSimulator
-      ? "No simulator selected."
-      : isDiscoveringTargets && targets.length === 0
-        ? "Loading..."
-        : targets.length === 0
-          ? selectedSimulator.isBooted
-            ? "No DevTools targets. Open Safari, enable inspectable WKWebViews, start Metro, or launch a Chrome remote debugging target."
-            : "No DevTools targets. Boot the simulator for Safari/WebKit, or start Metro or Chrome remote debugging."
-          : "");
-  const emptyOverviewMessage = isDiscoveringTargets
-    ? "Loading..."
-    : "No targets";
+  const effectivelyDisconnected =
+    disconnected || error === NOT_CONNECTED_MESSAGE;
+  const chromeDevToolsBlocked = Boolean(
+    selectedTarget && isChromeTarget(selectedTarget) && isSafariBrowser(),
+  );
+  const webKitConnectionMessage =
+    selectedTarget && isWebKitTarget(selectedTarget)
+      ? webKitSocketStatusMessage(webKitSocketState)
+      : "";
+  const statusMessage = effectivelyDisconnected
+    ? NOT_CONNECTED_MESSAGE
+    : chromeDevToolsBlocked
+      ? "Chrome DevTools don't work in Safari"
+      : error ||
+        (!selectedSimulator
+          ? "No simulator selected."
+          : isDiscoveringTargets && targets.length === 0
+            ? "Loading..."
+            : targets.length === 0
+              ? selectedSimulator.isBooted
+                ? "No DevTools targets. Open Safari, enable inspectable WKWebViews, start Metro, or launch a Chrome remote debugging target."
+                : "No DevTools targets. Boot the simulator for Safari/WebKit, or start Metro or Chrome remote debugging."
+              : "");
+  const emptyOverviewMessage = effectivelyDisconnected
+    ? NOT_CONNECTED_MESSAGE
+    : isDiscoveringTargets
+      ? "Loading..."
+      : "No targets";
   const panelStyle = {
     "--webkit-panel-width": `${panelWidth}px`,
   } as CSSProperties;
@@ -618,7 +700,11 @@ export function DevToolsPanel({
       ) : null}
 
       <div className="webkit-frame-wrap">
-        {overviewVisible ? (
+        {effectivelyDisconnected || chromeDevToolsBlocked ? (
+          <div className={`webkit-status ${error ? "error" : ""}`}>
+            {statusMessage}
+          </div>
+        ) : overviewVisible ? (
           <DevToolsOverview
             emptyMessage={emptyOverviewMessage}
             targets={targets}
@@ -637,6 +723,10 @@ export function DevToolsPanel({
             {!frameLoaded ? (
               <div className="webkit-status" role="status">
                 Loading...
+              </div>
+            ) : webKitConnectionMessage ? (
+              <div className="webkit-status" role="status">
+                {webKitConnectionMessage}
               </div>
             ) : null}
           </>
@@ -828,6 +918,31 @@ function isWebKitTarget(target: DevToolsTarget): boolean {
     target.source === "WebKit" ||
     target.source === "WebKit proxy"
   );
+}
+
+function isSafariBrowser(): boolean {
+  if (typeof navigator === "undefined") {
+    return false;
+  }
+  const userAgent = navigator.userAgent;
+  return (
+    /safari/i.test(userAgent) &&
+    !/chrome|chromium|crios|fxios|edg/i.test(userAgent)
+  );
+}
+
+function webKitSocketStatusMessage(state: WebKitSocketState): string {
+  switch (state) {
+    case "connecting":
+      return "Connecting...";
+    case "reconnecting":
+    case "failed":
+      return "Reconnecting...";
+    case "disconnected":
+      return "Not connected";
+    default:
+      return "";
+  }
 }
 
 function readStoredPanelWidth(): number {
@@ -1037,6 +1152,9 @@ function userFacingDevToolsMessage(message: string): string {
   }
 
   const lower = normalized.toLowerCase();
+  if (isProviderDisconnectedMessage(normalized)) {
+    return NOT_CONNECTED_MESSAGE;
+  }
   if (
     lower.includes("no app inspector found") ||
     lower.includes("no connected websocket inspector found") ||
@@ -1056,6 +1174,18 @@ function userFacingDevToolsMessage(message: string): string {
   }
 
   return normalized;
+}
+
+function isProviderDisconnectedMessage(message: string): boolean {
+  const lower = message.trim().toLowerCase();
+  return (
+    lower.includes("failed to fetch") ||
+    lower.includes("load failed") ||
+    lower.includes("networkerror") ||
+    lower.includes("network error") ||
+    lower.includes("timed out loading chrome devtools targets") ||
+    lower.includes("timed out loading webkit targets")
+  );
 }
 
 function cleanDevToolsMessages(messages: string[]): string[] {

--- a/client/src/features/devtools/DevToolsPanel.tsx
+++ b/client/src/features/devtools/DevToolsPanel.tsx
@@ -27,7 +27,8 @@ import { usePanelPresence } from "../../shared/hooks/usePanelPresence";
 
 const DEVTOOLS_TARGET_REFRESH_MS = 750;
 const CHROME_DEVTOOLS_REQUEST_TIMEOUT_MS = 6000;
-const WEBKIT_DEVTOOLS_REQUEST_TIMEOUT_MS = 7000;
+const WEBKIT_DEVTOOLS_REQUEST_TIMEOUT_MS = 6000;
+const DEVTOOLS_EMPTY_DISCOVERY_GRACE_MS = 8000;
 const FOREGROUND_SELECTION_SETTLE_MS = 1800;
 const DEVTOOLS_PANEL_WIDTH_STORAGE_KEY = "xcw-devtools-panel-width";
 const LEGACY_PANEL_WIDTH_STORAGE_KEYS = [
@@ -57,14 +58,17 @@ interface ResizeState {
 
 interface DevToolsTarget {
   appId?: string | null;
+  appActive?: boolean;
   appName?: string | null;
   bundleIdentifier?: string | null;
   frameUrl: string;
   id: string;
   meta: string;
+  pageActive?: boolean;
   processIdentifier?: number | null;
   source: string;
   title: string;
+  url?: string | null;
 }
 
 interface DevToolsDiscovery {
@@ -97,18 +101,23 @@ export function DevToolsPanel({
   const [isLoading, setIsLoading] = useState(false);
   const [isWebKitLoading, setIsWebKitLoading] = useState(false);
   const [error, setError] = useState("");
+  const [frameInstanceKey, setFrameInstanceKey] = useState(0);
   const [frameLoaded, setFrameLoaded] = useState(false);
   const [overviewVisible, setOverviewVisible] = useState(false);
   const [webKitSocketState, setWebKitSocketState] =
     useState<WebKitSocketState>("");
   const discoveryRef = useRef<DevToolsDiscovery | null>(null);
+  const emptyDiscoveryGraceUntilRef = useRef(0);
   const frameRef = useRef<HTMLIFrameElement | null>(null);
   const loadingTargetsRef = useRef(false);
   const loadingWebKitTargetsRef = useRef(false);
   const panelWidthRef = useRef(panelWidth);
   const requestIdRef = useRef(0);
+  const reconnectFrameTimerRef = useRef<number | null>(null);
   const resizeStateRef = useRef<ResizeState | null>(null);
   const selectedSimulatorUdidRef = useRef<string | null>(null);
+  const stableDiscoveryAtRef = useRef(0);
+  const stableDiscoveryRef = useRef<DevToolsDiscovery | null>(null);
   const overviewPinnedRef = useRef(false);
   const foregroundSelectionPausedUntilRef = useRef(0);
   const foregroundKeyRef = useRef("");
@@ -139,6 +148,14 @@ export function DevToolsPanel({
   const applyDiscovery = useCallback(
     (nextDiscovery: DevToolsDiscovery | null) => {
       discoveryRef.current = nextDiscovery;
+      if (nextDiscovery?.targets.length) {
+        stableDiscoveryRef.current = nextDiscovery;
+        stableDiscoveryAtRef.current = Date.now();
+        emptyDiscoveryGraceUntilRef.current = 0;
+      } else {
+        stableDiscoveryRef.current = null;
+        stableDiscoveryAtRef.current = 0;
+      }
       setDiscovery(nextDiscovery);
     },
     [],
@@ -155,6 +172,7 @@ export function DevToolsPanel({
     }
 
     if (disconnected) {
+      emptyDiscoveryGraceUntilRef.current = 0;
       applyDiscovery(null);
       applySelectedTargetId("");
       setError("");
@@ -164,6 +182,7 @@ export function DevToolsPanel({
     }
 
     if (!selectedSimulator) {
+      emptyDiscoveryGraceUntilRef.current = 0;
       applyDiscovery(null);
       applySelectedTargetId("");
       setError("");
@@ -181,7 +200,7 @@ export function DevToolsPanel({
     }
     const requestId = ++requestIdRef.current;
     setIsLoading(true);
-    setError((current) => (current === NOT_CONNECTED_MESSAGE ? current : ""));
+    setError("");
     try {
       const chromeTargets = requestWithTimeout(
         (signal) =>
@@ -224,6 +243,7 @@ export function DevToolsPanel({
         let currentForegroundKey = foregroundKeyRef.current;
         let warnings: string[] = [];
         let errors: string[] = [];
+        let providerDisconnectedError = false;
 
         if (chromeResult) {
           if (chromeResult.status === "fulfilled") {
@@ -240,11 +260,16 @@ export function DevToolsPanel({
             );
             warnings = warnings.concat(chromeResult.value.warnings);
           } else {
-            const staleChromeTargets = previousTargets.filter(isChromeTarget);
+            const message = errorMessage(chromeResult.reason);
+            providerDisconnectedError ||=
+              isProviderDisconnectedMessage(message);
+            const staleChromeTargets = providerDisconnectedError
+              ? []
+              : previousTargets.filter(isChromeTarget);
             if (staleChromeTargets.length > 0) {
               nextTargets.push(...staleChromeTargets);
             } else {
-              errors = errors.concat(errorMessage(chromeResult.reason));
+              errors = errors.concat(message);
             }
           }
         } else {
@@ -258,41 +283,67 @@ export function DevToolsPanel({
             );
             warnings = warnings.concat(webKitResult.value.warnings);
           } else {
-            const staleWebKitTargets = previousTargets.filter(isWebKitTarget);
-            if (staleWebKitTargets.length > 0) {
-              nextTargets.push(...staleWebKitTargets);
-            } else {
-              errors = errors.concat(errorMessage(webKitResult.reason));
-            }
+            const message = errorMessage(webKitResult.reason);
+            providerDisconnectedError ||=
+              isProviderDisconnectedMessage(message);
+            errors = errors.concat(message);
           }
         } else {
           nextTargets.push(...previousTargets.filter(isWebKitTarget));
         }
 
-        warnings = cleanDevToolsMessages(warnings);
-        errors = cleanDevToolsMessages(errors);
-
-        if (
-          nextTargets.length === 0 &&
-          previousDiscovery &&
-          previousDiscovery.targets.length > 0
-        ) {
-          applyDiscovery({
-            ...previousDiscovery,
-            warnings: mergeWarnings(
-              warnings,
-              cleanDevToolsMessages(previousDiscovery.warnings),
-            ),
-          });
+        if (providerDisconnectedError) {
+          applyDiscovery(null);
+          applySelectedTargetId("");
+          setError(NOT_CONNECTED_MESSAGE);
+          setFrameLoaded(false);
+          setIsLoading(false);
+          setIsWebKitLoading(false);
+          setOverviewVisible(false);
+          setWebKitSocketState("");
           return;
         }
+
+        warnings = cleanDevToolsMessages(warnings);
+        errors = cleanDevToolsMessages(errors);
 
         const nextDiscovery = {
           targets: nextTargets,
           warnings: mergeWarnings(warnings, errors),
         };
+
+        const webKitDiscoveryPending =
+          !webKitResult && shouldLoadWebKit && loadingWebKitTargetsRef.current;
+        const hasEmptyDiscovery =
+          nextTargets.length === 0 && errors.length === 0;
+        if (
+          hasEmptyDiscovery &&
+          selectedSimulator.isBooted &&
+          (webKitDiscoveryPending ||
+            Date.now() < emptyDiscoveryGraceUntilRef.current)
+        ) {
+          setError("");
+          return;
+        }
+
+        if (
+          hasEmptyDiscovery &&
+          selectedSimulator.isBooted &&
+          stableDiscoveryRef.current &&
+          Date.now() - stableDiscoveryAtRef.current <
+            DEVTOOLS_EMPTY_DISCOVERY_GRACE_MS
+        ) {
+          setError("");
+          discoveryRef.current = stableDiscoveryRef.current;
+          setDiscovery(stableDiscoveryRef.current);
+          return;
+        }
+
         applyDiscovery(nextDiscovery);
         const current = selectedTargetIdRef.current;
+        const currentTarget = nextTargets.find(
+          (target) => target.id === current,
+        );
         const pendingForegroundApp = pendingForegroundAppRef.current;
         const pendingForegroundKey = pendingForegroundKeyRef.current;
         const foregroundApp = foregroundAppRef.current;
@@ -306,17 +357,19 @@ export function DevToolsPanel({
             ? highlyCompatibleTargetForForeground(
                 nextTargets,
                 pendingForegroundApp,
+                current,
               )
             : isSafariForegroundApp(foregroundApp)
-              ? highlyCompatibleTargetForForeground(nextTargets, foregroundApp)
+              ? highlyCompatibleTargetForForeground(
+                  nextTargets,
+                  foregroundApp,
+                  current,
+                )
               : null;
         if (compatibleTarget) {
           pendingForegroundKeyRef.current = "";
           pendingForegroundAppRef.current = null;
         }
-        const currentTarget = nextTargets.find(
-          (target) => target.id === current,
-        );
         const nextTargetId =
           compatibleTarget?.id || currentTarget?.id || nextTargets[0]?.id || "";
         if (compatibleTarget && !overviewPinnedRef.current) {
@@ -328,22 +381,35 @@ export function DevToolsPanel({
         }
       };
 
-      const chromeResult = await chromeResultPromise;
-      applyTargetResults({ chromeResult });
-      if (requestId === requestIdRef.current && !webKitResultPromise) {
-        setIsLoading(false);
-      }
-      loadingTargetsRef.current = false;
-
+      const pendingResults: Promise<void>[] = [
+        chromeResultPromise.then((chromeResult) => {
+          applyTargetResults({ chromeResult });
+        }),
+      ];
       if (webKitResultPromise) {
-        const webKitResult = await webKitResultPromise;
-        applyTargetResults({ webKitResult });
+        pendingResults.push(
+          webKitResultPromise.then((webKitResult) => {
+            applyTargetResults({ webKitResult });
+          }),
+        );
       }
+      await Promise.all(pendingResults);
     } catch (targetError) {
       if (requestId !== requestIdRef.current) {
         return;
       }
       const message = errorMessage(targetError);
+      if (isProviderDisconnectedMessage(message)) {
+        applyDiscovery(null);
+        applySelectedTargetId("");
+        setError(NOT_CONNECTED_MESSAGE);
+        setFrameLoaded(false);
+        setIsLoading(false);
+        setIsWebKitLoading(false);
+        setOverviewVisible(false);
+        setWebKitSocketState("");
+        return;
+      }
       const previousDiscovery = discoveryRef.current;
       if (previousDiscovery && previousDiscovery.targets.length > 0) {
         applyDiscovery({
@@ -379,6 +445,8 @@ export function DevToolsPanel({
   useEffect(() => {
     selectedSimulatorUdidRef.current = selectedSimulator?.udid ?? null;
     requestIdRef.current += 1;
+    emptyDiscoveryGraceUntilRef.current =
+      Date.now() + DEVTOOLS_EMPTY_DISCOVERY_GRACE_MS;
     applyDiscovery(null);
     applySelectedTargetId("");
     overviewPinnedRef.current = false;
@@ -396,9 +464,12 @@ export function DevToolsPanel({
 
   useEffect(() => {
     if (!disconnected) {
+      emptyDiscoveryGraceUntilRef.current =
+        Date.now() + DEVTOOLS_EMPTY_DISCOVERY_GRACE_MS;
       return;
     }
     requestIdRef.current += 1;
+    emptyDiscoveryGraceUntilRef.current = 0;
     applyDiscovery(null);
     applySelectedTargetId("");
     setError("");
@@ -423,6 +494,10 @@ export function DevToolsPanel({
   useEffect(() => {
     setFrameLoaded(false);
     setWebKitSocketState("");
+    if (reconnectFrameTimerRef.current != null) {
+      window.clearTimeout(reconnectFrameTimerRef.current);
+      reconnectFrameTimerRef.current = null;
+    }
   }, [frameUrl]);
 
   useEffect(() => {
@@ -453,6 +528,50 @@ export function DevToolsPanel({
     window.addEventListener("message", handleWebKitSocketState);
     return () => window.removeEventListener("message", handleWebKitSocketState);
   }, []);
+
+  useEffect(() => {
+    return () => {
+      if (reconnectFrameTimerRef.current != null) {
+        window.clearTimeout(reconnectFrameTimerRef.current);
+        reconnectFrameTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (
+      !visible ||
+      overviewVisible ||
+      !selectedTarget ||
+      !isWebKitTarget(selectedTarget)
+    ) {
+      return;
+    }
+    if (
+      webKitSocketState === "reconnecting" ||
+      webKitSocketState === "disconnected" ||
+      webKitSocketState === "failed"
+    ) {
+      void loadTargets();
+      if (reconnectFrameTimerRef.current == null) {
+        reconnectFrameTimerRef.current = window.setTimeout(() => {
+          reconnectFrameTimerRef.current = null;
+          if (selectedTargetIdRef.current !== selectedTarget.id) {
+            return;
+          }
+          setFrameLoaded(false);
+          setWebKitSocketState("");
+          setFrameInstanceKey((current) => current + 1);
+        }, 1500);
+      }
+    }
+  }, [
+    loadTargets,
+    overviewVisible,
+    selectedTarget,
+    visible,
+    webKitSocketState,
+  ]);
 
   useEffect(() => {
     if (overviewRequestKey <= 0) {
@@ -577,6 +696,7 @@ export function DevToolsPanel({
     pendingForegroundKeyRef.current = "";
     pendingForegroundAppRef.current = null;
     applySelectedTargetId(targetId);
+    setFrameInstanceKey((current) => current + 1);
     setOverviewVisible(false);
   }
 
@@ -585,7 +705,13 @@ export function DevToolsPanel({
     setOverviewVisible(true);
   }
 
-  const isDiscoveringTargets = isLoading || isWebKitLoading;
+  const isHoldingEmptyDiscovery =
+    discovery === null &&
+    Boolean(selectedSimulator?.isBooted) &&
+    Date.now() < emptyDiscoveryGraceUntilRef.current;
+  const isDiscoveringTargets =
+    discovery === null &&
+    (isLoading || isWebKitLoading || isHoldingEmptyDiscovery);
   const effectivelyDisconnected =
     disconnected || error === NOT_CONNECTED_MESSAGE;
   const chromeDevToolsBlocked = Boolean(
@@ -603,7 +729,7 @@ export function DevToolsPanel({
         (!selectedSimulator
           ? "No simulator selected."
           : isDiscoveringTargets && targets.length === 0
-            ? "Loading..."
+            ? "Connecting..."
             : targets.length === 0
               ? selectedSimulator.isBooted
                 ? "No DevTools targets. Open Safari, enable inspectable WKWebViews, start Metro, or launch a Chrome remote debugging target."
@@ -612,8 +738,11 @@ export function DevToolsPanel({
   const emptyOverviewMessage = effectivelyDisconnected
     ? NOT_CONNECTED_MESSAGE
     : isDiscoveringTargets
-      ? "Loading..."
+      ? "Connecting..."
       : "No targets";
+  const displayWarnings = (discovery?.warnings ?? []).filter(
+    shouldDisplayDevToolsWarning,
+  );
   const panelStyle = {
     "--webkit-panel-width": `${panelWidth}px`,
   } as CSSProperties;
@@ -663,7 +792,9 @@ export function DevToolsPanel({
           value={selectedTarget?.id ?? ""}
         >
           {targets.length === 0 ? (
-            <option value="">No targets</option>
+            <option value="">
+              {isDiscoveringTargets ? "Connecting..." : "No targets"}
+            </option>
           ) : (
             targets.map((target) => (
               <option key={target.id} value={target.id}>
@@ -675,7 +806,14 @@ export function DevToolsPanel({
         <button
           aria-label="Refresh DevTools Targets"
           className="tbtn icon-btn"
-          onClick={() => void loadTargets()}
+          onClick={() => {
+            emptyDiscoveryGraceUntilRef.current =
+              Date.now() + DEVTOOLS_EMPTY_DISCOVERY_GRACE_MS;
+            setFrameLoaded(false);
+            setWebKitSocketState("");
+            setFrameInstanceKey((current) => current + 1);
+            void loadTargets();
+          }}
           title="Refresh DevTools Targets"
           type="button"
         >
@@ -715,6 +853,7 @@ export function DevToolsPanel({
             <iframe
               allow="clipboard-read; clipboard-write"
               className="webkit-frame"
+              key={`${frameUrl}:${frameInstanceKey}`}
               onLoad={() => setFrameLoaded(true)}
               ref={frameRef}
               src={frameUrl}
@@ -722,7 +861,7 @@ export function DevToolsPanel({
             />
             {!frameLoaded ? (
               <div className="webkit-status" role="status">
-                Loading...
+                Connecting...
               </div>
             ) : webKitConnectionMessage ? (
               <div className="webkit-status" role="status">
@@ -737,9 +876,9 @@ export function DevToolsPanel({
         )}
       </div>
 
-      {discovery?.warnings.length ? (
+      {displayWarnings.length ? (
         <div className="webkit-warnings">
-          {discovery.warnings.map((warning) => (
+          {displayWarnings.map((warning) => (
             <div key={warning}>{warning}</div>
           ))}
         </div>
@@ -808,32 +947,45 @@ function mapChromeTarget(target: ChromeDevToolsTarget): DevToolsTarget {
 function mapWebKitTarget(target: WebKitTarget): DevToolsTarget {
   return {
     appId: target.appId,
+    appActive: target.appActive ?? false,
     appName: target.appName ?? null,
     frameUrl: buildWebKitInspectorFrameUrl(target),
     id: `webkit:${target.id}`,
     meta: target.url ?? "",
+    pageActive: target.pageActive ?? false,
     processIdentifier: webKitTargetProcessIdentifier(target),
     source: webKitTargetKindLabel(target),
     title: webKitTargetLabel(target),
+    url: target.url ?? null,
   };
 }
 
 function highlyCompatibleTargetForForeground(
   targets: DevToolsTarget[],
   foregroundApp: ChromeDevToolsTargetDiscovery["foregroundApp"],
+  currentTargetId = "",
 ): DevToolsTarget | null {
   if (!foregroundApp) {
     return null;
   }
-  return (
-    targets
-      .map((target) => ({
-        score: foregroundCompatibilityScore(target, foregroundApp),
-        target,
-      }))
-      .filter(({ score }) => score >= 85)
-      .sort((left, right) => right.score - left.score)[0]?.target ?? null
+  const scoredTargets = targets
+    .map((target) => ({
+      score: foregroundCompatibilityScore(target, foregroundApp),
+      target,
+    }))
+    .filter(({ score }) => score >= 85)
+    .sort((left, right) => right.score - left.score);
+  const currentTarget = scoredTargets.find(
+    ({ target }) => target.id === currentTargetId,
   );
+  const bestTarget = scoredTargets[0] ?? null;
+  if (!bestTarget) {
+    return null;
+  }
+  if (currentTarget && currentTarget.score >= bestTarget.score) {
+    return currentTarget.target;
+  }
+  return bestTarget.target;
 }
 
 function foregroundCompatibilityScore(
@@ -857,11 +1009,26 @@ function foregroundCompatibilityScore(
     score = Math.max(score, target.source === "React Native Metro" ? 98 : 90);
   }
 
+  if (isWebKitTarget(target) && target.appActive) {
+    score = Math.max(score, 93);
+  }
+
+  if (isWebKitTarget(target) && target.pageActive) {
+    score = Math.max(score, 112);
+  }
+
   if (
     isSafariForeground(foregroundApp) &&
-    (target.source === "Safari" || isWebKitTarget(target))
+    (target.source === "Safari" || (isWebKitTarget(target) && target.appActive))
   ) {
-    score = Math.max(score, target.source === "Safari" ? 96 : 88);
+    score = Math.max(
+      score,
+      target.source === "Safari" && target.pageActive
+        ? 120
+        : target.source === "Safari" && target.appActive
+          ? 97
+          : 90,
+    );
   }
 
   if (
@@ -937,9 +1104,8 @@ function webKitSocketStatusMessage(state: WebKitSocketState): string {
       return "Connecting...";
     case "reconnecting":
     case "failed":
-      return "Reconnecting...";
     case "disconnected":
-      return "Not connected";
+      return "Connecting...";
     default:
       return "";
   }
@@ -1182,9 +1348,24 @@ function isProviderDisconnectedMessage(message: string): boolean {
     lower.includes("failed to fetch") ||
     lower.includes("load failed") ||
     lower.includes("networkerror") ||
-    lower.includes("network error") ||
+    lower.includes("network error")
+  );
+}
+
+function shouldDisplayDevToolsWarning(message: string): boolean {
+  const normalized = message.trim();
+  if (!normalized || normalized === NOT_CONNECTED_MESSAGE) {
+    return false;
+  }
+
+  const lower = normalized.toLowerCase();
+  return !(
     lower.includes("timed out loading chrome devtools targets") ||
-    lower.includes("timed out loading webkit targets")
+    lower.includes("timed out loading webkit targets") ||
+    lower.includes("unable to read webkit packet header") ||
+    lower.includes("unable to write webkit packet") ||
+    lower.includes("retried webkit target discovery") ||
+    lower.includes("webinspectord was settling")
   );
 }
 

--- a/client/src/styles/components.css
+++ b/client/src/styles/components.css
@@ -1455,50 +1455,69 @@
   line-height: 1.35;
 }
 
-.performance-process-list {
+.performance-target-bar {
   display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   gap: 6px;
+  min-height: 34px;
   margin-bottom: 8px;
 }
 
-.performance-process {
-  display: grid;
-  gap: 2px;
+.performance-process-select-wrap {
+  min-width: 0;
+}
+
+.performance-process-select {
   width: 100%;
-  padding: 8px 9px;
+  height: 34px;
+  min-width: 0;
+  padding: 0 30px 0 10px;
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: var(--surface);
   color: var(--text);
   font: inherit;
-  text-align: left;
+  font-size: 12px;
+  outline: none;
 }
 
-.performance-process:hover {
-  background: var(--surface-hover);
+.performance-process-select:disabled {
+  color: var(--text-muted);
 }
 
-.performance-process.selected {
-  border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
-  background: color-mix(in srgb, var(--accent) 12%, var(--surface));
+.performance-process-select:focus {
+  border-color: color-mix(in srgb, var(--accent) 65%, var(--border));
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 16%, transparent);
 }
 
-.performance-process-name,
-.performance-process-meta {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.performance-follow-button {
+  height: 34px;
+  padding: 0 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 11px;
+  font-weight: 700;
   white-space: nowrap;
 }
 
-.performance-process-name {
-  font-size: 12px;
-  font-weight: 700;
+.performance-follow-button:hover:not(:disabled) {
+  background: var(--surface-hover);
+  color: var(--text);
 }
 
-.performance-process-meta {
+.performance-follow-button.active {
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+  background: color-mix(in srgb, var(--accent) 12%, var(--surface));
+  color: var(--text);
+}
+
+.performance-follow-button:disabled {
   color: var(--text-muted);
-  font-size: 10px;
+  cursor: default;
+  opacity: 0.7;
 }
 
 .performance-summary {
@@ -1558,6 +1577,10 @@
   color: var(--error);
 }
 
+.performance-hang.state-quiet span:first-child {
+  color: color-mix(in srgb, var(--error) 64%, var(--success));
+}
+
 .performance-hang.state-responsive span:first-child {
   color: var(--success);
 }
@@ -1602,12 +1625,17 @@
   touch-action: none;
 }
 
-.performance-chart-svg line {
+.performance-chart-grid {
   stroke: var(--border-subtle);
   stroke-width: 1;
+  vector-effect: non-scaling-stroke;
 }
 
-.performance-chart-svg polyline {
+.performance-chart-area {
+  pointer-events: none;
+}
+
+.performance-chart-line {
   fill: none;
   stroke: var(--accent);
   stroke-linecap: round;

--- a/server/src/api/routes.rs
+++ b/server/src/api/routes.rs
@@ -929,7 +929,6 @@ async fn chrome_devtools_targets(
 ) -> Result<Json<devtools::ChromeDevToolsTargetDiscovery>, AppError> {
     let origin = request_origin(&headers);
     let mut warnings = Vec::new();
-    let mut inspector_warnings = Vec::new();
     let foreground_app = foreground_app_metadata(&state, &udid).await.ok().flatten();
     let simulator = match list_simulators_cached(state.clone(), false).await {
         Ok(simulators) => simulators
@@ -942,32 +941,6 @@ async fn chrome_devtools_targets(
             None
         }
     };
-    let mut sessions = match inspector_sessions_for_udid(&state, &udid).await {
-        Ok(sessions) => sessions,
-        Err(error) => {
-            inspector_warnings.push(error);
-            Vec::new()
-        }
-    };
-    if sessions.is_empty() {
-        match inspector_session_for_state(&state, &udid).await {
-            Ok(session) => sessions.push(session),
-            Err(error) => inspector_warnings.push(error),
-        }
-    }
-    let mut targets: Vec<devtools::ChromeDevToolsTarget> = sessions
-        .iter()
-        .map(|session| {
-            let source = chrome_devtools_source_for_session(session);
-            devtools::build_target(
-                &udid,
-                origin.as_deref(),
-                &session.info,
-                session.process_identifier,
-                source,
-            )
-        })
-        .collect();
     let (mut external_targets, external_warnings) = devtools::discover_external_devtools_targets(
         &udid,
         origin.as_deref(),
@@ -977,10 +950,8 @@ async fn chrome_devtools_targets(
             .map(|simulator| simulator.device_type_name.as_str()),
     )
     .await;
+    let mut targets = Vec::new();
     targets.append(&mut external_targets);
-    if targets.is_empty() {
-        warnings.extend(inspector_warnings);
-    }
     warnings.extend(external_warnings);
     Ok(Json(devtools::ChromeDevToolsTargetDiscovery {
         udid,
@@ -4705,64 +4676,6 @@ fn inspector_session_from_published(inspector: PublishedInspector) -> InspectorS
         info: inspector.info,
         process_identifier: inspector.process_identifier,
     }
-}
-
-async fn inspector_sessions_for_udid(
-    state: &AppState,
-    udid: &str,
-) -> Result<Vec<InspectorSession>, String> {
-    let mut probed_inspectors = Vec::new();
-    let mut candidates = Vec::new();
-    for inspector in state.inspectors.connected().await {
-        if inspector_process_belongs_to_udid(udid, inspector.process_identifier).await? {
-            candidates.push(InspectorSession {
-                transport: InspectorSessionTransport::Connected,
-                available_sources: inspector_available_sources(&inspector.info),
-                info: inspector.info,
-                process_identifier: inspector.process_identifier,
-            });
-            continue;
-        }
-
-        probed_inspectors.push(format!("process {}", inspector.process_identifier));
-    }
-
-    for inspector in state.inspectors.published_inspectors().await {
-        if !inspector_process_belongs_to_udid(udid, inspector.process_identifier).await? {
-            probed_inspectors.push(format!("registry process {}", inspector.process_identifier));
-            continue;
-        }
-        if candidates.iter().any(|session: &InspectorSession| {
-            session.process_identifier == inspector.process_identifier
-        }) {
-            continue;
-        }
-        let session = inspector_session_from_published(inspector);
-        if query_inspector_session(state, &session, "Runtime.ping", Value::Null)
-            .await
-            .is_err()
-        {
-            probed_inspectors.push(format!(
-                "unreachable registry process {}",
-                session.process_identifier
-            ));
-            continue;
-        }
-        candidates.push(session);
-    }
-
-    if candidates.is_empty() {
-        if probed_inspectors.is_empty() {
-            return Err(format!("No app inspector found for simulator {udid}."));
-        }
-        return Err(format!(
-            "No app inspector matched simulator {udid}. Found inspectors for {}.",
-            probed_inspectors.join(", ")
-        ));
-    }
-
-    candidates.sort_by_key(inspector_session_score);
-    Ok(candidates)
 }
 
 async fn inspector_session(

--- a/server/src/api/routes.rs
+++ b/server/src/api/routes.rs
@@ -26,7 +26,7 @@ use axum::response::{IntoResponse, Redirect, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use bytes::{Bytes, BytesMut};
-use futures::{SinkExt, StreamExt};
+use futures::{future::join_all, SinkExt, StreamExt};
 use serde::Deserialize;
 use serde_json::Map;
 use serde_json::{json as json_value, Value};
@@ -54,6 +54,13 @@ const H264_WS_FLAG_CONFIG: u8 = 1 << 1;
 const H264_WS_SEND_TIMEOUT: Duration = Duration::from_secs(2);
 const H264_WS_KEYFRAME_WAIT_TIMEOUT: Duration = Duration::from_secs(3);
 const STREAM_CLIENT_FOREGROUND_TTL: Duration = Duration::from_secs(30);
+const CHROME_DEVTOOLS_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(1);
+const FOREGROUND_APP_CACHE_TTL: Duration = Duration::from_secs(3);
+const FOREGROUND_APP_STALE_TTL: Duration = Duration::from_secs(30);
+const SAFARI_ACTIVE_TAB_HINT_TIMEOUT: Duration = Duration::from_millis(750);
+
+static FOREGROUND_APP_CACHE: OnceLock<StdMutex<HashMap<String, CachedForegroundApp>>> =
+    OnceLock::new();
 
 #[derive(Clone)]
 pub struct AppState {
@@ -66,6 +73,12 @@ pub struct AppState {
     pub stream_clients: StreamClientForegroundRegistry,
     pub simulator_inventory: SimulatorInventoryCache,
     pub android: AndroidBridge,
+}
+
+#[derive(Clone)]
+struct CachedForegroundApp {
+    cached_at: Instant,
+    foreground_app: devtools::ForegroundApp,
 }
 
 #[derive(Clone, Default)]
@@ -892,24 +905,16 @@ async fn webkit_targets(
 ) -> Result<Json<webkit::WebKitTargetDiscovery>, AppError> {
     let origin = request_origin(&headers);
     let mut discovery = webkit::discover_targets(&udid, origin.as_deref()).await?;
-    if discovery.targets.is_empty() {
-        if let Some(foreground_app) = foreground_app_metadata(&state, &udid).await.ok().flatten() {
-            let foreground_name = foreground_app.app_name.as_deref().unwrap_or_default();
-            let foreground_bundle = foreground_app
-                .bundle_identifier
-                .as_deref()
-                .unwrap_or_default();
-            if foreground_name == "MobileSafari"
-                || foreground_name == "Safari"
-                || foreground_bundle == "com.apple.mobilesafari"
-            {
-                discovery.targets.push(webkit::synthetic_safari_target(
-                    &udid,
-                    origin.as_deref().unwrap_or(""),
-                    foreground_app.process_identifier,
-                ));
-                discovery.warnings.clear();
-            }
+    let foreground_app = foreground_app_for_simulator(&state, &udid)
+        .await
+        .ok()
+        .flatten();
+    if foreground_app
+        .as_ref()
+        .is_some_and(is_safari_foreground_app)
+    {
+        if let Some(active_url_hint) = safari_active_url_hint(&state, &udid).await {
+            mark_safari_active_webkit_target(&mut discovery.targets, &active_url_hint);
         }
     }
     Ok(Json(discovery))
@@ -922,6 +927,181 @@ async fn webkit_target_socket(
     ws.on_upgrade(move |socket| webkit::attach_websocket(udid, target_id, socket))
 }
 
+async fn safari_active_url_hint(state: &AppState, udid: &str) -> Option<String> {
+    let probe_points = safari_active_url_probe_points(state.clone(), udid.to_owned()).await;
+    for point in probe_points {
+        let Ok(Ok(snapshot)) = timeout(
+            SAFARI_ACTIVE_TAB_HINT_TIMEOUT,
+            accessibility_snapshot(state.clone(), udid.to_owned(), Some(point), Some(0)),
+        )
+        .await
+        else {
+            continue;
+        };
+        if let Some(hint) = active_url_hint_from_accessibility_snapshot(&snapshot) {
+            return Some(hint);
+        }
+    }
+    None
+}
+
+async fn safari_active_url_probe_points(state: AppState, udid: String) -> Vec<(f64, f64)> {
+    let profile = run_bridge_action(state, move |bridge| bridge.chrome_profile(&udid)).await;
+    let (screen_width, screen_height) = profile
+        .map(|profile| (profile.screen_width, profile.screen_height))
+        .unwrap_or((402.0, 874.0));
+    let center_x = (screen_width * 0.5).max(1.0);
+    let bottom_address_y = (screen_height - 54.0).clamp(1.0, screen_height.max(1.0));
+    let bottom_title_y = (screen_height - 28.0).clamp(1.0, screen_height.max(1.0));
+    let top_address_y = 92.0_f64.min((screen_height * 0.18).max(1.0));
+    vec![
+        (center_x, bottom_address_y),
+        (center_x, bottom_title_y),
+        (center_x, top_address_y),
+    ]
+}
+
+fn active_url_hint_from_accessibility_snapshot(snapshot: &Value) -> Option<String> {
+    let roots = snapshot.get("roots").and_then(Value::as_array)?;
+    roots
+        .iter()
+        .find_map(active_url_hint_from_accessibility_node)
+}
+
+fn active_url_hint_from_accessibility_node(node: &Value) -> Option<String> {
+    for key in [
+        "AXValue", "value", "url", "AXLabel", "label", "title", "name",
+    ] {
+        if let Some(hint) = node
+            .get(key)
+            .and_then(Value::as_str)
+            .and_then(sanitize_active_url_hint)
+        {
+            return Some(hint);
+        }
+    }
+    node.get("children")
+        .and_then(Value::as_array)
+        .and_then(|children| {
+            children
+                .iter()
+                .find_map(active_url_hint_from_accessibility_node)
+        })
+}
+
+fn sanitize_active_url_hint(value: &str) -> Option<String> {
+    let cleaned = value
+        .chars()
+        .filter(|character| {
+            !character.is_control()
+                && !matches!(
+                    *character,
+                    '\u{200e}' | '\u{200f}' | '\u{202a}'..='\u{202e}' | '\u{2066}'..='\u{2069}'
+                )
+        })
+        .collect::<String>()
+        .trim()
+        .to_owned();
+    if cleaned.is_empty() || cleaned.eq_ignore_ascii_case("address") {
+        return None;
+    }
+    let lower = cleaned.to_ascii_lowercase();
+    if lower.starts_with("http://")
+        || lower.starts_with("https://")
+        || lower.starts_with("file://")
+        || cleaned.contains('.')
+    {
+        return Some(cleaned);
+    }
+    None
+}
+
+fn mark_safari_active_webkit_target(targets: &mut [webkit::WebKitTarget], url_hint: &str) {
+    let Some((active_index, _score)) = targets
+        .iter()
+        .enumerate()
+        .filter(|(_, target)| target.kind == "safari-page")
+        .filter_map(|(index, target)| {
+            let score = safari_active_url_match_score(url_hint, target);
+            (score > 0).then_some((index, score))
+        })
+        .max_by_key(|(_, score)| *score)
+    else {
+        return;
+    };
+
+    for (index, target) in targets.iter_mut().enumerate() {
+        target.page_active = index == active_index;
+    }
+    targets.sort_by(|lhs, rhs| {
+        rhs.page_active
+            .cmp(&lhs.page_active)
+            .then(lhs.app_name.cmp(&rhs.app_name))
+            .then(lhs.title.cmp(&rhs.title))
+            .then(lhs.url.cmp(&rhs.url))
+            .then(lhs.page_id.cmp(&rhs.page_id))
+    });
+}
+
+fn safari_active_url_match_score(url_hint: &str, target: &webkit::WebKitTarget) -> u8 {
+    let Some(target_url) = target.url.as_deref() else {
+        return 0;
+    };
+    let hint_key = normalized_url_key(url_hint);
+    let target_key = normalized_url_key(target_url);
+    if hint_key.is_empty() || target_key.is_empty() {
+        return 0;
+    }
+    if hint_key == target_key {
+        return 100;
+    }
+
+    let hint_host = normalized_url_host(&hint_key);
+    let target_host = normalized_url_host(&target_key);
+    if !hint_host.is_empty() && hint_host == target_host {
+        return 90;
+    }
+    if target_key.contains(&hint_key)
+        || (!target_host.is_empty() && hint_key.contains(&target_host))
+    {
+        return 80;
+    }
+    0
+}
+
+fn normalized_url_key(value: &str) -> String {
+    let mut key = value
+        .trim()
+        .trim_matches('"')
+        .trim_end_matches('/')
+        .to_ascii_lowercase();
+    for prefix in ["https://", "http://", "file://"] {
+        if let Some(stripped) = key.strip_prefix(prefix) {
+            key = stripped.to_owned();
+            break;
+        }
+    }
+    if let Some(stripped) = key.strip_prefix("www.") {
+        key = stripped.to_owned();
+    }
+    key.trim_end_matches('/').to_owned()
+}
+
+fn normalized_url_host(value: &str) -> String {
+    normalized_url_key(value)
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or("")
+        .trim_start_matches("www.")
+        .to_owned()
+}
+
+fn is_safari_foreground_app(foreground: &devtools::ForegroundApp) -> bool {
+    foreground.bundle_identifier.as_deref() == Some("com.apple.mobilesafari")
+        || foreground.app_name.as_deref() == Some("Safari")
+        || foreground.app_name.as_deref() == Some("MobileSafari")
+}
+
 async fn chrome_devtools_targets(
     State(state): State<AppState>,
     Path(udid): Path<String>,
@@ -929,7 +1109,10 @@ async fn chrome_devtools_targets(
 ) -> Result<Json<devtools::ChromeDevToolsTargetDiscovery>, AppError> {
     let origin = request_origin(&headers);
     let mut warnings = Vec::new();
-    let foreground_app = foreground_app_metadata(&state, &udid).await.ok().flatten();
+    let foreground_app = foreground_app_for_simulator(&state, &udid)
+        .await
+        .ok()
+        .flatten();
     let simulator = match list_simulators_cached(state.clone(), false).await {
         Ok(simulators) => simulators
             .into_iter()
@@ -941,15 +1124,25 @@ async fn chrome_devtools_targets(
             None
         }
     };
-    let (mut external_targets, external_warnings) = devtools::discover_external_devtools_targets(
-        &udid,
-        origin.as_deref(),
-        simulator.as_ref().map(|simulator| simulator.name.as_str()),
-        simulator
-            .as_ref()
-            .map(|simulator| simulator.device_type_name.as_str()),
+    let (mut external_targets, external_warnings) = match timeout(
+        CHROME_DEVTOOLS_DISCOVERY_TIMEOUT,
+        devtools::discover_external_devtools_targets(
+            &udid,
+            origin.as_deref(),
+            simulator.as_ref().map(|simulator| simulator.name.as_str()),
+            simulator
+                .as_ref()
+                .map(|simulator| simulator.device_type_name.as_str()),
+        ),
     )
-    .await;
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => {
+            warnings.push("Timed out loading Chrome DevTools targets.".to_owned());
+            (Vec::new(), Vec::new())
+        }
+    };
     let mut targets = Vec::new();
     targets.append(&mut external_targets);
     warnings.extend(external_warnings);
@@ -1005,7 +1198,8 @@ async fn chrome_devtools_socket_session(
         .and_then(|value| value.parse::<i64>().ok())
         .ok_or_else(|| "Invalid Chrome DevTools target id.".to_owned())?;
     let session = inspector_session_for_process(state, udid, process_identifier).await?;
-    let source = chrome_devtools_source_for_session(&session);
+    let source = chrome_devtools_source_for_session(&session)
+        .ok_or_else(|| "This app inspector does not expose a Chrome DevTools target.".to_owned())?;
     let target = devtools::build_target(
         udid,
         None,
@@ -1024,29 +1218,22 @@ async fn chrome_devtools_socket_session(
     Ok((runtime, query))
 }
 
-fn chrome_devtools_source_for_session(session: &InspectorSession) -> &str {
+fn chrome_devtools_source_for_session(session: &InspectorSession) -> Option<&str> {
     if session
         .available_sources
         .iter()
         .any(|source| source == SOURCE_REACT_NATIVE)
     {
-        return SOURCE_REACT_NATIVE;
+        return Some(SOURCE_REACT_NATIVE);
     }
     if session
         .available_sources
         .iter()
         .any(|source| source == SOURCE_NATIVE_SCRIPT)
     {
-        return SOURCE_NATIVE_SCRIPT;
+        return Some(SOURCE_NATIVE_SCRIPT);
     }
-    if session
-        .available_sources
-        .iter()
-        .any(|source| source == SOURCE_SWIFTUI)
-    {
-        return SOURCE_SWIFTUI;
-    }
-    SOURCE_UIKIT
+    None
 }
 
 async fn chrome_devtools_ui_redirect() -> Redirect {
@@ -1514,7 +1701,10 @@ async fn simulator_state(
         .and_then(Value::as_bool)
         .unwrap_or(false);
     let foreground_app = if is_booted && !android::is_android_id(&udid) {
-        foreground_app_metadata(&state, &udid).await.ok().flatten()
+        foreground_app_for_simulator(&state, &udid)
+            .await
+            .ok()
+            .flatten()
     } else {
         None
     };
@@ -1635,10 +1825,10 @@ async fn sample_process_stack(
 }
 
 async fn performance_foreground_process(state: &AppState, udid: &str) -> Option<ForegroundProcess> {
-    let foreground = match foreground_app_metadata(state, udid).await {
-        Ok(Some(foreground)) => Some(foreground),
-        _ => foreground_app_from_launchctl(udid).await.ok().flatten(),
-    };
+    let foreground = foreground_app_for_simulator(state, udid)
+        .await
+        .ok()
+        .flatten();
     foreground.map(|foreground| ForegroundProcess {
         process_identifier: foreground.process_identifier,
         bundle_identifier: foreground.bundle_identifier,
@@ -4533,10 +4723,11 @@ async fn inspector_session_for_state(
     state: &AppState,
     udid: &str,
 ) -> Result<InspectorSession, String> {
-    let frontmost_pid = frontmost_process_identifier(state, udid)
+    let frontmost_pid = foreground_app_for_simulator(state, udid)
         .await
         .ok()
-        .flatten();
+        .flatten()
+        .map(|foreground| foreground.process_identifier);
     let connected_error = match connected_inspector_session(state, udid, frontmost_pid).await {
         Ok(session) => return Ok(session),
         Err(error) => error,
@@ -4835,12 +5026,78 @@ async fn frontmost_process_identifier(state: &AppState, udid: &str) -> Result<Op
     let snapshot = accessibility_snapshot(state.clone(), udid.to_owned(), None, Some(0))
         .await
         .map_err(|error| error.to_string())?;
-    Ok(snapshot
-        .get("roots")
+    if let Some(process_identifier) = process_identifier_from_accessibility_snapshot(&snapshot) {
+        return Ok(Some(process_identifier));
+    }
+    frontmost_process_identifier_from_points(state, udid).await
+}
+
+async fn frontmost_process_identifier_from_points(
+    state: &AppState,
+    udid: &str,
+) -> Result<Option<i64>, String> {
+    let probe_points = foreground_process_probe_points(state.clone(), udid.to_owned()).await;
+    let mut last_error: Option<String> = None;
+    for point in probe_points {
+        match timeout(
+            SAFARI_ACTIVE_TAB_HINT_TIMEOUT,
+            accessibility_snapshot(state.clone(), udid.to_owned(), Some(point), Some(0)),
+        )
+        .await
+        {
+            Ok(Ok(snapshot)) => {
+                if let Some(process_identifier) =
+                    process_identifier_from_accessibility_snapshot(&snapshot)
+                {
+                    return Ok(Some(process_identifier));
+                }
+            }
+            Ok(Err(error)) => last_error = Some(error.to_string()),
+            Err(_) => {}
+        }
+    }
+    if let Some(error) = last_error {
+        Err(error)
+    } else {
+        Ok(None)
+    }
+}
+
+async fn foreground_process_probe_points(state: AppState, udid: String) -> Vec<(f64, f64)> {
+    let profile = run_bridge_action(state, move |bridge| bridge.chrome_profile(&udid)).await;
+    let (screen_width, screen_height) = profile
+        .map(|profile| (profile.screen_width, profile.screen_height))
+        .unwrap_or((402.0, 874.0));
+    let center_x = (screen_width * 0.5).max(1.0);
+    let center_y = (screen_height * 0.5).clamp(1.0, screen_height.max(1.0));
+    let bottom_address_y = (screen_height - 54.0).clamp(1.0, screen_height.max(1.0));
+    let bottom_title_y = (screen_height - 28.0).clamp(1.0, screen_height.max(1.0));
+    vec![
+        (center_x, bottom_address_y),
+        (center_x, bottom_title_y),
+        (center_x, 92.0_f64.min((screen_height * 0.18).max(1.0))),
+        (center_x, center_y),
+    ]
+}
+
+fn process_identifier_from_accessibility_snapshot(snapshot: &Value) -> Option<i64> {
+    let roots = snapshot.get("roots").and_then(Value::as_array)?;
+    roots
+        .iter()
+        .find_map(process_identifier_from_accessibility_node)
+}
+
+fn process_identifier_from_accessibility_node(node: &Value) -> Option<i64> {
+    if let Some(process_identifier) = node.get("pid").and_then(Value::as_i64) {
+        return Some(process_identifier);
+    }
+    node.get("children")
         .and_then(Value::as_array)
-        .and_then(|roots| roots.first())
-        .and_then(|root| root.get("pid"))
-        .and_then(Value::as_i64))
+        .and_then(|children| {
+            children
+                .iter()
+                .find_map(process_identifier_from_accessibility_node)
+        })
 }
 
 async fn foreground_app_metadata(
@@ -4851,6 +5108,9 @@ async fn foreground_app_metadata(
         return Ok(None);
     };
     let command = process_command(process_identifier).await?;
+    if command.contains(".appex/") || command.contains("WebContent") {
+        return Ok(None);
+    }
     let app_path = app_bundle_path_from_command(&command);
     let bundle_identifier = match app_path.as_deref() {
         Some(path) => app_bundle_identifier(path).await.ok().flatten(),
@@ -4870,6 +5130,67 @@ async fn foreground_app_metadata(
         bundle_identifier,
         app_name,
     }))
+}
+
+async fn foreground_app_for_simulator(
+    state: &AppState,
+    udid: &str,
+) -> Result<Option<devtools::ForegroundApp>, String> {
+    if let Some(foreground) = cached_foreground_app(udid) {
+        return Ok(Some(foreground));
+    }
+
+    let mut last_error: Option<String> = None;
+    match foreground_app_metadata(state, udid).await {
+        Ok(Some(foreground)) => {
+            cache_foreground_app(udid, &foreground);
+            return Ok(Some(foreground));
+        }
+        Ok(None) => {}
+        Err(error) => last_error = Some(error),
+    }
+
+    match foreground_app_from_launchctl(udid).await {
+        Ok(Some(foreground)) => {
+            cache_foreground_app(udid, &foreground);
+            Ok(Some(foreground))
+        }
+        Ok(None) => Ok(stale_cached_foreground_app(udid)),
+        Err(error) => stale_cached_foreground_app(udid)
+            .map(Some)
+            .ok_or_else(|| last_error.unwrap_or(error)),
+    }
+}
+
+fn cache_foreground_app(udid: &str, foreground_app: &devtools::ForegroundApp) {
+    let cache = FOREGROUND_APP_CACHE.get_or_init(|| StdMutex::new(HashMap::new()));
+    let Ok(mut cache) = cache.lock() else {
+        return;
+    };
+    cache.insert(
+        udid.to_owned(),
+        CachedForegroundApp {
+            cached_at: Instant::now(),
+            foreground_app: foreground_app.clone(),
+        },
+    );
+}
+
+fn cached_foreground_app(udid: &str) -> Option<devtools::ForegroundApp> {
+    cached_foreground_app_with_ttl(udid, FOREGROUND_APP_CACHE_TTL)
+}
+
+fn stale_cached_foreground_app(udid: &str) -> Option<devtools::ForegroundApp> {
+    cached_foreground_app_with_ttl(udid, FOREGROUND_APP_STALE_TTL)
+}
+
+fn cached_foreground_app_with_ttl(udid: &str, ttl: Duration) -> Option<devtools::ForegroundApp> {
+    let cache = FOREGROUND_APP_CACHE.get()?;
+    let Ok(cache) = cache.lock() else {
+        return None;
+    };
+    let cached = cache.get(udid)?;
+    (cached.cached_at.elapsed() <= ttl).then(|| cached.foreground_app.clone())
 }
 
 #[derive(Clone, Debug)]
@@ -4892,8 +5213,22 @@ async fn foreground_app_from_launchctl(
 ) -> Result<Option<devtools::ForegroundApp>, String> {
     let services = simulator_ui_application_services(udid).await?;
     let mut best: Option<UIKitApplicationServiceDetails> = None;
-    for service in services {
-        let Some(details) = ui_application_service_details(udid, &service).await? else {
+    let detail_results = join_all(
+        services
+            .iter()
+            .map(|service| ui_application_service_details(udid, service)),
+    )
+    .await;
+    let mut skipped_details = 0_u32;
+    for result in detail_results {
+        let Some(details) = (match result {
+            Ok(details) => details,
+            Err(error) => {
+                skipped_details += 1;
+                tracing::debug!("Skipping UIKit application foreground candidate: {error}");
+                None
+            }
+        }) else {
             continue;
         };
         let details_score = ui_application_foreground_score(&details);
@@ -4904,6 +5239,14 @@ async fn foreground_app_from_launchctl(
         if details_score > best_score {
             best = Some(details);
         }
+    }
+
+    if skipped_details > 0
+        && best
+            .as_ref()
+            .is_some_and(|details| ui_application_foreground_score(details) < (2, 3))
+    {
+        return Ok(None);
     }
 
     Ok(best.map(|details| devtools::ForegroundApp {
@@ -4917,7 +5260,7 @@ async fn simulator_ui_application_services(
     udid: &str,
 ) -> Result<Vec<UIKitApplicationService>, String> {
     let output = timeout(
-        Duration::from_secs(2),
+        Duration::from_secs(3),
         Command::new("xcrun")
             .args(["simctl", "spawn", udid, "launchctl", "print", "user/501"])
             .output(),
@@ -4955,7 +5298,7 @@ async fn ui_application_service_details(
     service: &UIKitApplicationService,
 ) -> Result<Option<UIKitApplicationServiceDetails>, String> {
     let output = timeout(
-        Duration::from_secs(1),
+        Duration::from_secs(3),
         Command::new("xcrun")
             .args([
                 "simctl",
@@ -5996,13 +6339,16 @@ async fn accessibility_snapshot(
 #[cfg(test)]
 mod tests {
     use super::{
-        accessibility_point_snapshot, attach_tree_metadata, available_sources_for_snapshot,
-        best_inspector_session, client_stats_foreground, compact_accessibility_snapshot,
-        element_matches_selector, first_matching_element, inspector_available_sources,
-        inspector_metadata, inspector_session_from_published, inspector_session_score,
-        is_inspector_agent_transport_path, normalize_inspector_node,
+        accessibility_point_snapshot, active_url_hint_from_accessibility_snapshot,
+        attach_tree_metadata, available_sources_for_snapshot, best_inspector_session,
+        chrome_devtools_source_for_session, client_stats_foreground,
+        compact_accessibility_snapshot, element_matches_selector, first_matching_element,
+        inspector_available_sources, inspector_metadata, inspector_session_from_published,
+        inspector_session_score, is_inspector_agent_transport_path,
+        mark_safari_active_webkit_target, normalize_inspector_node,
         normalize_screen_point_from_snapshot, normalized_gesture_coordinates,
-        parse_lsof_tcp_listener, parse_ui_application_service_line, resolved_stream_quality_limits,
+        parse_lsof_tcp_listener, parse_ui_application_service_line,
+        process_identifier_from_accessibility_snapshot, resolved_stream_quality_limits,
         split_filter_values, stream_quality_profile, suppress_native_ax_translation_error,
         tap_point_from_snapshot, trim_tree_depth, ui_application_foreground_score,
         AccessibilityHierarchySource, ElementSelectorPayload, InspectorSession,
@@ -6039,6 +6385,76 @@ mod tests {
                 }]
             }]
         })
+    }
+
+    fn webkit_target(title: &str, url: &str, page_id: u64) -> crate::webkit::WebKitTarget {
+        crate::webkit::WebKitTarget {
+            id: format!("target-{page_id}"),
+            app_id: "com.apple.mobilesafari".to_owned(),
+            app_name: Some("Safari".to_owned()),
+            app_active: true,
+            page_active: false,
+            page_id,
+            title: Some(title.to_owned()),
+            url: Some(url.to_owned()),
+            kind: "safari-page".to_owned(),
+            inspector_url: format!("/webkit/{page_id}"),
+            web_socket_url: format!("ws://localhost/{page_id}"),
+        }
+    }
+
+    #[test]
+    fn active_safari_url_hint_reads_bidi_stripped_ax_value() {
+        let snapshot = json!({
+            "roots": [{
+                "type": "TextField",
+                "AXLabel": "Address",
+                "AXValue": "\u{200e}webkit.org",
+                "children": []
+            }]
+        });
+
+        assert_eq!(
+            active_url_hint_from_accessibility_snapshot(&snapshot),
+            Some("webkit.org".to_owned())
+        );
+    }
+
+    #[test]
+    fn accessibility_snapshot_pid_search_reads_nested_point_results() {
+        let snapshot = json!({
+            "roots": [{
+                "type": "Window",
+                "children": [{
+                    "type": "TextField",
+                    "pid": 24218,
+                    "children": []
+                }]
+            }]
+        });
+
+        assert_eq!(
+            process_identifier_from_accessibility_snapshot(&snapshot),
+            Some(24218)
+        );
+    }
+
+    #[test]
+    fn mark_safari_active_webkit_target_promotes_matching_tab() {
+        let mut targets = vec![
+            webkit_target("Example Domain", "https://example.com/", 2),
+            webkit_target("WebKit", "https://webkit.org/", 8),
+            webkit_target("SimDeck", "https://simdeck.nativescript.org/", 1),
+        ];
+
+        mark_safari_active_webkit_target(&mut targets, "webkit.org");
+
+        assert_eq!(
+            targets.first().and_then(|target| target.url.as_deref()),
+            Some("https://webkit.org/")
+        );
+        assert!(targets[0].page_active);
+        assert!(targets.iter().skip(1).all(|target| !target.page_active));
     }
 
     #[test]
@@ -6225,6 +6641,38 @@ mod tests {
                 SOURCE_UIKIT.to_owned()
             ]
         );
+    }
+
+    #[test]
+    fn chrome_devtools_source_only_allows_cdp_capable_app_inspectors() {
+        let react_native = InspectorSession {
+            transport: InspectorSessionTransport::Connected,
+            available_sources: vec![SOURCE_REACT_NATIVE.to_owned(), SOURCE_SWIFTUI.to_owned()],
+            info: json!({}),
+            process_identifier: 1,
+        };
+        let native_script = InspectorSession {
+            transport: InspectorSessionTransport::Connected,
+            available_sources: vec![SOURCE_NATIVE_SCRIPT.to_owned()],
+            info: json!({}),
+            process_identifier: 2,
+        };
+        let swiftui = InspectorSession {
+            transport: InspectorSessionTransport::Connected,
+            available_sources: vec![SOURCE_SWIFTUI.to_owned(), SOURCE_UIKIT.to_owned()],
+            info: json!({}),
+            process_identifier: 3,
+        };
+
+        assert_eq!(
+            chrome_devtools_source_for_session(&react_native),
+            Some(SOURCE_REACT_NATIVE)
+        );
+        assert_eq!(
+            chrome_devtools_source_for_session(&native_script),
+            Some(SOURCE_NATIVE_SCRIPT)
+        );
+        assert_eq!(chrome_devtools_source_for_session(&swiftui), None);
     }
 
     #[test]

--- a/server/src/native/bridge.rs
+++ b/server/src/native/bridge.rs
@@ -9,7 +9,8 @@ use std::time::Duration;
 
 const RECOVERABLE_RESTART_EXIT_CODE: i32 = 75;
 const RESTART_ON_CORE_SIMULATOR_MISMATCH_ENV: &str = "SIMDECK_RESTART_ON_CORE_SIMULATOR_MISMATCH";
-const ACCESSIBILITY_SNAPSHOT_MAX_ATTEMPTS: usize = 10;
+const ACCESSIBILITY_POINT_SNAPSHOT_MAX_ATTEMPTS: usize = 1;
+const ACCESSIBILITY_SNAPSHOT_MAX_ATTEMPTS: usize = 4;
 const ACCESSIBILITY_SNAPSHOT_RETRY_DELAY_MS: u64 = 100;
 
 static RECOVERABLE_RESTART_SCHEDULED: AtomicBool = AtomicBool::new(false);
@@ -365,7 +366,12 @@ impl NativeBridge {
     ) -> Result<serde_json::Value, AppError> {
         let udid = CString::new(udid).map_err(|e| AppError::bad_request(e.to_string()))?;
         let max_depth = max_depth.unwrap_or(80).min(80);
-        for attempt in 1..=ACCESSIBILITY_SNAPSHOT_MAX_ATTEMPTS {
+        let max_attempts = if point.is_some() || max_depth == 0 {
+            ACCESSIBILITY_POINT_SNAPSHOT_MAX_ATTEMPTS
+        } else {
+            ACCESSIBILITY_SNAPSHOT_MAX_ATTEMPTS
+        };
+        for attempt in 1..=max_attempts {
             let json = match native_accessibility_snapshot_json(&udid, point, max_depth) {
                 Ok(json) => json,
                 Err(error) if is_core_simulator_service_mismatch(&error.to_string()) => {
@@ -376,9 +382,7 @@ impl NativeBridge {
             };
             let snapshot: serde_json::Value =
                 serde_json::from_str(&json).map_err(|e| AppError::internal(e.to_string()))?;
-            if !accessibility_snapshot_is_transient_empty(&snapshot)
-                || attempt == ACCESSIBILITY_SNAPSHOT_MAX_ATTEMPTS
-            {
+            if !accessibility_snapshot_is_transient_empty(&snapshot) || attempt == max_attempts {
                 return Ok(snapshot);
             }
             std::thread::sleep(Duration::from_millis(ACCESSIBILITY_SNAPSHOT_RETRY_DELAY_MS));

--- a/server/src/performance.rs
+++ b/server/src/performance.rs
@@ -13,7 +13,7 @@ const HISTORY_MAX_SAMPLES: usize = 720;
 const PROCESS_LIST_TIMEOUT: Duration = Duration::from_secs(2);
 const PROCESS_SAMPLE_TIMEOUT: Duration = Duration::from_secs(2);
 const NETWORK_SAMPLE_TIMEOUT: Duration = Duration::from_millis(650);
-const NETWORK_TOTALS_TIMEOUT: Duration = Duration::from_secs(6);
+const NETWORK_TOTALS_TIMEOUT: Duration = Duration::from_millis(650);
 const STACK_SAMPLE_MAX_BYTES: usize = 256 * 1024;
 
 #[derive(Clone, Default)]
@@ -542,6 +542,7 @@ fn app_processes_from_ps(
         .into_iter()
         .filter(|process| {
             process.command.contains(udid)
+                && !is_simulator_probe_process(&process.command)
                 && (is_relevant_app_process(&process.command)
                     || foreground_pid == Some(process.pid))
         })
@@ -608,10 +609,12 @@ fn performance_process(
 }
 
 fn is_relevant_app_process(command: &str) -> bool {
-    command.contains(".app/")
-        || command.contains(".appex/")
-        || command.contains("WebContent")
-        || command.contains("UIKitApplication")
+    command.contains(".app/") || command.contains(".appex/") || command.contains("WebContent")
+}
+
+fn is_simulator_probe_process(command: &str) -> bool {
+    let executable = process_name_from_command(command);
+    executable == "simctl" || executable == "xcrun" && command.contains(" simctl ")
 }
 
 fn process_role(command: &str) -> String {
@@ -1052,7 +1055,10 @@ unsafe extern "C" {
 
 #[cfg(test)]
 mod tests {
-    use super::{app_bundle_path_from_command, parse_nettop_network_totals, parse_ps_line};
+    use super::{
+        app_bundle_path_from_command, is_relevant_app_process, is_simulator_probe_process,
+        parse_nettop_network_totals, parse_ps_line,
+    };
 
     #[test]
     fn parse_ps_line_keeps_command_tail() {
@@ -1083,6 +1089,25 @@ mod tests {
                     .to_owned()
             )
         );
+    }
+
+    #[test]
+    fn simulator_probe_processes_are_not_app_processes() {
+        let command = "/usr/bin/xcrun simctl spawn 4889 launchctl print user/501/UIKitApplication:com.apple.mobilesafari[abc]";
+
+        assert!(is_simulator_probe_process(command));
+        assert!(!is_relevant_app_process(command));
+    }
+
+    #[test]
+    fn relevant_app_processes_still_include_apps_extensions_and_web_content() {
+        assert!(is_relevant_app_process("/tmp/Foo.app/Foo --argument value"));
+        assert!(is_relevant_app_process(
+            "/tmp/Foo.appex/FooExtension --argument value"
+        ));
+        assert!(is_relevant_app_process(
+            "/System/Library/Frameworks/WebKit.framework/WebContent"
+        ));
     }
 
     #[test]

--- a/server/src/webkit.rs
+++ b/server/src/webkit.rs
@@ -6,27 +6,28 @@ use serde::Serialize;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Mutex, OnceLock};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::UnixStream;
 use tokio::process::Command;
+use tokio::sync::{Notify, RwLock};
 use tokio::time::{sleep, timeout, Instant};
 use tracing::{debug, warn};
 
 const WEBINSPECTORD_SOCKET_NAME: &str = "com.apple.webinspectord_sim.socket";
 const WEBKIT_PACKET_MAX_LEN: usize = 64 * 1024 * 1024;
-const WEBKIT_DISCOVERY_TIMEOUT: Duration = Duration::from_millis(5000);
-const WEBKIT_DISCOVERY_ATTEMPT_TIMEOUT: Duration = Duration::from_millis(1600);
-const WEBKIT_DISCOVERY_REFRESH_INTERVAL: Duration = Duration::from_millis(400);
-const WEBKIT_DISCOVERY_CACHE_TTL: Duration = Duration::from_secs(120);
+const WEBKIT_DISCOVERY_TIMEOUT: Duration = Duration::from_millis(2200);
+const WEBKIT_DISCOVERY_REFRESH_INTERVAL: Duration = Duration::from_secs(2);
 const WEBKIT_SOCKET_ACTIVATION_DELAY: Duration = Duration::from_millis(200);
+const WEBKIT_TARGET_ATTACH_TIMEOUT: Duration = Duration::from_millis(2200);
 const WEBKIT_IO_TIMEOUT: Duration = Duration::from_secs(4);
 const WEBKIT_SOCKET_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(5);
+const WEBKIT_DISCOVERY_RECONNECT_DELAY: Duration = Duration::from_millis(500);
 
 static WEBKIT_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
-static WEBKIT_DISCOVERY_CACHE: OnceLock<Mutex<HashMap<String, CachedWebKitDiscovery>>> =
+static WEBKIT_DISCOVERY_MONITORS: OnceLock<Mutex<HashMap<String, Arc<WebKitDiscoveryMonitor>>>> =
     OnceLock::new();
 
 #[derive(Clone, Debug, Serialize)]
@@ -35,6 +36,8 @@ pub struct WebKitTarget {
     pub id: String,
     pub app_id: String,
     pub app_name: Option<String>,
+    pub app_active: bool,
+    pub page_active: bool,
     pub page_id: u64,
     pub title: Option<String>,
     pub url: Option<String>,
@@ -52,32 +55,12 @@ pub struct WebKitTargetDiscovery {
     pub warnings: Vec<String>,
 }
 
-pub fn synthetic_safari_target(
-    udid: &str,
-    http_origin: &str,
-    process_identifier: i64,
-) -> WebKitTarget {
-    webkit_target(
-        udid,
-        http_origin,
-        WebKitPage {
-            app_id: format!("PID:{process_identifier}"),
-            page_id: 1,
-            title: Some("Safari".to_owned()),
-            url: None,
-        },
-        Some(&WebKitApplication {
-            id: format!("PID:{process_identifier}"),
-            name: Some("Safari".to_owned()),
-            is_proxy: false,
-        }),
-    )
-}
-
 #[derive(Clone, Debug)]
 struct WebKitApplication {
     id: String,
     name: Option<String>,
+    bundle_identifier: Option<String>,
+    active: bool,
     is_proxy: bool,
 }
 
@@ -87,6 +70,7 @@ struct WebKitPage {
     page_id: u64,
     title: Option<String>,
     url: Option<String>,
+    connection_id: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -100,276 +84,346 @@ struct LsofProcess {
     sockets: Vec<String>,
 }
 
-#[derive(Clone)]
-struct CachedWebKitDiscovery {
-    discovery: WebKitTargetDiscovery,
-    cached_at: SystemTime,
+#[derive(Clone, Default)]
+struct WebKitDiscoveryState {
+    socket_path: Option<String>,
+    applications: BTreeMap<String, WebKitApplication>,
+    pages: BTreeMap<(String, u64), WebKitPage>,
+    warnings: Vec<String>,
+}
+
+struct WebKitDiscoveryMonitor {
+    udid: String,
+    running: AtomicBool,
+    state: RwLock<WebKitDiscoveryState>,
+    notify: Notify,
 }
 
 pub async fn discover_targets(
     udid: &str,
     http_origin: Option<&str>,
 ) -> Result<WebKitTargetDiscovery, AppError> {
-    let socket = match discover_webinspector_socket(udid).await? {
-        Some(socket) => socket,
-        None => {
-            return Ok(WebKitTargetDiscovery {
-                udid: udid.to_owned(),
-                socket_path: None,
-                targets: Vec::new(),
-                warnings: vec![format!(
-                    "No WebKit Remote Inspector socket was found for simulator {udid}. Boot the simulator and open an inspectable Safari page or WKWebView."
-                )],
-            });
-        }
-    };
-
-    if let Some(cached) = cached_webkit_discovery(udid, Some(socket.path.clone()), Vec::new()) {
-        return Ok(cached);
-    }
+    let monitor = webkit_discovery_monitor(udid);
+    monitor.clone().ensure_started();
 
     let deadline = Instant::now() + WEBKIT_DISCOVERY_TIMEOUT;
-    let mut attempts = 0usize;
-    let mut last_discovery: Option<WebKitTargetDiscovery> = None;
-    let mut accumulated_warnings = Vec::new();
     loop {
-        attempts += 1;
-        match discover_targets_once(udid, http_origin, &socket).await {
-            Ok(discovery) if !discovery.targets.is_empty() => {
-                cache_webkit_discovery(&discovery);
-                return Ok(discovery);
-            }
-            Ok(discovery) => {
-                for warning in &discovery.warnings {
-                    push_unique_warning(&mut accumulated_warnings, warning);
-                }
-                last_discovery = Some(discovery);
-            }
-            Err(error) => {
-                push_unique_warning(&mut accumulated_warnings, error.to_string());
-            }
+        let discovery = monitor.discovery(http_origin).await;
+        if !discovery.targets.is_empty() || Instant::now() >= deadline {
+            return Ok(discovery);
         }
 
-        if Instant::now() >= deadline {
-            break;
-        }
-        sleep(Duration::from_millis(250)).await;
-    }
-
-    let mut discovery = last_discovery.unwrap_or_else(|| WebKitTargetDiscovery {
-        udid: udid.to_owned(),
-        socket_path: Some(socket.path.clone()),
-        targets: Vec::new(),
-        warnings: Vec::new(),
-    });
-    discovery.warnings = accumulated_warnings;
-    if attempts > 1 {
-        push_unique_warning(
-            &mut discovery.warnings,
-            format!("Retried WebKit target discovery {attempts} times while simulator webinspectord was settling."),
-        );
-    }
-
-    if let Some(cached) = cached_webkit_discovery(
-        udid,
-        discovery.socket_path.clone(),
-        discovery.warnings.clone(),
-    ) {
-        return Ok(cached);
-    }
-
-    Ok(discovery)
-}
-
-async fn discover_targets_once(
-    udid: &str,
-    http_origin: Option<&str>,
-    socket: &WebKitSocket,
-) -> Result<WebKitTargetDiscovery, AppError> {
-    let mut stream = timeout(WEBKIT_IO_TIMEOUT, UnixStream::connect(&socket.path))
+        let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+            return Ok(discovery);
+        };
+        if timeout(
+            remaining.min(Duration::from_millis(250)),
+            monitor.notify.notified(),
+        )
         .await
-        .map_err(|_| AppError::native("Timed out connecting to simulator webinspectord."))?
-        .map_err(|error| {
-            AppError::native(format!(
-                "Unable to connect to simulator webinspectord at {}: {error}",
-                socket.path
-            ))
-        })?;
+        .is_err()
+        {
+            continue;
+        }
+    }
+}
 
-    let connection_id = new_remote_inspector_id();
-    send_rpc(
-        &mut stream,
-        "_rpc_reportIdentifier:",
-        rpc_args(&connection_id),
-    )
-    .await?;
+fn webkit_discovery_monitor(udid: &str) -> Arc<WebKitDiscoveryMonitor> {
+    let monitors = WEBKIT_DISCOVERY_MONITORS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut monitors = monitors
+        .lock()
+        .expect("WebKit discovery monitor lock poisoned");
+    monitors
+        .entry(udid.to_owned())
+        .or_insert_with(|| Arc::new(WebKitDiscoveryMonitor::new(udid.to_owned())))
+        .clone()
+}
 
-    let deadline = Instant::now() + WEBKIT_DISCOVERY_ATTEMPT_TIMEOUT;
-    let mut next_listing_refresh = Instant::now() + WEBKIT_DISCOVERY_REFRESH_INTERVAL;
-    let mut applications: BTreeMap<String, WebKitApplication> = BTreeMap::new();
-    let mut requested_listings: HashSet<String> = HashSet::new();
-    let mut pages: BTreeMap<(String, u64), WebKitPage> = BTreeMap::new();
-    let mut warnings = Vec::new();
-
-    while let Some(remaining) = deadline.checked_duration_since(Instant::now()) {
-        let read_timeout = remaining.min(Duration::from_millis(250));
-        let packet = match timeout(read_timeout, read_packet(&mut stream)).await {
-            Ok(Ok(packet)) => packet,
-            Ok(Err(error)) => {
-                warnings.push(error.to_string());
-                break;
-            }
-            Err(_) if !pages.is_empty() => break,
-            Err(_) if Instant::now() < deadline => {
-                if Instant::now() >= next_listing_refresh {
-                    for app_id in applications.keys() {
-                        send_forward_get_listing(&mut stream, &connection_id, app_id).await?;
-                    }
-                    next_listing_refresh = Instant::now() + WEBKIT_DISCOVERY_REFRESH_INTERVAL;
-                }
-                continue;
-            }
-            Err(_) => break,
-        };
-
-        let message = match parse_rpc_message(&packet) {
-            Ok(message) => message,
-            Err(error) => {
-                warnings.push(error.to_string());
-                continue;
-            }
-        };
-        debug!(
-            selector = %message.selector,
-            "Received WebKit discovery selector"
-        );
-
-        match message.selector.as_str() {
-            "_rpc_reportConnectedApplicationList:" => {
-                for app in parse_application_list(&message.args) {
-                    if requested_listings.insert(app.id.clone()) {
-                        send_forward_get_listing(&mut stream, &connection_id, &app.id).await?;
-                    }
-                    applications.insert(app.id.clone(), app);
-                }
-            }
-            "_rpc_applicationConnected:" => {
-                if let Some(app) = parse_application(&message.args) {
-                    if requested_listings.insert(app.id.clone()) {
-                        send_forward_get_listing(&mut stream, &connection_id, &app.id).await?;
-                    }
-                    applications.insert(app.id.clone(), app);
-                }
-            }
-            "_rpc_applicationUpdated:" => {
-                if let Some(app_id) = string_value(&message.args, "WIRApplicationIdentifierKey") {
-                    if requested_listings.insert(app_id.clone()) {
-                        send_forward_get_listing(&mut stream, &connection_id, &app_id).await?;
-                    }
-                    applications
-                        .entry(app_id.clone())
-                        .or_insert(WebKitApplication {
-                            id: app_id,
-                            name: string_value(&message.args, "WIRApplicationNameKey"),
-                            is_proxy: bool_value(&message.args, "WIRIsApplicationProxyKey")
-                                .unwrap_or(false),
-                        });
-                }
-            }
-            "_rpc_applicationSentListing:" => {
-                for page in parse_page_listing(&message.args) {
-                    pages.insert((page.app_id.clone(), page.page_id), page);
-                }
-            }
-            "_rpc_applicationDisconnected:" => {
-                if let Some(app) = parse_application(&message.args) {
-                    applications.remove(&app.id);
-                    pages.retain(|(app_id, _), _| app_id != &app.id);
-                }
-            }
-            "_rpc_reportSetup:"
-            | "_rpc_reportConnectedDriverList:"
-            | "_rpc_reportCurrentState:" => {}
-            selector => debug!("Ignoring WebKit inspector discovery selector {selector}."),
+impl WebKitDiscoveryMonitor {
+    fn new(udid: String) -> Self {
+        Self {
+            udid,
+            running: AtomicBool::new(false),
+            state: RwLock::new(WebKitDiscoveryState::default()),
+            notify: Notify::new(),
         }
     }
 
-    let origin = http_origin.unwrap_or("");
-    let mut targets = pages
-        .into_values()
-        .map(|page| {
-            let app = applications.get(&page.app_id);
-            webkit_target(udid, origin, page, app)
-        })
-        .collect::<Vec<_>>();
-    targets.sort_by(|lhs, rhs| {
-        lhs.app_name
-            .cmp(&rhs.app_name)
-            .then(lhs.title.cmp(&rhs.title))
-            .then(lhs.url.cmp(&rhs.url))
-            .then(lhs.page_id.cmp(&rhs.page_id))
-    });
+    fn ensure_started(self: Arc<Self>) {
+        if self.running.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        tokio::spawn(async move {
+            self.run().await;
+        });
+    }
 
-    let discovery = WebKitTargetDiscovery {
-        udid: udid.to_owned(),
-        socket_path: Some(socket.path.clone()),
-        targets,
-        warnings,
-    };
+    async fn discovery(&self, http_origin: Option<&str>) -> WebKitTargetDiscovery {
+        let state = self.state.read().await.clone();
+        self.discovery_from_state(state, http_origin)
+    }
 
-    Ok(discovery)
+    fn discovery_from_state(
+        &self,
+        state: WebKitDiscoveryState,
+        http_origin: Option<&str>,
+    ) -> WebKitTargetDiscovery {
+        let origin = http_origin.unwrap_or("");
+        let mut targets = state
+            .pages
+            .into_values()
+            .filter(|page| !is_incomplete_or_transient_page(page))
+            .map(|page| {
+                let app = state.applications.get(&page.app_id);
+                webkit_target(&self.udid, origin, page, app)
+            })
+            .collect::<Vec<_>>();
+        targets.retain(is_inspectable_webkit_target);
+        targets.sort_by(|lhs, rhs| {
+            lhs.app_name
+                .cmp(&rhs.app_name)
+                .then(lhs.title.cmp(&rhs.title))
+                .then(lhs.url.cmp(&rhs.url))
+                .then(lhs.page_id.cmp(&rhs.page_id))
+        });
+
+        WebKitTargetDiscovery {
+            udid: self.udid.clone(),
+            socket_path: state.socket_path,
+            targets,
+            warnings: state.warnings,
+        }
+    }
+
+    async fn run(self: Arc<Self>) {
+        loop {
+            match discover_webinspector_socket(&self.udid).await {
+                Ok(Some(socket)) => {
+                    self.set_socket_state(Some(socket.path.clone()), Vec::new())
+                        .await;
+                    if let Err(error) = self.run_connection(socket).await {
+                        debug!(
+                            "WebKit discovery connection ended for {}: {error}",
+                            self.udid
+                        );
+                    }
+                }
+                Ok(None) => {
+                    self.set_socket_state(
+                        None,
+                        vec![format!(
+                            "No WebKit Remote Inspector socket was found for simulator {}. Boot the simulator and open an inspectable Safari page or WKWebView.",
+                            self.udid
+                        )],
+                    )
+                    .await;
+                }
+                Err(error) => {
+                    self.set_socket_state(None, vec![error.to_string()]).await;
+                }
+            }
+            sleep(WEBKIT_DISCOVERY_RECONNECT_DELAY).await;
+        }
+    }
+
+    async fn set_socket_state(&self, socket_path: Option<String>, warnings: Vec<String>) {
+        let mut state = self.state.write().await;
+        state.socket_path = socket_path;
+        state.warnings = warnings;
+        if state.socket_path.is_none() {
+            state.applications.clear();
+            state.pages.clear();
+        }
+        drop(state);
+        self.notify.notify_waiters();
+    }
+
+    async fn publish_listing(
+        &self,
+        socket_path: &str,
+        applications: &BTreeMap<String, WebKitApplication>,
+        pages: &BTreeMap<(String, u64), WebKitPage>,
+    ) {
+        let mut state = self.state.write().await;
+        state.socket_path = Some(socket_path.to_owned());
+        state.applications = applications.clone();
+        state.pages = pages.clone();
+        state.warnings.clear();
+        drop(state);
+        self.notify.notify_waiters();
+    }
+
+    async fn run_connection(&self, socket: WebKitSocket) -> Result<(), AppError> {
+        let mut stream = timeout(WEBKIT_IO_TIMEOUT, UnixStream::connect(&socket.path))
+            .await
+            .map_err(|_| AppError::native("Timed out connecting to simulator webinspectord."))?
+            .map_err(|error| {
+                AppError::native(format!(
+                    "Unable to connect to simulator webinspectord at {}: {error}",
+                    socket.path
+                ))
+            })?;
+
+        let connection_id = new_remote_inspector_id();
+        send_rpc(
+            &mut stream,
+            "_rpc_reportIdentifier:",
+            rpc_args(&connection_id),
+        )
+        .await?;
+        sleep(WEBKIT_SOCKET_ACTIVATION_DELAY).await;
+        send_get_connected_applications(&mut stream, &connection_id).await?;
+
+        let mut next_listing_refresh = Instant::now() + WEBKIT_DISCOVERY_REFRESH_INTERVAL;
+        let mut applications: BTreeMap<String, WebKitApplication> = BTreeMap::new();
+        let mut requested_listings: HashSet<String> = HashSet::new();
+        let mut pages: BTreeMap<(String, u64), WebKitPage> = BTreeMap::new();
+
+        loop {
+            let read_timeout = Duration::from_millis(500);
+            let packet = match timeout(read_timeout, read_packet(&mut stream)).await {
+                Ok(Ok(packet)) => packet,
+                Ok(Err(error)) => return Err(error),
+                Err(_) => {
+                    if Instant::now() >= next_listing_refresh {
+                        send_get_connected_applications(&mut stream, &connection_id).await?;
+                        for app_id in applications.keys() {
+                            send_forward_get_listing(&mut stream, &connection_id, app_id).await?;
+                        }
+                        next_listing_refresh = Instant::now() + WEBKIT_DISCOVERY_REFRESH_INTERVAL;
+                    }
+                    continue;
+                }
+            };
+
+            let message = match parse_rpc_message(&packet) {
+                Ok(message) => message,
+                Err(error) => {
+                    debug!("Ignoring malformed WebKit discovery packet: {error}");
+                    continue;
+                }
+            };
+            debug!(
+                selector = %message.selector,
+                "Received WebKit discovery selector"
+            );
+
+            match message.selector.as_str() {
+                "_rpc_reportConnectedApplicationList:" => {
+                    let live_apps = parse_application_list(&message.args);
+                    let live_ids = live_apps
+                        .iter()
+                        .map(|app| app.id.clone())
+                        .collect::<HashSet<_>>();
+                    applications.retain(|app_id, _| live_ids.contains(app_id));
+                    pages.retain(|(app_id, _), _| live_ids.contains(app_id));
+                    requested_listings.retain(|app_id| live_ids.contains(app_id));
+                    for app in live_apps {
+                        if requested_listings.insert(app.id.clone()) {
+                            send_forward_get_listing(&mut stream, &connection_id, &app.id).await?;
+                        }
+                        applications.insert(app.id.clone(), app);
+                    }
+                    self.publish_listing(&socket.path, &applications, &pages)
+                        .await;
+                }
+                "_rpc_applicationConnected:" => {
+                    if let Some(app) = parse_application(&message.args) {
+                        if requested_listings.insert(app.id.clone()) {
+                            send_forward_get_listing(&mut stream, &connection_id, &app.id).await?;
+                        }
+                        applications.insert(app.id.clone(), app);
+                        self.publish_listing(&socket.path, &applications, &pages)
+                            .await;
+                    }
+                }
+                "_rpc_applicationUpdated:" => {
+                    if let Some(app_id) = string_value(&message.args, "WIRApplicationIdentifierKey")
+                    {
+                        if requested_listings.insert(app_id.clone()) {
+                            send_forward_get_listing(&mut stream, &connection_id, &app_id).await?;
+                        }
+                        let app = applications
+                            .entry(app_id.clone())
+                            .or_insert(WebKitApplication {
+                                id: app_id,
+                                name: None,
+                                bundle_identifier: None,
+                                active: false,
+                                is_proxy: false,
+                            });
+                        if let Some(name) = string_value(&message.args, "WIRApplicationNameKey") {
+                            app.name = Some(name);
+                        }
+                        if let Some(bundle_identifier) =
+                            string_value(&message.args, "WIRApplicationBundleIdentifierKey")
+                        {
+                            app.bundle_identifier = Some(bundle_identifier);
+                        }
+                        if let Some(active) =
+                            integer_value(&message.args, "WIRIsApplicationActiveKey")
+                        {
+                            app.active = active > 0;
+                        }
+                        if let Some(is_proxy) =
+                            bool_value(&message.args, "WIRIsApplicationProxyKey")
+                        {
+                            app.is_proxy = is_proxy;
+                        }
+                        self.publish_listing(&socket.path, &applications, &pages)
+                            .await;
+                    }
+                }
+                "_rpc_applicationSentListing:" => {
+                    apply_page_listing(&mut pages, &message.args);
+                    self.publish_listing(&socket.path, &applications, &pages)
+                        .await;
+                }
+                "_rpc_applicationDisconnected:" => {
+                    if let Some(app) = parse_application(&message.args) {
+                        applications.remove(&app.id);
+                        requested_listings.remove(&app.id);
+                        pages.retain(|(app_id, _), _| app_id != &app.id);
+                        self.publish_listing(&socket.path, &applications, &pages)
+                            .await;
+                    }
+                }
+                "_rpc_reportSetup:" => {
+                    send_get_connected_applications(&mut stream, &connection_id).await?;
+                }
+                "_rpc_reportConnectedDriverList:" | "_rpc_reportCurrentState:" => {}
+                selector => debug!("Ignoring WebKit inspector discovery selector {selector}."),
+            }
+        }
+    }
 }
 
-fn cache_webkit_discovery(discovery: &WebKitTargetDiscovery) {
-    if discovery.targets.is_empty() {
-        return;
+fn is_incomplete_or_transient_page(page: &WebKitPage) -> bool {
+    let url = page.url.as_deref().map(str::trim).unwrap_or_default();
+    if url.is_empty() {
+        return true;
     }
-    let cache = WEBKIT_DISCOVERY_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
-    let Ok(mut cache) = cache.lock() else {
-        return;
-    };
-    cache.insert(
-        discovery.udid.clone(),
-        CachedWebKitDiscovery {
-            discovery: discovery.clone(),
-            cached_at: SystemTime::now(),
-        },
-    );
+    url == "about:blank"
+        && page
+            .title
+            .as_deref()
+            .map(str::trim)
+            .unwrap_or_default()
+            .is_empty()
 }
 
-fn cached_webkit_discovery(
-    udid: &str,
-    socket_path: Option<String>,
-    warnings: Vec<String>,
-) -> Option<WebKitTargetDiscovery> {
-    let cache = WEBKIT_DISCOVERY_CACHE.get()?;
-    let Ok(cache) = cache.lock() else {
-        return None;
-    };
-    let cached = cache.get(udid)?;
-    if cached.discovery.targets.is_empty()
-        || cached.cached_at.elapsed().ok()? > WEBKIT_DISCOVERY_CACHE_TTL
-    {
-        return None;
+fn is_inspectable_webkit_target(target: &WebKitTarget) -> bool {
+    let url = target.url.as_deref().map(str::trim).unwrap_or_default();
+    if url.is_empty() {
+        return false;
     }
-
-    let mut discovery = cached.discovery.clone();
-    if socket_path.is_some() {
-        discovery.socket_path = socket_path;
-    }
-    discovery.warnings = warnings;
-    for warning in &cached.discovery.warnings {
-        push_unique_warning(&mut discovery.warnings, warning);
-    }
-    Some(discovery)
-}
-
-fn push_unique_warning(warnings: &mut Vec<String>, warning: impl AsRef<str>) {
-    let warning = warning.as_ref();
-    if warnings.iter().any(|existing| existing == warning) {
-        return;
-    }
-    warnings.push(warning.to_owned());
+    !(url == "about:blank"
+        && target
+            .title
+            .as_deref()
+            .map(str::trim)
+            .unwrap_or_default()
+            .is_empty())
 }
 
 pub async fn attach_websocket(udid: String, target_id: String, socket: WebSocket) {
@@ -400,7 +454,7 @@ async fn attach_websocket_inner(
         })?;
 
     let connection_id = new_remote_inspector_id();
-    let sender_id = new_remote_inspector_id();
+    let sender_id = connection_id.clone();
     let (mut inspector_reader, mut inspector_writer) = stream.into_split();
     send_rpc(
         &mut inspector_writer,
@@ -409,6 +463,14 @@ async fn attach_websocket_inner(
     )
     .await?;
     sleep(WEBKIT_SOCKET_ACTIVATION_DELAY).await;
+    prepare_webkit_target_for_attach(
+        &mut inspector_reader,
+        &mut inspector_writer,
+        &connection_id,
+        &app_id,
+        page_id,
+    )
+    .await?;
     send_forward_indicate_webview(
         &mut inspector_writer,
         &connection_id,
@@ -433,8 +495,16 @@ async fn attach_websocket_inner(
         &sender_id,
     )
     .await?;
+    let initial_messages =
+        wait_for_webkit_socket_setup(&mut inspector_reader, &app_id, page_id, &sender_id).await?;
 
     let (mut client_writer, mut client_reader) = socket.split();
+    for message in initial_messages {
+        client_writer
+            .send(Message::Text(message.into()))
+            .await
+            .map_err(|error| AppError::internal(format!("WebSocket send failed: {error}")))?;
+    }
     let mut closed_cleanly = false;
     loop {
         tokio::select! {
@@ -503,6 +573,161 @@ async fn attach_websocket_inner(
         let _ = client_writer.send(Message::Close(None)).await;
     }
     Ok(())
+}
+
+async fn prepare_webkit_target_for_attach<R, W>(
+    inspector_reader: &mut R,
+    inspector_writer: &mut W,
+    connection_id: &str,
+    app_id: &str,
+    page_id: u64,
+) -> Result<(), AppError>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    send_forward_get_listing(inspector_writer, connection_id, app_id).await?;
+    let deadline = Instant::now() + WEBKIT_TARGET_ATTACH_TIMEOUT;
+    let mut released_connections = HashSet::new();
+
+    loop {
+        let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+            return Err(AppError::native(format!(
+                "Timed out preparing WebKit target {app_id}/{page_id} for inspection."
+            )));
+        };
+        let packet = timeout(
+            remaining.min(Duration::from_millis(500)),
+            read_packet(inspector_reader),
+        )
+        .await;
+        let packet = match packet {
+            Ok(Ok(packet)) => packet,
+            Ok(Err(error)) => return Err(error),
+            Err(_) => continue,
+        };
+
+        let message = parse_rpc_message(&packet)?;
+        match message.selector.as_str() {
+            "_rpc_applicationSentListing:" => {
+                if string_value(&message.args, "WIRApplicationIdentifierKey").as_deref()
+                    != Some(app_id)
+                {
+                    continue;
+                }
+
+                let Some(page) = parse_page_listing(&message.args)
+                    .into_iter()
+                    .find(|page| page.page_id == page_id)
+                else {
+                    return Err(AppError::not_found(format!(
+                        "WebKit target {app_id}/{page_id} is no longer available."
+                    )));
+                };
+
+                let Some(existing_connection_id) = page.connection_id else {
+                    return Ok(());
+                };
+                if existing_connection_id == connection_id {
+                    return Ok(());
+                }
+                if !released_connections.insert(existing_connection_id.clone()) {
+                    send_forward_get_listing(inspector_writer, connection_id, app_id).await?;
+                    continue;
+                }
+
+                debug!(
+                    app_id,
+                    page_id,
+                    existing_connection_id,
+                    "Releasing stale WebKit inspector target owner"
+                );
+                send_forward_did_close(
+                    inspector_writer,
+                    &existing_connection_id,
+                    app_id,
+                    page_id,
+                    &existing_connection_id,
+                )
+                .await?;
+                send_forward_get_listing(inspector_writer, connection_id, app_id).await?;
+            }
+            "_rpc_applicationDisconnected:" => {
+                if string_value(&message.args, "WIRApplicationIdentifierKey").as_deref()
+                    == Some(app_id)
+                {
+                    return Err(AppError::not_found(format!(
+                        "WebKit application {app_id} disconnected before inspection could start."
+                    )));
+                }
+            }
+            "_rpc_reportSetup:" => {
+                send_get_connected_applications(inspector_writer, connection_id).await?;
+                send_forward_get_listing(inspector_writer, connection_id, app_id).await?;
+            }
+            "_rpc_reportCurrentState:"
+            | "_rpc_reportConnectedApplicationList:"
+            | "_rpc_reportConnectedDriverList:"
+            | "_rpc_applicationUpdated:" => {}
+            selector => debug!("Ignoring WebKit inspector attach preflight selector {selector}."),
+        }
+    }
+}
+
+async fn wait_for_webkit_socket_setup<R>(
+    inspector_reader: &mut R,
+    app_id: &str,
+    page_id: u64,
+    sender_id: &str,
+) -> Result<Vec<String>, AppError>
+where
+    R: AsyncRead + Unpin,
+{
+    let deadline = Instant::now() + WEBKIT_TARGET_ATTACH_TIMEOUT;
+    loop {
+        let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+            return Err(AppError::native(format!(
+                "WebKit target {app_id}/{page_id} did not acknowledge inspector socket setup."
+            )));
+        };
+        let packet = timeout(
+            remaining.min(Duration::from_millis(500)),
+            read_packet(inspector_reader),
+        )
+        .await;
+        let packet = match packet {
+            Ok(Ok(packet)) => packet,
+            Ok(Err(error)) => return Err(error),
+            Err(_) => continue,
+        };
+
+        let message = parse_rpc_message(&packet)?;
+        match message.selector.as_str() {
+            "_rpc_applicationSentData:" => {
+                if string_value(&message.args, "WIRDestinationKey").as_deref() == Some(sender_id) {
+                    if let Some(data) = data_value(&message.args, "WIRMessageDataKey") {
+                        return Ok(vec![String::from_utf8(data).unwrap_or_default()]);
+                    }
+                }
+            }
+            "_rpc_applicationDisconnected:" => {
+                if string_value(&message.args, "WIRApplicationIdentifierKey").as_deref()
+                    == Some(app_id)
+                {
+                    return Err(AppError::not_found(format!(
+                        "WebKit application {app_id} disconnected before inspection could start."
+                    )));
+                }
+            }
+            "_rpc_applicationSentListing:"
+            | "_rpc_applicationUpdated:"
+            | "_rpc_reportSetup:"
+            | "_rpc_reportCurrentState:"
+            | "_rpc_reportConnectedApplicationList:"
+            | "_rpc_reportConnectedDriverList:" => {}
+            selector => debug!("Ignoring WebKit inspector setup selector {selector}."),
+        }
+    }
 }
 
 async fn discover_webinspector_socket(udid: &str) -> Result<Option<WebKitSocket>, AppError> {
@@ -637,6 +862,18 @@ async fn send_forward_get_listing<W: AsyncWrite + Unpin>(
         Value::String(app_id.to_owned()),
     );
     send_rpc(writer, "_rpc_forwardGetListing:", args).await
+}
+
+async fn send_get_connected_applications<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    connection_id: &str,
+) -> Result<(), AppError> {
+    send_rpc(
+        writer,
+        "_rpc_getConnectedApplications:",
+        rpc_args(connection_id),
+    )
+    .await
 }
 
 async fn send_forward_indicate_webview<W: AsyncWrite + Unpin>(
@@ -808,9 +1045,18 @@ fn parse_application_list(args: &Dictionary) -> Vec<WebKitApplication> {
         return Vec::new();
     };
 
-    apps.values()
-        .filter_map(Value::as_dictionary)
-        .filter_map(parse_application)
+    apps.iter()
+        .filter_map(|(app_id, value)| {
+            let app = value.as_dictionary()?;
+            Some(WebKitApplication {
+                id: string_value(app, "WIRApplicationIdentifierKey")
+                    .unwrap_or_else(|| app_id.clone()),
+                name: string_value(app, "WIRApplicationNameKey"),
+                bundle_identifier: string_value(app, "WIRApplicationBundleIdentifierKey"),
+                active: integer_value(app, "WIRIsApplicationActiveKey").unwrap_or(0) > 0,
+                is_proxy: bool_value(app, "WIRIsApplicationProxyKey").unwrap_or(false),
+            })
+        })
         .collect()
 }
 
@@ -819,6 +1065,8 @@ fn parse_application(args: &Dictionary) -> Option<WebKitApplication> {
     Some(WebKitApplication {
         id,
         name: string_value(args, "WIRApplicationNameKey"),
+        bundle_identifier: string_value(args, "WIRApplicationBundleIdentifierKey"),
+        active: integer_value(args, "WIRIsApplicationActiveKey").unwrap_or(0) > 0,
         is_proxy: bool_value(args, "WIRIsApplicationProxyKey").unwrap_or(false),
     })
 }
@@ -832,18 +1080,29 @@ fn parse_page_listing(args: &Dictionary) -> Vec<WebKitPage> {
     };
 
     listing
-        .values()
-        .filter_map(Value::as_dictionary)
-        .filter_map(|page| {
-            let page_id = integer_value(page, "WIRPageIdentifierKey")?;
+        .iter()
+        .filter_map(|(page_key, value)| {
+            let page = value.as_dictionary()?;
+            let page_id = integer_value(page, "WIRPageIdentifierKey")
+                .or_else(|| page_key.parse::<u64>().ok())?;
             Some(WebKitPage {
                 app_id: app_id.clone(),
                 page_id,
                 title: string_value(page, "WIRTitleKey"),
                 url: string_value(page, "WIRURLKey"),
+                connection_id: string_value(page, "WIRConnectionIdentifierKey"),
             })
         })
         .collect()
+}
+
+fn apply_page_listing(pages: &mut BTreeMap<(String, u64), WebKitPage>, listing_args: &Dictionary) {
+    if let Some(app_id) = string_value(listing_args, "WIRApplicationIdentifierKey") {
+        pages.retain(|(page_app_id, _), _| page_app_id != &app_id);
+    }
+    for page in parse_page_listing(listing_args) {
+        pages.insert((page.app_id.clone(), page.page_id), page);
+    }
 }
 
 fn rpc_args(connection_id: &str) -> Dictionary {
@@ -871,10 +1130,15 @@ fn webkit_target(
             .trim_start_matches("wss://")
     );
     let app_name = app.and_then(|app| app.name.clone());
+    let app_active = app.map(|app| app.active).unwrap_or(false);
     let normalized_app_id = page.app_id.to_ascii_lowercase();
     let normalized_app_name = app_name.as_deref().map(str::to_ascii_lowercase);
+    let normalized_bundle_id = app
+        .and_then(|app| app.bundle_identifier.as_deref())
+        .map(str::to_ascii_lowercase);
     let kind = if normalized_app_id.contains("mobilesafari")
         || normalized_app_name.as_deref() == Some("safari")
+        || normalized_bundle_id.as_deref() == Some("com.apple.mobilesafari")
     {
         "safari-page"
     } else if app.is_some_and(|app| app.is_proxy) {
@@ -888,6 +1152,8 @@ fn webkit_target(
         id,
         app_id: page.app_id,
         app_name,
+        app_active,
+        page_active: false,
         page_id: page.page_id,
         title: page.title,
         url: page.url,
@@ -1107,6 +1373,22 @@ fn browser_frontend_host_script() -> &'static str {
         );
     }
 
+    function installNetworkManagerCompatibilityFallbacks() {
+        const prototype = window.WI?.NetworkManager?.prototype;
+        if (!prototype || prototype.__simdeckMainFrameResourceTreePatch)
+            return;
+        const original = prototype._processMainFrameResourceTreePayload;
+        if (typeof original !== "function")
+            return;
+
+        prototype.__simdeckMainFrameResourceTreePatch = true;
+        prototype._processMainFrameResourceTreePayload = function (error, mainFramePayload) {
+            if (this._transitioningPageTarget && !this._mainFrame)
+                this._transitioningPageTarget = false;
+            return original.call(this, error, mainFramePayload);
+        };
+    }
+
     function copyText(text) {
         if (navigator.clipboard && navigator.clipboard.writeText) {
             navigator.clipboard.writeText(text).catch(() => {});
@@ -1267,6 +1549,7 @@ fn browser_frontend_host_script() -> &'static str {
             if (window.WI && typeof WI.updateVisibilityState === "function")
                 WI.updateVisibilityState(true);
             installCSSCompatibilityFallbacks();
+            installNetworkManagerCompatibilityFallbacks();
             flushBackendQueue();
         },
         closeWindow() {},
@@ -1385,6 +1668,143 @@ mod tests {
     }
 
     #[test]
+    fn parses_webkit_listing_ids_from_dictionary_keys() {
+        let mut app = Dictionary::new();
+        app.insert(
+            "WIRApplicationNameKey".to_owned(),
+            Value::String("Safari".to_owned()),
+        );
+        app.insert(
+            "WIRApplicationBundleIdentifierKey".to_owned(),
+            Value::String("com.apple.mobilesafari".to_owned()),
+        );
+        app.insert(
+            "WIRIsApplicationActiveKey".to_owned(),
+            Value::Integer(2.into()),
+        );
+        let mut app_dictionary = Dictionary::new();
+        app_dictionary.insert("PID:42".to_owned(), Value::Dictionary(app));
+        let mut app_args = Dictionary::new();
+        app_args.insert(
+            "WIRApplicationDictionaryKey".to_owned(),
+            Value::Dictionary(app_dictionary),
+        );
+
+        let applications = parse_application_list(&app_args);
+        assert_eq!(applications.len(), 1);
+        assert_eq!(applications[0].id, "PID:42");
+        assert_eq!(applications[0].name.as_deref(), Some("Safari"));
+        assert_eq!(
+            applications[0].bundle_identifier.as_deref(),
+            Some("com.apple.mobilesafari")
+        );
+        assert!(applications[0].active);
+
+        let mut page = Dictionary::new();
+        page.insert(
+            "WIRTitleKey".to_owned(),
+            Value::String("Example Domain".to_owned()),
+        );
+        page.insert(
+            "WIRURLKey".to_owned(),
+            Value::String("https://example.com/".to_owned()),
+        );
+        page.insert(
+            "WIRConnectionIdentifierKey".to_owned(),
+            Value::String("existing-connection".to_owned()),
+        );
+        let mut listing = Dictionary::new();
+        listing.insert("7".to_owned(), Value::Dictionary(page));
+        let mut page_args = Dictionary::new();
+        page_args.insert(
+            "WIRApplicationIdentifierKey".to_owned(),
+            Value::String("PID:42".to_owned()),
+        );
+        page_args.insert("WIRListingKey".to_owned(), Value::Dictionary(listing));
+
+        let pages = parse_page_listing(&page_args);
+        assert_eq!(pages.len(), 1);
+        assert_eq!(pages[0].app_id, "PID:42");
+        assert_eq!(pages[0].page_id, 7);
+        assert_eq!(pages[0].url.as_deref(), Some("https://example.com/"));
+        assert_eq!(
+            pages[0].connection_id.as_deref(),
+            Some("existing-connection")
+        );
+    }
+
+    #[test]
+    fn page_listing_replaces_previous_pages_for_application() {
+        let mut pages = BTreeMap::new();
+        pages.insert(
+            ("PID:42".to_owned(), 1),
+            WebKitPage {
+                app_id: "PID:42".to_owned(),
+                page_id: 1,
+                title: Some("Old Example".to_owned()),
+                url: Some("https://example.com/old".to_owned()),
+                connection_id: None,
+            },
+        );
+        pages.insert(
+            ("PID:99".to_owned(), 1),
+            WebKitPage {
+                app_id: "PID:99".to_owned(),
+                page_id: 1,
+                title: Some("Other App".to_owned()),
+                url: Some("https://other.example/".to_owned()),
+                connection_id: None,
+            },
+        );
+
+        let mut page = Dictionary::new();
+        page.insert(
+            "WIRTitleKey".to_owned(),
+            Value::String("Example Domain".to_owned()),
+        );
+        page.insert(
+            "WIRURLKey".to_owned(),
+            Value::String("https://example.com/".to_owned()),
+        );
+        let mut listing = Dictionary::new();
+        listing.insert("2".to_owned(), Value::Dictionary(page));
+        let mut listing_args = Dictionary::new();
+        listing_args.insert(
+            "WIRApplicationIdentifierKey".to_owned(),
+            Value::String("PID:42".to_owned()),
+        );
+        listing_args.insert("WIRListingKey".to_owned(), Value::Dictionary(listing));
+
+        apply_page_listing(&mut pages, &listing_args);
+
+        assert!(!pages.contains_key(&("PID:42".to_owned(), 1)));
+        assert!(pages.contains_key(&("PID:42".to_owned(), 2)));
+        assert!(pages.contains_key(&("PID:99".to_owned(), 1)));
+    }
+
+    #[test]
+    fn webkit_target_uses_application_activity_and_bundle_kind() {
+        let app = WebKitApplication {
+            id: "PID:42".to_owned(),
+            name: None,
+            bundle_identifier: Some("com.apple.mobilesafari".to_owned()),
+            active: true,
+            is_proxy: false,
+        };
+        let page = WebKitPage {
+            app_id: app.id.clone(),
+            page_id: 7,
+            title: Some("Example Domain".to_owned()),
+            url: Some("https://example.com/".to_owned()),
+            connection_id: None,
+        };
+
+        let target = webkit_target("UDID", "http://127.0.0.1:4311", page, Some(&app));
+        assert_eq!(target.kind, "safari-page");
+        assert!(target.app_active);
+    }
+
+    #[test]
     fn inject_frontend_host_precedes_main_script() {
         let html = r#"<script src="CodeMirror.js"></script>
     <script src="Main.js"></script>"#;
@@ -1398,19 +1818,89 @@ mod tests {
         assert!(injected.contains("notifySocketState(\"reconnecting\")"));
         assert!(injected.contains("Page.setShowRulers"));
         assert!(injected.contains("maybeHandleUnsupportedFrontendCommand(message)"));
+        assert!(injected.contains("installNetworkManagerCompatibilityFallbacks()"));
     }
 
     #[test]
     fn webkit_attach_uses_page_activation_before_socket_setup() {
         let source = include_str!("webkit.rs");
+        let preflight_index = source
+            .find("prepare_webkit_target_for_attach(")
+            .expect("attach should preflight target ownership before socket setup");
         let indicate_index = source
             .find("send_forward_indicate_webview(")
             .expect("attach should indicate the WebView before socket setup");
         let setup_index = source
             .find("send_forward_socket_setup(")
             .expect("attach should still set up the forwarding socket");
+        assert!(preflight_index < setup_index);
         assert!(indicate_index < setup_index);
         assert!(source.contains("_rpc_forwardIndicateWebView:"));
+        assert!(source.contains("Releasing stale WebKit inspector target owner"));
+    }
+
+    #[test]
+    fn webkit_discovery_requests_connected_applications() {
+        let source = include_str!("webkit.rs");
+        let identifier_index = source
+            .find("\"_rpc_reportIdentifier:\"")
+            .expect("discovery should report a WebKit connection identifier");
+        let connected_applications_index = source
+            .find("send_get_connected_applications(")
+            .expect("discovery should explicitly request connected applications");
+        assert!(identifier_index < connected_applications_index);
+        assert!(source.contains("_rpc_getConnectedApplications:"));
+    }
+
+    #[test]
+    fn incomplete_and_transient_pages_are_not_advertised() {
+        let incomplete_page = WebKitPage {
+            app_id: "PID:1".to_owned(),
+            page_id: 1,
+            title: Some("Safari".to_owned()),
+            url: None,
+            connection_id: None,
+        };
+        let blank_page = WebKitPage {
+            app_id: "PID:1".to_owned(),
+            page_id: 1,
+            title: None,
+            url: Some("about:blank".to_owned()),
+            connection_id: None,
+        };
+        let titled_blank_page = WebKitPage {
+            app_id: "PID:1".to_owned(),
+            page_id: 1,
+            title: Some("Blank".to_owned()),
+            url: Some("about:blank".to_owned()),
+            connection_id: None,
+        };
+        let real_page = WebKitPage {
+            app_id: "PID:1".to_owned(),
+            page_id: 1,
+            title: Some("SimDeck".to_owned()),
+            url: Some("https://simdeck.nativescript.org/".to_owned()),
+            connection_id: None,
+        };
+
+        assert!(is_incomplete_or_transient_page(&incomplete_page));
+        assert!(is_incomplete_or_transient_page(&blank_page));
+        assert!(!is_incomplete_or_transient_page(&titled_blank_page));
+        assert!(!is_incomplete_or_transient_page(&real_page));
+
+        assert!(!is_inspectable_webkit_target(&WebKitTarget {
+            id: "target".to_owned(),
+            app_id: "PID:1".to_owned(),
+            app_name: Some("Safari".to_owned()),
+            app_active: true,
+            page_active: false,
+            page_id: 1,
+            title: Some("Safari".to_owned()),
+            url: None,
+            kind: "safari-page".to_owned(),
+            inspector_url: "/inspector".to_owned(),
+            web_socket_url: "/socket".to_owned(),
+        }));
     }
 
     #[test]

--- a/server/src/webkit.rs
+++ b/server/src/webkit.rs
@@ -23,6 +23,7 @@ const WEBKIT_DISCOVERY_REFRESH_INTERVAL: Duration = Duration::from_millis(400);
 const WEBKIT_DISCOVERY_CACHE_TTL: Duration = Duration::from_secs(120);
 const WEBKIT_SOCKET_ACTIVATION_DELAY: Duration = Duration::from_millis(200);
 const WEBKIT_IO_TIMEOUT: Duration = Duration::from_secs(4);
+const WEBKIT_SOCKET_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(5);
 
 static WEBKIT_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
 static WEBKIT_DISCOVERY_CACHE: OnceLock<Mutex<HashMap<String, CachedWebKitDiscovery>>> =
@@ -408,6 +409,22 @@ async fn attach_websocket_inner(
     )
     .await?;
     sleep(WEBKIT_SOCKET_ACTIVATION_DELAY).await;
+    send_forward_indicate_webview(
+        &mut inspector_writer,
+        &connection_id,
+        &app_id,
+        page_id,
+        true,
+    )
+    .await?;
+    send_forward_indicate_webview(
+        &mut inspector_writer,
+        &connection_id,
+        &app_id,
+        page_id,
+        false,
+    )
+    .await?;
     send_forward_socket_setup(
         &mut inspector_writer,
         &connection_id,
@@ -490,9 +507,9 @@ async fn attach_websocket_inner(
 
 async fn discover_webinspector_socket(udid: &str) -> Result<Option<WebKitSocket>, AppError> {
     let output = timeout(
-        Duration::from_secs(2),
+        WEBKIT_SOCKET_DISCOVERY_TIMEOUT,
         Command::new("/usr/sbin/lsof")
-            .args(["-nP", "-c", "webinspectord", "-F", "pn"])
+            .args(["-nP", "-U", "-F", "pn"])
             .output(),
     )
     .await
@@ -509,7 +526,8 @@ async fn discover_webinspector_socket(udid: &str) -> Result<Option<WebKitSocket>
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let mut processes: HashMap<String, LsofProcess> = HashMap::new();
-    let udid_marker = format!("/Devices/{udid}/");
+    let device_marker = format!("/Devices/{udid}/");
+    let launchd_marker = format!("CoreSimulator.SimDevice.{udid}/");
     let mut current_pid: Option<String> = None;
     for line in stdout.lines() {
         if let Some(pid) = line.strip_prefix('p') {
@@ -524,7 +542,7 @@ async fn discover_webinspector_socket(udid: &str) -> Result<Option<WebKitSocket>
             continue;
         };
         let process = processes.entry(pid.clone()).or_default();
-        if name.contains(&udid_marker) {
+        if name.contains(&device_marker) || name.contains(&launchd_marker) {
             process.belongs_to_udid = true;
         }
         if name.ends_with(WEBINSPECTORD_SOCKET_NAME) {
@@ -552,7 +570,7 @@ async fn discover_launchd_webinspector_socket(
     udid: &str,
 ) -> Result<Option<WebKitSocket>, AppError> {
     let output = match timeout(
-        Duration::from_secs(2),
+        WEBKIT_SOCKET_DISCOVERY_TIMEOUT,
         Command::new("xcrun")
             .args([
                 "simctl",
@@ -619,6 +637,26 @@ async fn send_forward_get_listing<W: AsyncWrite + Unpin>(
         Value::String(app_id.to_owned()),
     );
     send_rpc(writer, "_rpc_forwardGetListing:", args).await
+}
+
+async fn send_forward_indicate_webview<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    connection_id: &str,
+    app_id: &str,
+    page_id: u64,
+    enabled: bool,
+) -> Result<(), AppError> {
+    let mut args = rpc_args(connection_id);
+    args.insert(
+        "WIRApplicationIdentifierKey".to_owned(),
+        Value::String(app_id.to_owned()),
+    );
+    args.insert(
+        "WIRPageIdentifierKey".to_owned(),
+        Value::Integer(page_id.into()),
+    );
+    args.insert("WIRIndicateEnabledKey".to_owned(), Value::Boolean(enabled));
+    send_rpc(writer, "_rpc_forwardIndicateWebView:", args).await
 }
 
 async fn send_forward_socket_setup<W: AsyncWrite + Unpin>(
@@ -951,12 +989,14 @@ pub fn webkit_inspector_ui_root() -> Option<PathBuf> {
 
 pub fn inject_frontend_host(main_html: &str) -> String {
     let localized_strings = r#"<script src="en.lproj/localizedStrings.js"></script>"#;
+    let localized_string_fixups =
+        r#"<script>localizedStrings["Refresh layers"] ||= "Refresh layers";</script>"#;
     let compatibility_style = format!("<style>{}</style>", browser_frontend_compatibility_css());
     let shim = format!("<script>{}</script>", browser_frontend_host_script());
     main_html.replacen(
         "<script src=\"Main.js\"></script>",
         &format!(
-            "{localized_strings}\n    {compatibility_style}\n    {shim}\n    <script src=\"Main.js\"></script>"
+            "{localized_strings}\n    {localized_string_fixups}\n    {compatibility_style}\n    {shim}\n    <script src=\"Main.js\"></script>"
         ),
         1,
     )
@@ -1044,6 +1084,29 @@ fn browser_frontend_host_script() -> &'static str {
             dispatchBackendMessage(message);
     }
 
+    function installCSSCompatibilityFallbacks() {
+        const cssManager = window.WI?.cssManager;
+        if (!cssManager || cssManager.propertyNameCompletions || !window.WI?.CSSPropertyNameCompletions)
+            return;
+
+        const propertyMap = window.WI.CSSKeywordCompletions?._propertyKeywordMap || {};
+        const propertyNames = new Set(Object.keys(propertyMap));
+        for (const name of [
+            "background",
+            "color",
+            "display",
+            "font-family",
+            "height",
+            "margin",
+            "width",
+        ])
+            propertyNames.add(name);
+
+        cssManager._propertyNameCompletions = new WI.CSSPropertyNameCompletions(
+            Array.from(propertyNames, (name) => ({ name }))
+        );
+    }
+
     function copyText(text) {
         if (navigator.clipboard && navigator.clipboard.writeText) {
             navigator.clipboard.writeText(text).catch(() => {});
@@ -1064,6 +1127,15 @@ fn browser_frontend_host_script() -> &'static str {
     let reconnectTimer = 0;
     let socket = null;
 
+    function notifySocketState(state) {
+        if (window.parent === window)
+            return;
+        window.parent.postMessage({
+            type: "simdeck:webkit-inspector:socket",
+            state,
+        }, "*");
+    }
+
     function clearReconnectTimer() {
         if (!reconnectTimer)
             return;
@@ -1072,8 +1144,13 @@ fn browser_frontend_host_script() -> &'static str {
     }
 
     function scheduleReconnect() {
-        if (reconnectTimer || !websocketUrl())
+        if (reconnectTimer)
             return;
+        if (!websocketUrl()) {
+            notifySocketState("disconnected");
+            return;
+        }
+        notifySocketState("reconnecting");
         const delay = reconnectDelay;
         reconnectDelay = Math.min(Math.ceil(reconnectDelay * 1.5), 3000);
         reconnectTimer = setTimeout(() => {
@@ -1095,6 +1172,7 @@ fn browser_frontend_host_script() -> &'static str {
         if (socket && (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING))
             return;
         clearReconnectTimer();
+        notifySocketState("connecting");
         const nextSocket = new WebSocket(url);
         socket = nextSocket;
         nextSocket.addEventListener("message", (event) => dispatchBackendMessage(event.data));
@@ -1102,6 +1180,7 @@ fn browser_frontend_host_script() -> &'static str {
             if (socket !== nextSocket)
                 return;
             reconnectDelay = 500;
+            notifySocketState("connected");
             while (pendingMessages.length)
                 nextSocket.send(pendingMessages.shift());
         });
@@ -1111,7 +1190,53 @@ fn browser_frontend_host_script() -> &'static str {
             socket = null;
             scheduleReconnect();
         });
-        nextSocket.addEventListener("error", (event) => console.error("SimDeck WebKit Inspector socket error", event));
+        nextSocket.addEventListener("error", (event) => {
+            if (socket === nextSocket)
+                notifySocketState("failed");
+            console.error("SimDeck WebKit Inspector socket error", event);
+        });
+    }
+
+    const unsupportedOptionalTargetCommands = new Set([
+        "Page.setShowRulers",
+    ]);
+
+    function maybeHandleUnsupportedFrontendCommand(message) {
+        let payload;
+        try {
+            payload = JSON.parse(message);
+        } catch {
+            return false;
+        }
+
+        if (unsupportedOptionalTargetCommands.has(payload.method)) {
+            dispatchBackendMessage(JSON.stringify({ id: payload.id, result: {} }));
+            return true;
+        }
+
+        if (payload.method !== "Target.sendMessageToTarget" || !payload.params)
+            return false;
+        const targetId = payload.params.targetId;
+        if (!targetId || typeof payload.params.message !== "string")
+            return false;
+
+        let targetPayload;
+        try {
+            targetPayload = JSON.parse(payload.params.message);
+        } catch {
+            return false;
+        }
+        if (!unsupportedOptionalTargetCommands.has(targetPayload.method))
+            return false;
+
+        dispatchBackendMessage(JSON.stringify({
+            method: "Target.dispatchMessageFromTarget",
+            params: {
+                targetId,
+                message: JSON.stringify({ id: targetPayload.id, result: {} }),
+            },
+        }));
+        return true;
     }
 
     window.InspectorFrontendHost = {
@@ -1134,13 +1259,14 @@ fn browser_frontend_host_script() -> &'static str {
         platformVersionName: "",
         supportsDiagnosticLogging: false,
         supportsWebExtensions: false,
-        localizedStringsURL: "en.lproj/localizedStrings.js",
+        localizedStringsURL: null,
         connect() {
             connectSocket();
         },
         loaded() {
             if (window.WI && typeof WI.updateVisibilityState === "function")
                 WI.updateVisibilityState(true);
+            installCSSCompatibilityFallbacks();
             flushBackendQueue();
         },
         closeWindow() {},
@@ -1187,6 +1313,8 @@ fn browser_frontend_host_script() -> &'static str {
             event.target?.dispatchEvent(new MouseEvent("contextmenu", event));
         },
         sendMessageToBackend(message) {
+            if (maybeHandleUnsupportedFrontendCommand(message))
+                return;
             if (socket && socket.readyState === WebSocket.OPEN) {
                 socket.send(message);
             } else {
@@ -1266,6 +1394,23 @@ mod tests {
         let main_index = injected.find(r#"<script src="Main.js"></script>"#).unwrap();
         assert!(strings_index < shim_index);
         assert!(shim_index < main_index);
+        assert!(injected.contains("simdeck:webkit-inspector:socket"));
+        assert!(injected.contains("notifySocketState(\"reconnecting\")"));
+        assert!(injected.contains("Page.setShowRulers"));
+        assert!(injected.contains("maybeHandleUnsupportedFrontendCommand(message)"));
+    }
+
+    #[test]
+    fn webkit_attach_uses_page_activation_before_socket_setup() {
+        let source = include_str!("webkit.rs");
+        let indicate_index = source
+            .find("send_forward_indicate_webview(")
+            .expect("attach should indicate the WebView before socket setup");
+        let setup_index = source
+            .find("send_forward_socket_setup(")
+            .expect("attach should still set up the forwarding socket");
+        assert!(indicate_index < setup_index);
+        assert!(source.contains("_rpc_forwardIndicateWebView:"));
     }
 
     #[test]
@@ -1282,6 +1427,16 @@ mod tests {
                 "/private/var/tmp/com.apple.launchd.test/other.socket"
             ),
             None
+        );
+    }
+
+    #[test]
+    fn simulator_launchd_socket_marker_matches_udid() {
+        let udid = "2B3B4CA8-6F57-44D8-8AAE-1394456282B7";
+        let launchd_marker = format!("CoreSimulator.SimDevice.{udid}/");
+        assert!(
+            "/private/var/tmp/com.apple.CoreSimulator.SimDevice.2B3B4CA8-6F57-44D8-8AAE-1394456282B7/syslogsock"
+                .contains(&launchd_marker)
         );
     }
 }


### PR DESCRIPTION
## Summary
- Keep WebKit inspector attachments alive by using a more reliable socket discovery path and the missing page-activation handshake before socket setup.
- Surface daemon/provider disconnects as a stable `Not connected` state in the accessibility and devtools panels instead of flickering load/error states.
- Block Chrome DevTools in Safari with a clear message and stop advertising app inspectors as CDP targets.
- Patch WebInspectorUI compatibility gaps for the browser-hosted inspector so it renders consistently without spurious frontend errors.

## Testing
- `cargo test --manifest-path server/Cargo.toml webkit`
- `cargo clippy --manifest-path server/Cargo.toml --all-targets -- -D warnings`
- `npm run build:cli`
- `npm run build:client`
- Playwright E2E on `http://127.0.0.1:4310/`: opened WebKit DevTools for Safari, confirmed DOM protocol completion and a stable inspector WebSocket over a 60s hold, and verified the panel did not fall back to reconnecting/loading states.