### PR TITLE
feat(simulators): add native simulator creation flow for iOS and Android

### DIFF
--- a/cli/XCWSimctl.h
+++ b/cli/XCWSimctl.h
@@ -5,6 +5,14 @@ NS_ASSUME_NONNULL_BEGIN
 @interface XCWSimctl : NSObject
 
 - (nullable NSArray<NSDictionary *> *)listSimulatorsWithError:(NSError * _Nullable * _Nullable)error;
+- (nullable NSDictionary *)simulatorCreationOptionsWithError:(NSError * _Nullable * _Nullable)error;
+- (nullable NSDictionary *)createSimulatorWithName:(NSString *)name
+                              deviceTypeIdentifier:(NSString *)deviceTypeIdentifier
+                                 runtimeIdentifier:(nullable NSString *)runtimeIdentifier
+                                   pairedWatchName:(nullable NSString *)pairedWatchName
+                   pairedWatchDeviceTypeIdentifier:(nullable NSString *)pairedWatchDeviceTypeIdentifier
+                      pairedWatchRuntimeIdentifier:(nullable NSString *)pairedWatchRuntimeIdentifier
+                                             error:(NSError * _Nullable * _Nullable)error;
 - (BOOL)bootSimulatorWithUDID:(NSString *)udid error:(NSError * _Nullable * _Nullable)error;
 - (BOOL)shutdownSimulatorWithUDID:(NSString *)udid error:(NSError * _Nullable * _Nullable)error;
 - (BOOL)toggleAppearanceForSimulatorUDID:(NSString *)udid error:(NSError * _Nullable * _Nullable)error;

--- a/cli/XCWSimctl.m
+++ b/cli/XCWSimctl.m
@@ -9,11 +9,16 @@ static NSString * const XCWSimctlErrorDomain = @"SimDeck.Simctl";
 
 @interface XCWSimctl ()
 
+- (nullable NSString *)createSingleSimulatorWithName:(NSString *)name
+                                deviceTypeIdentifier:(NSString *)deviceTypeIdentifier
+                                   runtimeIdentifier:(nullable NSString *)runtimeIdentifier
+                                               error:(NSError * _Nullable __autoreleasing *)error;
 + (nullable XCWProcessResult *)runSimctl:(NSArray<NSString *> *)arguments
                                    error:(NSError * _Nullable __autoreleasing *)error;
 + (nullable XCWProcessResult *)runSimctl:(NSArray<NSString *> *)arguments
                               timeoutSec:(NSTimeInterval)timeoutSec
                                    error:(NSError * _Nullable __autoreleasing *)error;
++ (nullable NSDictionary *)listJSONPayloadWithError:(NSError * _Nullable __autoreleasing *)error;
 
 @end
 
@@ -32,6 +37,10 @@ static NSArray *XCWArrayPayload(id payload, NSString *nestedKey) {
 
 static NSString *XCWStringValue(id value) {
     return [value isKindOfClass:[NSString class]] ? value : @"";
+}
+
+static NSNumber *XCWNumberValue(id value) {
+    return [value isKindOfClass:[NSNumber class]] ? value : nil;
 }
 
 static NSString *XCWRuntimeDisplayName(NSDictionary *runtime, NSString *runtimeIdentifier) {
@@ -64,22 +73,8 @@ static NSString *XCWRuntimeDisplayName(NSDictionary *runtime, NSString *runtimeI
 @implementation XCWSimctl
 
 - (nullable NSArray<NSDictionary *> *)listSimulatorsWithError:(NSError * _Nullable __autoreleasing *)error {
-    XCWProcessResult *result = [self.class runSimctl:@[@"list", @"--json"] error:error];
-    if (result == nil) {
-        return nil;
-    }
-    if (result.terminationStatus != 0) {
-        if (error != NULL) {
-            *error = [self.class errorWithDescription:result.stderrString.length > 0 ? result.stderrString : @"simctl list failed" code:1];
-        }
-        return nil;
-    }
-
-    NSDictionary *payload = [NSJSONSerialization JSONObjectWithData:result.stdoutData options:0 error:error];
-    if (![payload isKindOfClass:[NSDictionary class]]) {
-        if (error != NULL && *error == nil) {
-            *error = [self.class errorWithDescription:@"Unable to parse simctl JSON output." code:2];
-        }
+    NSDictionary *payload = [self.class listJSONPayloadWithError:error];
+    if (payload == nil) {
         return nil;
     }
 
@@ -166,6 +161,230 @@ static NSString *XCWRuntimeDisplayName(NSDictionary *runtime, NSString *runtimeI
     }];
 
     return flattened;
+}
+
+- (nullable NSDictionary *)simulatorCreationOptionsWithError:(NSError * _Nullable __autoreleasing *)error {
+    NSDictionary *payload = [self.class listJSONPayloadWithError:error];
+    if (payload == nil) {
+        return nil;
+    }
+
+    NSArray *runtimeArray = XCWArrayPayload(payload[@"runtimes"], @"runtimes");
+    NSMutableArray<NSDictionary *> *runtimes = [NSMutableArray array];
+    NSMutableDictionary<NSString *, NSMutableArray<NSString *> *> *runtimeIdentifiersByDeviceType = [NSMutableDictionary dictionary];
+
+    for (NSDictionary *runtime in runtimeArray) {
+        if (![runtime isKindOfClass:[NSDictionary class]]) {
+            continue;
+        }
+
+        NSString *identifier = XCWStringValue(runtime[@"identifier"]);
+        if (identifier.length == 0) {
+            continue;
+        }
+
+        BOOL isAvailable = [runtime[@"isAvailable"] respondsToSelector:@selector(boolValue)] ? [runtime[@"isAvailable"] boolValue] : YES;
+        if (!isAvailable) {
+            continue;
+        }
+
+        NSMutableArray<NSString *> *supportedDeviceTypeIdentifiers = [NSMutableArray array];
+        NSArray *supportedDeviceTypes = XCWArrayPayload(runtime[@"supportedDeviceTypes"], @"supportedDeviceTypes");
+        for (NSDictionary *deviceType in supportedDeviceTypes) {
+            if (![deviceType isKindOfClass:[NSDictionary class]]) {
+                continue;
+            }
+            NSString *deviceTypeIdentifier = XCWStringValue(deviceType[@"identifier"]);
+            if (deviceTypeIdentifier.length == 0) {
+                continue;
+            }
+            [supportedDeviceTypeIdentifiers addObject:deviceTypeIdentifier];
+            NSMutableArray<NSString *> *runtimeIdentifiers = runtimeIdentifiersByDeviceType[deviceTypeIdentifier];
+            if (runtimeIdentifiers == nil) {
+                runtimeIdentifiers = [NSMutableArray array];
+                runtimeIdentifiersByDeviceType[deviceTypeIdentifier] = runtimeIdentifiers;
+            }
+            [runtimeIdentifiers addObject:identifier];
+        }
+
+        NSMutableDictionary *entry = [NSMutableDictionary dictionary];
+        entry[@"identifier"] = identifier;
+        entry[@"name"] = XCWRuntimeDisplayName(runtime, identifier);
+        entry[@"isAvailable"] = @YES;
+        entry[@"supportedDeviceTypeIdentifiers"] = supportedDeviceTypeIdentifiers;
+
+        NSString *platform = XCWStringValue(runtime[@"platform"]);
+        if (platform.length > 0) {
+            entry[@"platform"] = platform;
+        }
+        NSString *version = XCWStringValue(runtime[@"version"]);
+        if (version.length > 0) {
+            entry[@"version"] = version;
+        }
+        NSString *buildVersion = XCWStringValue(runtime[@"buildversion"]);
+        if (buildVersion.length > 0) {
+            entry[@"buildVersion"] = buildVersion;
+        }
+
+        [runtimes addObject:entry];
+    }
+
+    NSArray *deviceTypesArray = XCWArrayPayload(payload[@"devicetypes"], @"devicetypes");
+    NSMutableArray<NSDictionary *> *deviceTypes = [NSMutableArray array];
+    for (NSDictionary *deviceType in deviceTypesArray) {
+        if (![deviceType isKindOfClass:[NSDictionary class]]) {
+            continue;
+        }
+
+        NSString *identifier = XCWStringValue(deviceType[@"identifier"]);
+        if (identifier.length == 0) {
+            continue;
+        }
+        NSArray<NSString *> *supportedRuntimeIdentifiers = runtimeIdentifiersByDeviceType[identifier];
+        if (supportedRuntimeIdentifiers.count == 0) {
+            continue;
+        }
+
+        NSMutableDictionary *entry = [NSMutableDictionary dictionary];
+        entry[@"identifier"] = identifier;
+        NSString *name = XCWStringValue(deviceType[@"name"]);
+        entry[@"name"] = name.length > 0 ? name : identifier;
+        entry[@"supportedRuntimeIdentifiers"] = supportedRuntimeIdentifiers;
+
+        NSString *productFamily = XCWStringValue(deviceType[@"productFamily"]);
+        if (productFamily.length > 0) {
+            entry[@"productFamily"] = productFamily;
+        }
+        NSString *modelIdentifier = XCWStringValue(deviceType[@"modelIdentifier"]);
+        if (modelIdentifier.length > 0) {
+            entry[@"modelIdentifier"] = modelIdentifier;
+        }
+        NSString *minRuntimeVersionString = XCWStringValue(deviceType[@"minRuntimeVersionString"]);
+        if (minRuntimeVersionString.length > 0) {
+            entry[@"minRuntimeVersionString"] = minRuntimeVersionString;
+        }
+        NSString *maxRuntimeVersionString = XCWStringValue(deviceType[@"maxRuntimeVersionString"]);
+        if (maxRuntimeVersionString.length > 0) {
+            entry[@"maxRuntimeVersionString"] = maxRuntimeVersionString;
+        }
+        NSNumber *minRuntimeVersion = XCWNumberValue(deviceType[@"minRuntimeVersion"]);
+        if (minRuntimeVersion != nil) {
+            entry[@"minRuntimeVersion"] = minRuntimeVersion;
+        }
+        NSNumber *maxRuntimeVersion = XCWNumberValue(deviceType[@"maxRuntimeVersion"]);
+        if (maxRuntimeVersion != nil) {
+            entry[@"maxRuntimeVersion"] = maxRuntimeVersion;
+        }
+
+        [deviceTypes addObject:entry];
+    }
+
+    return @{
+        @"deviceTypes": deviceTypes,
+        @"runtimes": runtimes,
+    };
+}
+
+- (nullable NSDictionary *)createSimulatorWithName:(NSString *)name
+                              deviceTypeIdentifier:(NSString *)deviceTypeIdentifier
+                                 runtimeIdentifier:(nullable NSString *)runtimeIdentifier
+                                   pairedWatchName:(nullable NSString *)pairedWatchName
+                   pairedWatchDeviceTypeIdentifier:(nullable NSString *)pairedWatchDeviceTypeIdentifier
+                      pairedWatchRuntimeIdentifier:(nullable NSString *)pairedWatchRuntimeIdentifier
+                                             error:(NSError * _Nullable __autoreleasing *)error {
+    NSString *primaryUDID = [self createSingleSimulatorWithName:name
+                                           deviceTypeIdentifier:deviceTypeIdentifier
+                                              runtimeIdentifier:runtimeIdentifier
+                                                          error:error];
+    if (primaryUDID.length == 0) {
+        return nil;
+    }
+
+    NSMutableDictionary *result = [@{
+        @"udid": primaryUDID,
+    } mutableCopy];
+
+    NSString *watchName = [pairedWatchName stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+    NSString *watchDeviceTypeIdentifier = [pairedWatchDeviceTypeIdentifier stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+    if (watchName.length == 0 && watchDeviceTypeIdentifier.length == 0) {
+        return result;
+    }
+    if (watchName.length == 0 || watchDeviceTypeIdentifier.length == 0) {
+        if (error != NULL) {
+            *error = [self.class errorWithDescription:@"Paired watch creation requires both a watch name and device type." code:23];
+        }
+        return nil;
+    }
+
+    NSString *watchUDID = [self createSingleSimulatorWithName:watchName
+                                         deviceTypeIdentifier:watchDeviceTypeIdentifier
+                                            runtimeIdentifier:pairedWatchRuntimeIdentifier
+                                                        error:error];
+    if (watchUDID.length == 0) {
+        return nil;
+    }
+
+    XCWProcessResult *pairResult = [self.class runSimctl:@[@"pair", watchUDID, primaryUDID]
+                                             timeoutSec:120
+                                                  error:error];
+    if (pairResult == nil) {
+        return nil;
+    }
+    if (pairResult.terminationStatus != 0) {
+        if (error != NULL) {
+            *error = [self.class errorWithDescription:pairResult.stderrString.length > 0 ? pairResult.stderrString : @"Unable to pair watch simulator." code:24];
+        }
+        return nil;
+    }
+
+    result[@"pairedWatchUDID"] = watchUDID;
+    return result;
+}
+
+- (nullable NSString *)createSingleSimulatorWithName:(NSString *)name
+                                deviceTypeIdentifier:(NSString *)deviceTypeIdentifier
+                                   runtimeIdentifier:(nullable NSString *)runtimeIdentifier
+                                               error:(NSError * _Nullable __autoreleasing *)error {
+    NSString *trimmedName = [name stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+    NSString *trimmedDeviceTypeIdentifier = [deviceTypeIdentifier stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+    NSString *trimmedRuntimeIdentifier = [runtimeIdentifier stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+    if (trimmedName.length == 0) {
+        if (error != NULL) {
+            *error = [self.class errorWithDescription:@"Simulator name is required." code:19];
+        }
+        return nil;
+    }
+    if (trimmedDeviceTypeIdentifier.length == 0) {
+        if (error != NULL) {
+            *error = [self.class errorWithDescription:@"Device type identifier is required." code:20];
+        }
+        return nil;
+    }
+
+    NSMutableArray<NSString *> *arguments = [@[@"create", trimmedName, trimmedDeviceTypeIdentifier] mutableCopy];
+    if (trimmedRuntimeIdentifier.length > 0) {
+        [arguments addObject:trimmedRuntimeIdentifier];
+    }
+
+    XCWProcessResult *result = [self.class runSimctl:arguments timeoutSec:120 error:error];
+    if (result == nil) {
+        return nil;
+    }
+    if (result.terminationStatus != 0) {
+        if (error != NULL) {
+            *error = [self.class errorWithDescription:result.stderrString.length > 0 ? result.stderrString : @"Unable to create simulator." code:21];
+        }
+        return nil;
+    }
+
+    NSString *udid = [result.stdoutString stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+    if (udid.length == 0) {
+        if (error != NULL) {
+            *error = [self.class errorWithDescription:@"simctl create did not return a simulator UDID." code:22];
+        }
+        return nil;
+    }
+    return udid;
 }
 
 - (nullable NSDictionary *)simulatorWithUDID:(NSString *)udid error:(NSError * _Nullable __autoreleasing *)error {
@@ -445,6 +664,28 @@ static NSString *XCWRuntimeDisplayName(NSDictionary *runtime, NSString *runtimeI
 + (nullable XCWProcessResult *)runSimctl:(NSArray<NSString *> *)arguments
                                    error:(NSError * _Nullable __autoreleasing *)error {
     return [self runSimctl:arguments timeoutSec:0 error:error];
+}
+
++ (nullable NSDictionary *)listJSONPayloadWithError:(NSError * _Nullable __autoreleasing *)error {
+    XCWProcessResult *result = [self runSimctl:@[@"list", @"--json"] error:error];
+    if (result == nil) {
+        return nil;
+    }
+    if (result.terminationStatus != 0) {
+        if (error != NULL) {
+            *error = [self errorWithDescription:result.stderrString.length > 0 ? result.stderrString : @"simctl list failed" code:1];
+        }
+        return nil;
+    }
+
+    NSDictionary *payload = [NSJSONSerialization JSONObjectWithData:result.stdoutData options:0 error:error];
+    if (![payload isKindOfClass:[NSDictionary class]]) {
+        if (error != NULL && *error == nil) {
+            *error = [self errorWithDescription:@"Unable to parse simctl JSON output." code:2];
+        }
+        return nil;
+    }
+    return payload;
 }
 
 + (nullable XCWProcessResult *)runSimctl:(NSArray<NSString *> *)arguments

--- a/cli/XCWSimctl.m
+++ b/cli/XCWSimctl.m
@@ -107,6 +107,54 @@ static NSString *XCWRuntimeDisplayName(NSDictionary *runtime, NSString *runtimeI
     if (![devicesByRuntime isKindOfClass:[NSDictionary class]]) {
         devicesByRuntime = @{};
     }
+    NSMutableDictionary<NSString *, NSDictionary *> *pairInfoByDeviceUDID = [NSMutableDictionary dictionary];
+    NSDictionary *pairs = payload[@"pairs"];
+    if ([pairs isKindOfClass:[NSDictionary class]]) {
+        [pairs enumerateKeysAndObjectsUsingBlock:^(id pairIdentifierValue, id pairValue, __unused BOOL *stop) {
+            if (![pairValue isKindOfClass:[NSDictionary class]]) {
+                return;
+            }
+            NSDictionary *pair = (NSDictionary *)pairValue;
+            NSDictionary *phone = [pair[@"phone"] isKindOfClass:[NSDictionary class]] ? pair[@"phone"] : nil;
+            NSDictionary *watch = [pair[@"watch"] isKindOfClass:[NSDictionary class]] ? pair[@"watch"] : nil;
+            NSString *phoneUDID = XCWStringValue(phone[@"udid"]);
+            NSString *watchUDID = XCWStringValue(watch[@"udid"]);
+            if (phoneUDID.length == 0 || watchUDID.length == 0) {
+                return;
+            }
+
+            NSString *pairIdentifier = XCWStringValue(pairIdentifierValue);
+            NSString *pairState = XCWStringValue(pair[@"state"]);
+            NSString *phoneName = XCWStringValue(phone[@"name"]);
+            NSString *watchName = XCWStringValue(watch[@"name"]);
+
+            NSMutableDictionary *phonePairInfo = [NSMutableDictionary dictionary];
+            phonePairInfo[@"pairedWatchUDID"] = watchUDID;
+            if (watchName.length > 0) {
+                phonePairInfo[@"pairedWatchName"] = watchName;
+            }
+            if (pairIdentifier.length > 0) {
+                phonePairInfo[@"devicePairIdentifier"] = pairIdentifier;
+            }
+            if (pairState.length > 0) {
+                phonePairInfo[@"devicePairState"] = pairState;
+            }
+            pairInfoByDeviceUDID[phoneUDID] = phonePairInfo;
+
+            NSMutableDictionary *watchPairInfo = [NSMutableDictionary dictionary];
+            watchPairInfo[@"pairedPhoneUDID"] = phoneUDID;
+            if (phoneName.length > 0) {
+                watchPairInfo[@"pairedPhoneName"] = phoneName;
+            }
+            if (pairIdentifier.length > 0) {
+                watchPairInfo[@"devicePairIdentifier"] = pairIdentifier;
+            }
+            if (pairState.length > 0) {
+                watchPairInfo[@"devicePairState"] = pairState;
+            }
+            pairInfoByDeviceUDID[watchUDID] = watchPairInfo;
+        }];
+    }
     [devicesByRuntime enumerateKeysAndObjectsUsingBlock:^(NSString *runtimeIdentifier, NSArray *devices, __unused BOOL *stop) {
         if (![devices isKindOfClass:[NSArray class]]) {
             return;
@@ -124,7 +172,7 @@ static NSString *XCWRuntimeDisplayName(NSDictionary *runtime, NSString *runtimeI
             NSString *state = device[@"state"] ?: @"Unknown";
             BOOL isAvailable = [device[@"isAvailable"] respondsToSelector:@selector(boolValue)] ? [device[@"isAvailable"] boolValue] : YES;
 
-            [flattened addObject:@{
+            NSMutableDictionary *entry = [@{
                 @"udid": udid,
                 @"name": device[@"name"] ?: @"Unknown Simulator",
                 @"state": state,
@@ -137,7 +185,12 @@ static NSString *XCWRuntimeDisplayName(NSDictionary *runtime, NSString *runtimeI
                 @"deviceTypeName": deviceType[@"name"] ?: device[@"name"] ?: @"Unknown Simulator",
                 @"runtimeIdentifier": runtimeIdentifier ?: [NSNull null],
                 @"runtimeName": XCWRuntimeDisplayName(runtime, runtimeIdentifier),
-            }];
+            } mutableCopy];
+            NSDictionary *pairInfo = pairInfoByDeviceUDID[udid];
+            if (pairInfo != nil) {
+                [entry addEntriesFromDictionary:pairInfo];
+            }
+            [flattened addObject:entry];
         }
     }];
 

--- a/cli/native/XCWNativeBridge.h
+++ b/cli/native/XCWNativeBridge.h
@@ -34,6 +34,14 @@ void xcw_native_initialize_app(void);
 void xcw_native_run_main_loop_slice(double duration_seconds);
 
 char * _Nullable xcw_native_list_simulators(char * _Nullable * _Nullable error_message);
+char * _Nullable xcw_native_simulator_creation_options(char * _Nullable * _Nullable error_message);
+char * _Nullable xcw_native_create_simulator(const char * _Nonnull name,
+                                             const char * _Nonnull device_type_identifier,
+                                             const char * _Nullable runtime_identifier,
+                                             const char * _Nullable paired_watch_name,
+                                             const char * _Nullable paired_watch_device_type_identifier,
+                                             const char * _Nullable paired_watch_runtime_identifier,
+                                             char * _Nullable * _Nullable error_message);
 bool xcw_native_boot_simulator(const char * _Nonnull udid, char * _Nullable * _Nullable error_message);
 bool xcw_native_shutdown_simulator(const char * _Nonnull udid, char * _Nullable * _Nullable error_message);
 bool xcw_native_toggle_appearance(const char * _Nonnull udid, char * _Nullable * _Nullable error_message);

--- a/cli/native/XCWNativeBridge.m
+++ b/cli/native/XCWNativeBridge.m
@@ -367,6 +367,44 @@ char *xcw_native_list_simulators(char **error_message) {
     }
 }
 
+char *xcw_native_simulator_creation_options(char **error_message) {
+    @autoreleasepool {
+        XCWSimctl *simctl = [[XCWSimctl alloc] init];
+        NSError *error = nil;
+        NSDictionary *options = [simctl simulatorCreationOptionsWithError:&error];
+        if (options == nil) {
+            XCWSetErrorMessage(error_message, error);
+            return NULL;
+        }
+        return XCWJSONStringFromObject(options, error_message);
+    }
+}
+
+char *xcw_native_create_simulator(const char *name,
+                                  const char *device_type_identifier,
+                                  const char *runtime_identifier,
+                                  const char *paired_watch_name,
+                                  const char *paired_watch_device_type_identifier,
+                                  const char *paired_watch_runtime_identifier,
+                                  char **error_message) {
+    @autoreleasepool {
+        XCWSimctl *simctl = [[XCWSimctl alloc] init];
+        NSError *error = nil;
+        NSDictionary *result = [simctl createSimulatorWithName:XCWStringFromCString(name)
+                                          deviceTypeIdentifier:XCWStringFromCString(device_type_identifier)
+                                             runtimeIdentifier:runtime_identifier == NULL ? nil : XCWStringFromCString(runtime_identifier)
+                                               pairedWatchName:paired_watch_name == NULL ? nil : XCWStringFromCString(paired_watch_name)
+                               pairedWatchDeviceTypeIdentifier:paired_watch_device_type_identifier == NULL ? nil : XCWStringFromCString(paired_watch_device_type_identifier)
+                                  pairedWatchRuntimeIdentifier:paired_watch_runtime_identifier == NULL ? nil : XCWStringFromCString(paired_watch_runtime_identifier)
+                                                         error:&error];
+        if (result == nil) {
+            XCWSetErrorMessage(error_message, error);
+            return NULL;
+        }
+        return XCWJSONStringFromObject(result, error_message);
+    }
+}
+
 bool xcw_native_boot_simulator(const char *udid, char **error_message) {
     @autoreleasepool {
         return XCWPerformSimctlAction(error_message, ^BOOL(XCWSimctl *simctl, NSError **error) {

--- a/client/src/api/simulators.ts
+++ b/client/src/api/simulators.ts
@@ -4,9 +4,12 @@ import type {
   AccessibilityTreeResponse,
   ChromeDevToolsTargetDiscovery,
   ChromeProfile,
+  CreateSimulatorRequest,
+  CreateSimulatorResponse,
   InspectorRequestResponse,
   SimulatorPerformanceResponse,
   SimulatorLogsResponse,
+  SimulatorCreateOptionsResponse,
   SimulatorMetadata,
   SimulatorProcessListResponse,
   SimulatorStateResponse,
@@ -20,6 +23,24 @@ export async function listSimulators(
 ): Promise<SimulatorMetadata[]> {
   const data = await apiRequest<SimulatorsResponse>("/api/simulators", options);
   return data.simulators ?? [];
+}
+
+export async function fetchSimulatorCreateOptions(
+  options: RequestInit = {},
+): Promise<SimulatorCreateOptionsResponse> {
+  return apiRequest<SimulatorCreateOptionsResponse>(
+    "/api/simulators/create-options",
+    options,
+  );
+}
+
+export async function createSimulator(
+  payload: CreateSimulatorRequest,
+): Promise<CreateSimulatorResponse> {
+  return apiRequest<CreateSimulatorResponse>("/api/simulators", {
+    body: JSON.stringify(payload),
+    method: "POST",
+  });
 }
 
 export async function fetchChromeProfile(udid: string): Promise<ChromeProfile> {

--- a/client/src/api/types.ts
+++ b/client/src/api/types.ts
@@ -53,6 +53,80 @@ export interface SimulatorsResponse {
   simulators: SimulatorMetadata[];
 }
 
+export interface SimulatorDeviceTypeOption {
+  identifier: string;
+  name: string;
+  productFamily?: string;
+  modelIdentifier?: string;
+  minRuntimeVersion?: number;
+  minRuntimeVersionString?: string;
+  maxRuntimeVersion?: number;
+  maxRuntimeVersionString?: string;
+  supportedRuntimeIdentifiers?: string[];
+}
+
+export interface SimulatorRuntimeOption {
+  identifier: string;
+  name: string;
+  platform?: string;
+  version?: string;
+  buildVersion?: string;
+  isAvailable?: boolean;
+  supportedDeviceTypeIdentifiers?: string[];
+}
+
+export interface AndroidEmulatorDeviceTypeOption {
+  identifier: string;
+  name: string;
+  oem?: string | null;
+  tag?: string | null;
+}
+
+export interface AndroidEmulatorSystemImageOption {
+  identifier: string;
+  name: string;
+  description?: string;
+  apiLevel?: number | null;
+  tag?: string;
+  abi?: string;
+}
+
+export interface AndroidEmulatorCreateOptions {
+  deviceTypes: AndroidEmulatorDeviceTypeOption[];
+  systemImages: AndroidEmulatorSystemImageOption[];
+  unavailableReason?: string;
+}
+
+export interface SimulatorCreateOptionsResponse {
+  deviceTypes: SimulatorDeviceTypeOption[];
+  runtimes: SimulatorRuntimeOption[];
+  android?: AndroidEmulatorCreateOptions;
+}
+
+export interface CreatePairedWatchRequest {
+  name: string;
+  deviceTypeIdentifier: string;
+  runtimeIdentifier?: string;
+}
+
+export interface CreateSimulatorRequest {
+  platform?: "ios" | "android" | string;
+  name: string;
+  deviceTypeIdentifier: string;
+  runtimeIdentifier?: string;
+  pairedWatch?: CreatePairedWatchRequest;
+}
+
+export interface CreateSimulatorResponse {
+  ok: boolean;
+  created: {
+    udid: string;
+    pairedWatchUDID?: string;
+  };
+  simulator: SimulatorMetadata;
+  pairedWatchSimulator?: SimulatorMetadata | null;
+}
+
 export interface WebKitTarget {
   id: string;
   appId: string;

--- a/client/src/api/types.ts
+++ b/client/src/api/types.ts
@@ -40,6 +40,12 @@ export interface SimulatorMetadata {
   runtimeIdentifier?: string;
   deviceTypeName?: string;
   deviceTypeIdentifier?: string;
+  pairedWatchUDID?: string;
+  pairedWatchName?: string;
+  pairedPhoneUDID?: string;
+  pairedPhoneName?: string;
+  devicePairIdentifier?: string;
+  devicePairState?: string;
   isBooted: boolean;
   android?: {
     avdName?: string;

--- a/client/src/app/AppShell.tsx
+++ b/client/src/app/AppShell.tsx
@@ -74,6 +74,7 @@ import type {
   ViewMode,
 } from "../features/viewport/types";
 import { useViewportLayout } from "../features/viewport/useViewportLayout";
+import { NewSimulatorModal } from "../features/simulators/NewSimulatorModal";
 import {
   buildShellRotationTransform,
   clampPan,
@@ -388,6 +389,7 @@ export function AppShell({
     initialUiState.bundleIDValue ?? "com.apple.Preferences",
   );
   const [menuOpen, setMenuOpen] = useState(false);
+  const [newSimulatorOpen, setNewSimulatorOpen] = useState(false);
   const [localError, setLocalError] = useState("");
   const [failedStreamUDIDs, setFailedStreamUDIDs] = useState<Set<string>>(
     () => new Set(),
@@ -2194,6 +2196,20 @@ export function AppShell({
     }
   }
 
+  function handleSimulatorCreated(response: {
+    simulator: SimulatorMetadata;
+    pairedWatchSimulator?: SimulatorMetadata | null;
+  }) {
+    updateSimulator(response.simulator);
+    if (response.pairedWatchSimulator) {
+      updateSimulator(response.pairedWatchSimulator);
+    }
+    setSelectedUDID(response.simulator.udid);
+    setNewSimulatorOpen(false);
+    setLocalError("");
+    void refresh();
+  }
+
   async function submitPairing(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     const code = pairingCode.trim();
@@ -2303,6 +2319,10 @@ export function AppShell({
           }
         }}
         onOpenBundlePrompt={promptForBundleID}
+        onOpenNewSimulator={() => {
+          setMenuOpen(false);
+          setNewSimulatorOpen(true);
+        }}
         onOpenUrlPrompt={promptForURL}
         onRotateRight={() => {
           if (!selectedSimulator) {
@@ -2386,6 +2406,12 @@ export function AppShell({
         )}
         touchOverlayVisible={touchOverlayVisible}
         devToolsVisible={devToolsVisible}
+      />
+      <NewSimulatorModal
+        onClose={() => setNewSimulatorOpen(false)}
+        onCreated={handleSimulatorCreated}
+        open={newSimulatorOpen && !hideSimulatorSelection}
+        selectedSimulator={selectedSimulator}
       />
       <SimulatorViewport
         accessibilityHoveredId={accessibilityHoveredId}

--- a/client/src/features/simulators/NewSimulatorModal.tsx
+++ b/client/src/features/simulators/NewSimulatorModal.tsx
@@ -1,0 +1,758 @@
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+
+import {
+  createSimulator,
+  fetchSimulatorCreateOptions,
+} from "../../api/simulators";
+import type {
+  AndroidEmulatorDeviceTypeOption,
+  AndroidEmulatorSystemImageOption,
+  CreateSimulatorResponse,
+  SimulatorCreateOptionsResponse,
+  SimulatorDeviceTypeOption,
+  SimulatorMetadata,
+  SimulatorRuntimeOption,
+} from "../../api/types";
+
+interface NewSimulatorModalProps {
+  onClose: () => void;
+  onCreated: (response: CreateSimulatorResponse) => void;
+  open: boolean;
+  selectedSimulator: SimulatorMetadata | null;
+}
+
+type ModalStep = "simulator" | "watch";
+type CreationPlatform = "ios" | "android";
+
+export function NewSimulatorModal({
+  onClose,
+  onCreated,
+  open,
+  selectedSimulator,
+}: NewSimulatorModalProps) {
+  const [options, setOptions] = useState<SimulatorCreateOptionsResponse | null>(
+    null,
+  );
+  const [platform, setPlatform] = useState<CreationPlatform>(
+    selectedSimulator?.platform === "android-emulator" ? "android" : "ios",
+  );
+  const [deviceTypeIdentifier, setDeviceTypeIdentifier] = useState("");
+  const [runtimeIdentifier, setRuntimeIdentifier] = useState("");
+  const [name, setName] = useState("");
+  const [nameDirty, setNameDirty] = useState(false);
+  const [androidDeviceTypeIdentifier, setAndroidDeviceTypeIdentifier] =
+    useState("");
+  const [androidSystemImageIdentifier, setAndroidSystemImageIdentifier] =
+    useState("");
+  const [androidName, setAndroidName] = useState("");
+  const [androidNameDirty, setAndroidNameDirty] = useState(false);
+  const [pairedWatch, setPairedWatch] = useState(false);
+  const [watchDeviceTypeIdentifier, setWatchDeviceTypeIdentifier] =
+    useState("");
+  const [watchRuntimeIdentifier, setWatchRuntimeIdentifier] = useState("");
+  const [watchName, setWatchName] = useState("");
+  const [watchNameDirty, setWatchNameDirty] = useState(false);
+  const [step, setStep] = useState<ModalStep>("simulator");
+  const [error, setError] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
+  const selectedDeviceTypeIdentifier =
+    selectedSimulator?.platform === "android-emulator"
+      ? ""
+      : (selectedSimulator?.deviceTypeIdentifier ?? "");
+  const selectedRuntimeIdentifier = selectedSimulator?.runtimeIdentifier ?? "";
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    let cancelled = false;
+    const controller =
+      typeof AbortController !== "undefined" ? new AbortController() : null;
+
+    setError("");
+    setIsLoading(true);
+    setIsCreating(false);
+    setOptions(null);
+    setStep("simulator");
+
+    void fetchSimulatorCreateOptions(
+      controller ? { signal: controller.signal } : {},
+    )
+      .then((nextOptions) => {
+        if (cancelled) {
+          return;
+        }
+        setOptions(nextOptions);
+        const initialPlatform =
+          selectedSimulator?.platform === "android-emulator" ? "android" : "ios";
+        setPlatform(initialPlatform);
+        const initialDeviceType = chooseInitialDeviceType(
+          nextOptions.deviceTypes,
+          selectedDeviceTypeIdentifier,
+        );
+        const initialRuntime = chooseCompatibleRuntime(
+          initialDeviceType?.identifier ?? "",
+          nextOptions,
+          selectedRuntimeIdentifier,
+        );
+        setDeviceTypeIdentifier(initialDeviceType?.identifier ?? "");
+        setRuntimeIdentifier(initialRuntime?.identifier ?? "");
+        setName(initialDeviceType?.name ?? "");
+        setNameDirty(false);
+
+        const initialWatchDeviceType = chooseInitialWatchDeviceType(
+          nextOptions,
+        );
+        const initialWatchRuntime = chooseCompatibleRuntime(
+          initialWatchDeviceType?.identifier ?? "",
+          nextOptions,
+        );
+        setWatchDeviceTypeIdentifier(initialWatchDeviceType?.identifier ?? "");
+        setWatchRuntimeIdentifier(initialWatchRuntime?.identifier ?? "");
+        setWatchName(initialWatchDeviceType?.name ?? "");
+        setWatchNameDirty(false);
+        setPairedWatch(false);
+
+        const initialAndroidDeviceType = chooseInitialAndroidDeviceType(
+          nextOptions,
+          selectedSimulator?.android?.avdName,
+        );
+        const initialAndroidSystemImage =
+          chooseInitialAndroidSystemImage(nextOptions);
+        setAndroidDeviceTypeIdentifier(
+          initialAndroidDeviceType?.identifier ?? "",
+        );
+        setAndroidSystemImageIdentifier(
+          initialAndroidSystemImage?.identifier ?? "",
+        );
+        setAndroidName(
+          initialAndroidDeviceType
+            ? defaultAndroidName(
+                initialAndroidDeviceType,
+                initialAndroidSystemImage,
+              )
+            : "",
+        );
+        setAndroidNameDirty(false);
+      })
+      .catch((loadError) => {
+        if (
+          !cancelled &&
+          !(loadError instanceof DOMException && loadError.name === "AbortError")
+        ) {
+          setError(
+            loadError instanceof Error
+              ? loadError.message
+              : "Failed to load simulator options.",
+          );
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+      controller?.abort();
+    };
+  }, [
+    open,
+    selectedDeviceTypeIdentifier,
+    selectedRuntimeIdentifier,
+    selectedSimulator?.android?.avdName,
+    selectedSimulator?.platform,
+  ]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onClose, open]);
+
+  const selectedDeviceType = options?.deviceTypes.find(
+    (deviceType) => deviceType.identifier === deviceTypeIdentifier,
+  );
+  const androidDeviceTypes = options?.android?.deviceTypes ?? [];
+  const androidSystemImages = options?.android?.systemImages ?? [];
+  const selectedAndroidDeviceType = androidDeviceTypes.find(
+    (deviceType) => deviceType.identifier === androidDeviceTypeIdentifier,
+  );
+  const selectedAndroidSystemImage = androidSystemImages.find(
+    (systemImage) => systemImage.identifier === androidSystemImageIdentifier,
+  );
+  const runtimeOptions = useMemo(
+    () => compatibleRuntimes(deviceTypeIdentifier, options),
+    [deviceTypeIdentifier, options],
+  );
+  const watchDeviceTypes = useMemo(
+    () =>
+      (options?.deviceTypes ?? []).filter(
+        (deviceType) =>
+          isWatchDeviceType(deviceType) &&
+          compatibleRuntimes(deviceType.identifier, options).length > 0,
+      ),
+    [options],
+  );
+  const watchRuntimeOptions = useMemo(
+    () => compatibleRuntimes(watchDeviceTypeIdentifier, options),
+    [options, watchDeviceTypeIdentifier],
+  );
+  const pairedWatchAvailable =
+    selectedDeviceType != null &&
+    isPhoneDeviceType(selectedDeviceType) &&
+    watchDeviceTypes.length > 0 &&
+    watchRuntimeOptions.length > 0;
+  const deviceTypeGroups = useMemo(
+    () => groupDeviceTypes(options?.deviceTypes ?? []),
+    [options],
+  );
+  const watchDeviceTypeGroups = useMemo(
+    () => groupDeviceTypes(watchDeviceTypes),
+    [watchDeviceTypes],
+  );
+  const trimmedName = name.trim();
+  const trimmedAndroidName = androidName.trim();
+  const trimmedWatchName = watchName.trim();
+  const canCreateAndroid =
+    Boolean(
+      trimmedAndroidName &&
+        androidDeviceTypeIdentifier &&
+        androidSystemImageIdentifier,
+    ) && !options?.android?.unavailableReason;
+  const canCreateSimulator =
+    platform === "android"
+      ? canCreateAndroid
+      : Boolean(trimmedName && deviceTypeIdentifier && runtimeIdentifier) &&
+        (!pairedWatch ||
+          Boolean(
+            trimmedWatchName &&
+              watchDeviceTypeIdentifier &&
+              watchRuntimeIdentifier,
+          ));
+
+  useEffect(() => {
+    if (!options || !deviceTypeIdentifier) {
+      return;
+    }
+    const nextRuntime = chooseCompatibleRuntime(
+      deviceTypeIdentifier,
+      options,
+      runtimeIdentifier,
+    );
+    if (nextRuntime?.identifier !== runtimeIdentifier) {
+      setRuntimeIdentifier(nextRuntime?.identifier ?? "");
+    }
+  }, [deviceTypeIdentifier, options, runtimeIdentifier]);
+
+  useEffect(() => {
+    if (!options || !watchDeviceTypeIdentifier) {
+      return;
+    }
+    const nextRuntime = chooseCompatibleRuntime(
+      watchDeviceTypeIdentifier,
+      options,
+      watchRuntimeIdentifier,
+    );
+    if (nextRuntime?.identifier !== watchRuntimeIdentifier) {
+      setWatchRuntimeIdentifier(nextRuntime?.identifier ?? "");
+    }
+  }, [options, watchDeviceTypeIdentifier, watchRuntimeIdentifier]);
+
+  useEffect(() => {
+    if (!pairedWatchAvailable) {
+      setPairedWatch(false);
+      setStep("simulator");
+    }
+  }, [pairedWatchAvailable]);
+
+  if (!open) {
+    return null;
+  }
+
+  function handlePlatformChange(nextPlatform: CreationPlatform) {
+    setPlatform(nextPlatform);
+    setStep("simulator");
+    setError("");
+    if (nextPlatform === "android") {
+      setPairedWatch(false);
+    }
+  }
+
+  function handleDeviceTypeChange(nextIdentifier: string) {
+    setDeviceTypeIdentifier(nextIdentifier);
+    const nextDeviceType = options?.deviceTypes.find(
+      (deviceType) => deviceType.identifier === nextIdentifier,
+    );
+    const nextRuntime = chooseCompatibleRuntime(nextIdentifier, options);
+    setRuntimeIdentifier(nextRuntime?.identifier ?? "");
+    if (!nameDirty) {
+      setName(nextDeviceType?.name ?? "");
+    }
+  }
+
+  function handleWatchDeviceTypeChange(nextIdentifier: string) {
+    setWatchDeviceTypeIdentifier(nextIdentifier);
+    const nextDeviceType = options?.deviceTypes.find(
+      (deviceType) => deviceType.identifier === nextIdentifier,
+    );
+    const nextRuntime = chooseCompatibleRuntime(nextIdentifier, options);
+    setWatchRuntimeIdentifier(nextRuntime?.identifier ?? "");
+    if (!watchNameDirty) {
+      setWatchName(nextDeviceType?.name ?? "");
+    }
+  }
+
+  function handleAndroidDeviceTypeChange(nextIdentifier: string) {
+    setAndroidDeviceTypeIdentifier(nextIdentifier);
+    const nextDeviceType = androidDeviceTypes.find(
+      (deviceType) => deviceType.identifier === nextIdentifier,
+    );
+    if (!androidNameDirty && nextDeviceType) {
+      setAndroidName(
+        defaultAndroidName(nextDeviceType, selectedAndroidSystemImage),
+      );
+    }
+  }
+
+  function handleAndroidSystemImageChange(nextIdentifier: string) {
+    setAndroidSystemImageIdentifier(nextIdentifier);
+    const nextSystemImage = androidSystemImages.find(
+      (systemImage) => systemImage.identifier === nextIdentifier,
+    );
+    if (!androidNameDirty && selectedAndroidDeviceType) {
+      setAndroidName(defaultAndroidName(selectedAndroidDeviceType, nextSystemImage));
+    }
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError("");
+    if (platform === "ios" && step === "simulator" && pairedWatch) {
+      setStep("watch");
+      return;
+    }
+    void create();
+  }
+
+  async function create() {
+    if (!canCreateSimulator) {
+      setError(
+        platform === "android"
+          ? "Choose a name, device profile, and system image."
+          : "Choose a name, device type, and OS version.",
+      );
+      return;
+    }
+    setIsCreating(true);
+    try {
+      const response = await createSimulator({
+        deviceTypeIdentifier:
+          platform === "android"
+            ? androidDeviceTypeIdentifier
+            : deviceTypeIdentifier,
+        name: platform === "android" ? trimmedAndroidName : trimmedName,
+        pairedWatch: platform === "ios" && pairedWatch
+          ? {
+              deviceTypeIdentifier: watchDeviceTypeIdentifier,
+              name: trimmedWatchName,
+              runtimeIdentifier: watchRuntimeIdentifier,
+            }
+          : undefined,
+        platform,
+        runtimeIdentifier:
+          platform === "android" ? androidSystemImageIdentifier : runtimeIdentifier,
+      });
+      onCreated(response);
+    } catch (createError) {
+      setError(
+        createError instanceof Error
+          ? createError.message
+          : "Failed to create simulator.",
+      );
+    } finally {
+      setIsCreating(false);
+    }
+  }
+
+  return (
+    <div
+      className="new-sim-overlay"
+      onPointerDown={(event) => {
+        if (event.target === event.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      <form
+        aria-labelledby="new-sim-title"
+        aria-modal="true"
+        className="new-sim-window"
+        onSubmit={handleSubmit}
+        role="dialog"
+      >
+        <div className="new-sim-titlebar">
+          <span className="new-sim-window-controls" aria-hidden="true">
+            <span className="new-sim-window-dot close" />
+            <span className="new-sim-window-dot minimize" />
+            <span className="new-sim-window-dot zoom" />
+          </span>
+          <h2 id="new-sim-title">New Simulator</h2>
+        </div>
+
+        <div className="new-sim-body">
+          <div className="new-sim-platform-switcher" aria-label="Platform">
+            <button
+              className={platform === "ios" ? "active" : ""}
+              onClick={() => handlePlatformChange("ios")}
+              type="button"
+            >
+              iOS
+            </button>
+            <button
+              className={platform === "android" ? "active" : ""}
+              onClick={() => handlePlatformChange("android")}
+              type="button"
+            >
+              Android
+            </button>
+          </div>
+          <fieldset className="new-sim-fieldset" disabled={isCreating}>
+            {isLoading ? (
+              <p className="new-sim-status">Loading simulator options...</p>
+            ) : platform === "android" ? (
+              <>
+                {options?.android?.unavailableReason ? (
+                  <p className="new-sim-status">
+                    {options.android.unavailableReason}
+                  </p>
+                ) : null}
+                <label className="new-sim-field">
+                  <span>Emulator Name:</span>
+                  <input
+                    autoFocus
+                    onChange={(event) => {
+                      setAndroidName(event.currentTarget.value);
+                      setAndroidNameDirty(true);
+                    }}
+                    value={androidName}
+                  />
+                </label>
+                <label className="new-sim-field">
+                  <span>Device Profile:</span>
+                  <select
+                    onChange={(event) =>
+                      handleAndroidDeviceTypeChange(event.currentTarget.value)
+                    }
+                    value={androidDeviceTypeIdentifier}
+                  >
+                    {androidDeviceTypes.map((deviceType) => (
+                      <option
+                        key={deviceType.identifier}
+                        value={deviceType.identifier}
+                      >
+                        {deviceType.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="new-sim-field">
+                  <span>System Image:</span>
+                  <select
+                    onChange={(event) =>
+                      handleAndroidSystemImageChange(event.currentTarget.value)
+                    }
+                    value={androidSystemImageIdentifier}
+                  >
+                    {androidSystemImages.map((systemImage) => (
+                      <option
+                        key={systemImage.identifier}
+                        value={systemImage.identifier}
+                      >
+                        {systemImage.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </>
+            ) : step === "watch" ? (
+              <>
+                <label className="new-sim-field">
+                  <span>Paired Watch Name:</span>
+                  <input
+                    autoFocus
+                    onChange={(event) => {
+                      setWatchName(event.currentTarget.value);
+                      setWatchNameDirty(true);
+                    }}
+                    value={watchName}
+                  />
+                </label>
+                <label className="new-sim-field">
+                  <span>Device Type:</span>
+                  <select
+                    onChange={(event) =>
+                      handleWatchDeviceTypeChange(event.currentTarget.value)
+                    }
+                    value={watchDeviceTypeIdentifier}
+                  >
+                    {renderDeviceTypeGroups(watchDeviceTypeGroups)}
+                  </select>
+                </label>
+                <label className="new-sim-field">
+                  <span>OS Version:</span>
+                  <select
+                    onChange={(event) =>
+                      setWatchRuntimeIdentifier(event.currentTarget.value)
+                    }
+                    value={watchRuntimeIdentifier}
+                  >
+                    {watchRuntimeOptions.map((runtime) => (
+                      <option
+                        key={runtime.identifier}
+                        value={runtime.identifier}
+                      >
+                        {runtime.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </>
+            ) : (
+              <>
+                <label className="new-sim-field">
+                  <span>Simulator Name:</span>
+                  <input
+                    autoFocus
+                    onChange={(event) => {
+                      setName(event.currentTarget.value);
+                      setNameDirty(true);
+                    }}
+                    value={name}
+                  />
+                </label>
+                <label className="new-sim-field">
+                  <span>Device Type:</span>
+                  <select
+                    onChange={(event) =>
+                      handleDeviceTypeChange(event.currentTarget.value)
+                    }
+                    value={deviceTypeIdentifier}
+                  >
+                    {renderDeviceTypeGroups(deviceTypeGroups)}
+                  </select>
+                </label>
+                <label className="new-sim-field">
+                  <span>OS Version:</span>
+                  <select
+                    onChange={(event) =>
+                      setRuntimeIdentifier(event.currentTarget.value)
+                    }
+                    value={runtimeIdentifier}
+                  >
+                    {runtimeOptions.map((runtime) => (
+                      <option
+                        key={runtime.identifier}
+                        value={runtime.identifier}
+                      >
+                        {runtime.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                {pairedWatchAvailable ? (
+                  <label className="new-sim-checkbox">
+                    <input
+                      checked={pairedWatch}
+                      onChange={(event) =>
+                        setPairedWatch(event.currentTarget.checked)
+                      }
+                      type="checkbox"
+                    />
+                    <span>Paired Apple Watch</span>
+                  </label>
+                ) : null}
+              </>
+            )}
+          </fieldset>
+          {error ? <p className="new-sim-error">{error}</p> : null}
+        </div>
+
+        <div className="new-sim-actions">
+          <button
+            className="new-sim-button"
+            disabled={isCreating}
+            onClick={onClose}
+            type="button"
+          >
+            Cancel
+          </button>
+          <span className="new-sim-action-spacer" />
+          <button
+            className="new-sim-button"
+            disabled={platform === "android" || step === "simulator" || isCreating}
+            onClick={() => setStep("simulator")}
+            type="button"
+          >
+            Previous
+          </button>
+          <button
+            className="new-sim-button"
+            disabled={
+              isLoading ||
+              isCreating ||
+              !canCreateSimulator ||
+              (platform === "ios" &&
+                step === "simulator" &&
+                pairedWatch &&
+                !pairedWatchAvailable)
+            }
+            type="submit"
+          >
+            {platform === "ios" && step === "simulator" && pairedWatch
+              ? "Next"
+              : isCreating
+                ? "Creating..."
+                : "Create"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function chooseInitialAndroidDeviceType(
+  options: SimulatorCreateOptionsResponse,
+  preferredName?: string,
+) {
+  const deviceTypes = options.android?.deviceTypes ?? [];
+  return (
+    deviceTypes.find((deviceType) => deviceType.identifier === preferredName) ??
+    deviceTypes.find((deviceType) => deviceType.identifier === "pixel_8") ??
+    deviceTypes.find((deviceType) => deviceType.identifier.startsWith("pixel_")) ??
+    deviceTypes[0]
+  );
+}
+
+function chooseInitialAndroidSystemImage(options: SimulatorCreateOptionsResponse) {
+  return options.android?.systemImages?.[0];
+}
+
+function defaultAndroidName(
+  deviceType: AndroidEmulatorDeviceTypeOption,
+  systemImage?: AndroidEmulatorSystemImageOption,
+) {
+  const apiSuffix = systemImage?.apiLevel ? `_API_${systemImage.apiLevel}` : "";
+  return `${deviceType.name}${apiSuffix}`
+    .replace(/[^A-Za-z0-9_.-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function chooseInitialDeviceType(
+  deviceTypes: SimulatorDeviceTypeOption[],
+  selectedDeviceTypeIdentifier: string,
+) {
+  return (
+    deviceTypes.find(
+      (deviceType) => deviceType.identifier === selectedDeviceTypeIdentifier,
+    ) ??
+    deviceTypes.find((deviceType) => isPhoneDeviceType(deviceType)) ??
+    deviceTypes.find((deviceType) => !isWatchDeviceType(deviceType)) ??
+    deviceTypes[0]
+  );
+}
+
+function chooseInitialWatchDeviceType(options: SimulatorCreateOptionsResponse) {
+  return options.deviceTypes.find(
+    (deviceType) =>
+      isWatchDeviceType(deviceType) &&
+      compatibleRuntimes(deviceType.identifier, options).length > 0,
+  );
+}
+
+function chooseCompatibleRuntime(
+  deviceTypeIdentifier: string,
+  options: SimulatorCreateOptionsResponse | null,
+  preferredIdentifier?: string,
+) {
+  const runtimes = compatibleRuntimes(deviceTypeIdentifier, options);
+  return (
+    runtimes.find((runtime) => runtime.identifier === preferredIdentifier) ??
+    runtimes[0]
+  );
+}
+
+function compatibleRuntimes(
+  deviceTypeIdentifier: string,
+  options: SimulatorCreateOptionsResponse | null,
+): SimulatorRuntimeOption[] {
+  if (!deviceTypeIdentifier || !options) {
+    return [];
+  }
+  const deviceType = options.deviceTypes.find(
+    (candidate) => candidate.identifier === deviceTypeIdentifier,
+  );
+  return options.runtimes.filter((runtime) => {
+    if (runtime.isAvailable === false) {
+      return false;
+    }
+    return (
+      runtime.supportedDeviceTypeIdentifiers?.includes(deviceTypeIdentifier) ||
+      deviceType?.supportedRuntimeIdentifiers?.includes(runtime.identifier)
+    );
+  });
+}
+
+function groupDeviceTypes(deviceTypes: SimulatorDeviceTypeOption[]) {
+  const groups: Array<{
+    family: string;
+    deviceTypes: SimulatorDeviceTypeOption[];
+  }> = [];
+  for (const deviceType of deviceTypes) {
+    const family = deviceType.productFamily ?? "Other";
+    let group = groups.find((candidate) => candidate.family === family);
+    if (!group) {
+      group = { deviceTypes: [], family };
+      groups.push(group);
+    }
+    group.deviceTypes.push(deviceType);
+  }
+  return groups;
+}
+
+function renderDeviceTypeGroups(
+  groups: Array<{
+    family: string;
+    deviceTypes: SimulatorDeviceTypeOption[];
+  }>,
+) {
+  return groups.map((group) => (
+    <optgroup key={group.family} label={group.family}>
+      {group.deviceTypes.map((deviceType) => (
+        <option key={deviceType.identifier} value={deviceType.identifier}>
+          {deviceType.name}
+        </option>
+      ))}
+    </optgroup>
+  ));
+}
+
+function isPhoneDeviceType(deviceType: SimulatorDeviceTypeOption): boolean {
+  return (deviceType.productFamily ?? "").toLowerCase() === "iphone";
+}
+
+function isWatchDeviceType(deviceType: SimulatorDeviceTypeOption): boolean {
+  return (deviceType.productFamily ?? "").toLowerCase().includes("watch");
+}

--- a/client/src/features/simulators/NewSimulatorModal.tsx
+++ b/client/src/features/simulators/NewSimulatorModal.tsx
@@ -86,7 +86,9 @@ export function NewSimulatorModal({
         }
         setOptions(nextOptions);
         const initialPlatform =
-          selectedSimulator?.platform === "android-emulator" ? "android" : "ios";
+          selectedSimulator?.platform === "android-emulator"
+            ? "android"
+            : "ios";
         setPlatform(initialPlatform);
         const initialDeviceType = chooseInitialDeviceType(
           nextOptions.deviceTypes,
@@ -102,9 +104,8 @@ export function NewSimulatorModal({
         setName(initialDeviceType?.name ?? "");
         setNameDirty(false);
 
-        const initialWatchDeviceType = chooseInitialWatchDeviceType(
-          nextOptions,
-        );
+        const initialWatchDeviceType =
+          chooseInitialWatchDeviceType(nextOptions);
         const initialWatchRuntime = chooseCompatibleRuntime(
           initialWatchDeviceType?.identifier ?? "",
           nextOptions,
@@ -140,7 +141,9 @@ export function NewSimulatorModal({
       .catch((loadError) => {
         if (
           !cancelled &&
-          !(loadError instanceof DOMException && loadError.name === "AbortError")
+          !(
+            loadError instanceof DOMException && loadError.name === "AbortError"
+          )
         ) {
           setError(
             loadError instanceof Error
@@ -229,8 +232,8 @@ export function NewSimulatorModal({
   const canCreateAndroid =
     Boolean(
       trimmedAndroidName &&
-        androidDeviceTypeIdentifier &&
-        androidSystemImageIdentifier,
+      androidDeviceTypeIdentifier &&
+      androidSystemImageIdentifier,
     ) && !options?.android?.unavailableReason;
   const canCreateSimulator =
     platform === "android"
@@ -239,8 +242,8 @@ export function NewSimulatorModal({
         (!pairedWatch ||
           Boolean(
             trimmedWatchName &&
-              watchDeviceTypeIdentifier &&
-              watchRuntimeIdentifier,
+            watchDeviceTypeIdentifier &&
+            watchRuntimeIdentifier,
           ));
 
   useEffect(() => {
@@ -333,7 +336,9 @@ export function NewSimulatorModal({
       (systemImage) => systemImage.identifier === nextIdentifier,
     );
     if (!androidNameDirty && selectedAndroidDeviceType) {
-      setAndroidName(defaultAndroidName(selectedAndroidDeviceType, nextSystemImage));
+      setAndroidName(
+        defaultAndroidName(selectedAndroidDeviceType, nextSystemImage),
+      );
     }
   }
 
@@ -364,16 +369,19 @@ export function NewSimulatorModal({
             ? androidDeviceTypeIdentifier
             : deviceTypeIdentifier,
         name: platform === "android" ? trimmedAndroidName : trimmedName,
-        pairedWatch: platform === "ios" && pairedWatch
-          ? {
-              deviceTypeIdentifier: watchDeviceTypeIdentifier,
-              name: trimmedWatchName,
-              runtimeIdentifier: watchRuntimeIdentifier,
-            }
-          : undefined,
+        pairedWatch:
+          platform === "ios" && pairedWatch
+            ? {
+                deviceTypeIdentifier: watchDeviceTypeIdentifier,
+                name: trimmedWatchName,
+                runtimeIdentifier: watchRuntimeIdentifier,
+              }
+            : undefined,
         platform,
         runtimeIdentifier:
-          platform === "android" ? androidSystemImageIdentifier : runtimeIdentifier,
+          platform === "android"
+            ? androidSystemImageIdentifier
+            : runtimeIdentifier,
       });
       onCreated(response);
     } catch (createError) {
@@ -602,7 +610,9 @@ export function NewSimulatorModal({
           <span className="new-sim-action-spacer" />
           <button
             className="new-sim-button"
-            disabled={platform === "android" || step === "simulator" || isCreating}
+            disabled={
+              platform === "android" || step === "simulator" || isCreating
+            }
             onClick={() => setStep("simulator")}
             type="button"
           >
@@ -641,12 +651,16 @@ function chooseInitialAndroidDeviceType(
   return (
     deviceTypes.find((deviceType) => deviceType.identifier === preferredName) ??
     deviceTypes.find((deviceType) => deviceType.identifier === "pixel_8") ??
-    deviceTypes.find((deviceType) => deviceType.identifier.startsWith("pixel_")) ??
+    deviceTypes.find((deviceType) =>
+      deviceType.identifier.startsWith("pixel_"),
+    ) ??
     deviceTypes[0]
   );
 }
 
-function chooseInitialAndroidSystemImage(options: SimulatorCreateOptionsResponse) {
+function chooseInitialAndroidSystemImage(
+  options: SimulatorCreateOptionsResponse,
+) {
   return options.android?.systemImages?.[0];
 }
 

--- a/client/src/features/simulators/SimulatorMenu.tsx
+++ b/client/src/features/simulators/SimulatorMenu.tsx
@@ -1,4 +1,7 @@
-import { MixerHorizontalIcon as MenuIcon } from "@radix-ui/react-icons";
+import {
+  MixerHorizontalIcon as MenuIcon,
+  PlusIcon,
+} from "@radix-ui/react-icons";
 import type { RefObject } from "react";
 
 import type { SimulatorMetadata } from "../../api/types";
@@ -25,6 +28,7 @@ interface SimulatorMenuProps {
   onHome: () => void;
   onOpenAppSwitcher: () => void;
   onOpenBundlePrompt: () => void;
+  onOpenNewSimulator: () => void;
   onOpenUrlPrompt: () => void;
   onRotateRight: () => void;
   onShutdown: () => void;
@@ -61,6 +65,7 @@ export function SimulatorMenu({
   onHome,
   onOpenAppSwitcher,
   onOpenBundlePrompt,
+  onOpenNewSimulator,
   onOpenUrlPrompt,
   onRotateRight,
   onShutdown,
@@ -126,6 +131,19 @@ export function SimulatorMenu({
                 placeholder="Search simulators..."
                 value={search}
               />
+              <div className="menu-actions menu-actions-compact">
+                <button
+                  className="menu-action menu-primary-action"
+                  onClick={() => {
+                    onOpenNewSimulator();
+                    onCloseMenu();
+                  }}
+                  type="button"
+                >
+                  <PlusIcon />
+                  New Simulator
+                </button>
+              </div>
               <div className="sim-list">
                 {isLoading ? <p className="list-empty">Loading...</p> : null}
                 {!isLoading && filteredSimulators.length === 0 ? (

--- a/client/src/features/simulators/useSimulatorList.ts
+++ b/client/src/features/simulators/useSimulatorList.ts
@@ -46,7 +46,7 @@ export function useSimulatorList({
       if (cancelled) {
         return;
       }
-      startTransition(() => setSimulators(nextSimulators));
+      startTransition(() => setSimulators(bootedFirst(nextSimulators)));
       setError("");
       lastLoadFailedRef.current = false;
     } catch (loadError) {
@@ -89,7 +89,7 @@ export function useSimulatorList({
             ...nextSimulator,
           };
         });
-        return replaced ? nextSimulators : [nextSimulator, ...current];
+        return bootedFirst(replaced ? nextSimulators : [nextSimulator, ...current]);
       }),
     );
   }, []);
@@ -145,4 +145,16 @@ export function useSimulatorList({
     simulators,
     updateSimulator,
   };
+}
+
+function bootedFirst(simulators: SimulatorMetadata[]): SimulatorMetadata[] {
+  return simulators
+    .map((simulator, index) => ({ simulator, index }))
+    .sort((left, right) => {
+      if (left.simulator.isBooted !== right.simulator.isBooted) {
+        return left.simulator.isBooted ? -1 : 1;
+      }
+      return left.index - right.index;
+    })
+    .map(({ simulator }) => simulator);
 }

--- a/client/src/features/simulators/useSimulatorList.ts
+++ b/client/src/features/simulators/useSimulatorList.ts
@@ -89,7 +89,9 @@ export function useSimulatorList({
             ...nextSimulator,
           };
         });
-        return bootedFirst(replaced ? nextSimulators : [nextSimulator, ...current]);
+        return bootedFirst(
+          replaced ? nextSimulators : [nextSimulator, ...current],
+        );
       }),
     );
   }, []);

--- a/client/src/features/toolbar/Toolbar.tsx
+++ b/client/src/features/toolbar/Toolbar.tsx
@@ -35,6 +35,7 @@ interface ToolbarProps {
   onHome: () => void;
   onOpenAppSwitcher: () => void;
   onOpenBundlePrompt: () => void;
+  onOpenNewSimulator: () => void;
   onOpenUrlPrompt: () => void;
   onRotateRight: () => void;
   onShutdown: () => void;
@@ -80,6 +81,7 @@ export function Toolbar({
   onHome,
   onOpenAppSwitcher,
   onOpenBundlePrompt,
+  onOpenNewSimulator,
   onOpenUrlPrompt,
   onRotateRight,
   onShutdown,
@@ -149,6 +151,7 @@ export function Toolbar({
           onHome={onHome}
           onOpenAppSwitcher={onOpenAppSwitcher}
           onOpenBundlePrompt={onOpenBundlePrompt}
+          onOpenNewSimulator={onOpenNewSimulator}
           onOpenUrlPrompt={onOpenUrlPrompt}
           onRotateRight={onRotateRight}
           onShutdown={onShutdown}

--- a/client/src/styles/components.css
+++ b/client/src/styles/components.css
@@ -333,6 +333,10 @@
   padding: 4px;
 }
 
+.menu-actions-compact {
+  border-bottom: 1px solid var(--border-subtle);
+}
+
 .menu-section {
   display: flex;
   flex: 0 0 auto;
@@ -450,6 +454,9 @@
 }
 
 .menu-action {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   width: 100%;
   padding: 8px 10px;
   border: none;
@@ -458,6 +465,7 @@
   color: var(--text);
   text-align: left;
   font-size: 12px;
+  font-weight: 600;
   transition: background 100ms;
 }
 
@@ -465,8 +473,428 @@
   background: var(--surface-hover);
 }
 
+.menu-action svg {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 auto;
+}
+
+.menu-primary-action {
+  color: var(--text);
+}
+
 .mobile-menu-action {
   display: none;
+}
+
+.new-sim-overlay {
+  --new-sim-overlay-bg: rgba(0, 0, 0, 0.34);
+  --new-sim-window-bg: #1f1f20;
+  --new-sim-titlebar-bg: #1f1f20;
+  --new-sim-window-border: #3f3f42;
+  --new-sim-titlebar-border: #2a2a2c;
+  --new-sim-panel-bg: #202021;
+  --new-sim-panel-border: #151516;
+  --new-sim-control-bg: #303033;
+  --new-sim-control-border: #3a3a3d;
+  --new-sim-input-bg: #202021;
+  --new-sim-button-bg: #303033;
+  --new-sim-button-hover-bg: #3a3a3d;
+  --new-sim-text: #e1e1e3;
+  --new-sim-title-text: #aaaaae;
+  --new-sim-muted-text: #aaaaae;
+  --new-sim-disabled-text: #747477;
+  --new-sim-focus: #4c92ff;
+  --new-sim-error-text: #ff7575;
+  --new-sim-checkbox-bg: #2b2b2d;
+  --new-sim-checkbox-border: #77777b;
+  --new-sim-checkbox-checked: #0a84ff;
+  --new-sim-window-shadow:
+    0 34px 90px rgba(0, 0, 0, 0.52),
+    0 12px 32px rgba(0, 0, 0, 0.34);
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: var(--new-sim-overlay-bg);
+}
+
+.new-sim-window {
+  width: min(740px, calc(100vw - 32px));
+  max-height: calc(100dvh - 48px);
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  overflow: hidden;
+  border: 1px solid var(--new-sim-window-border);
+  border-radius: 14px;
+  background: var(--new-sim-window-bg);
+  box-shadow: var(--new-sim-window-shadow);
+  color: var(--new-sim-text);
+  color-scheme: dark;
+}
+
+.new-sim-titlebar {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  min-width: 0;
+  height: 42px;
+  padding: 0 18px;
+  border-bottom: 1px solid var(--new-sim-titlebar-border);
+  background: var(--new-sim-titlebar-bg);
+}
+
+.new-sim-titlebar h2 {
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  color: var(--new-sim-title-text);
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.new-sim-window-controls {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  flex: 0 0 auto;
+}
+
+.new-sim-window-dot {
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  background: #545456;
+}
+
+.new-sim-window-dot.close {
+  background: #ff5f57;
+}
+
+.new-sim-window-dot.minimize {
+  background: #ffbd2e;
+}
+
+.new-sim-body {
+  min-width: 0;
+  min-height: 0;
+  overflow: auto;
+  padding: 24px 26px 22px;
+}
+
+.new-sim-body h3 {
+  margin: 0 0 12px;
+  color: var(--new-sim-text);
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.new-sim-platform-switcher {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  width: 190px;
+  height: 28px;
+  margin: 0 auto 14px;
+  padding: 2px;
+  border: 1px solid var(--new-sim-control-border);
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--new-sim-control-bg) 72%, transparent);
+}
+
+.new-sim-platform-switcher button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  height: 100%;
+  padding: 0;
+  appearance: none;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--new-sim-muted-text);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.new-sim-platform-switcher button.active {
+  background: var(--new-sim-button-bg);
+  color: var(--new-sim-text);
+  box-shadow: none;
+}
+
+.new-sim-fieldset {
+  display: grid;
+  align-content: center;
+  height: 200px;
+  margin: 0;
+  padding: 28px clamp(16px, 12vw, 148px);
+  border: 1px solid var(--new-sim-panel-border);
+  background: var(--new-sim-panel-bg);
+}
+
+.new-sim-fieldset:disabled {
+  opacity: 0.72;
+}
+
+.new-sim-field {
+  display: grid;
+  grid-template-columns: minmax(130px, 166px) minmax(0, 1fr);
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+  margin: 5px 0;
+}
+
+.new-sim-field span {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--new-sim-text);
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.2;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.new-sim-field input,
+.new-sim-field select {
+  width: 100%;
+  min-width: 0;
+  height: 28px;
+  padding: 0 10px;
+  border: 1px solid var(--new-sim-control-border);
+  border-radius: 6px;
+  background: var(--new-sim-control-bg);
+  color: var(--new-sim-text);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  outline: none;
+}
+
+.new-sim-field input {
+  background: var(--new-sim-input-bg);
+}
+
+.new-sim-field input:focus,
+.new-sim-field select:focus {
+  border-color: var(--new-sim-focus);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--new-sim-focus) 28%, transparent);
+}
+
+.new-sim-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 11px 0 0;
+  padding-left: 178px;
+  color: var(--new-sim-text);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.new-sim-checkbox input {
+  display: grid;
+  place-content: center;
+  width: 15px;
+  height: 15px;
+  margin: 0;
+  appearance: none;
+  border: 1px solid var(--new-sim-checkbox-border);
+  border-radius: 4px;
+  background: var(--new-sim-checkbox-bg);
+  color: #ffffff;
+}
+
+.new-sim-checkbox input::after {
+  width: 4px;
+  height: 8px;
+  margin-top: -1px;
+  border: solid currentColor;
+  border-width: 0 2px 2px 0;
+  content: "";
+  transform: rotate(45deg) scale(0);
+  transform-origin: center;
+}
+
+.new-sim-checkbox input:checked {
+  border-color: var(--new-sim-checkbox-checked);
+  background: var(--new-sim-checkbox-checked);
+}
+
+.new-sim-checkbox input:checked::after {
+  transform: rotate(45deg) scale(1);
+}
+
+.new-sim-checkbox input:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--new-sim-focus) 42%, transparent);
+  outline-offset: 2px;
+}
+
+.new-sim-status,
+.new-sim-error {
+  margin: 0;
+  color: var(--new-sim-muted-text);
+  font-size: 13px;
+  line-height: 1.35;
+  text-align: center;
+}
+
+.new-sim-error {
+  margin-top: 10px;
+  color: var(--new-sim-error-text);
+}
+
+.new-sim-actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 0 26px 24px;
+}
+
+.new-sim-action-spacer {
+  flex: 1 1 auto;
+}
+
+.new-sim-button {
+  min-width: 82px;
+  height: 32px;
+  padding: 0 14px;
+  border: 0;
+  border-radius: 7px;
+  background: var(--new-sim-button-bg);
+  color: var(--new-sim-text);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.new-sim-button:hover:not(:disabled) {
+  background: var(--new-sim-button-hover-bg);
+}
+
+.new-sim-button:disabled {
+  color: var(--new-sim-disabled-text);
+  cursor: default;
+  opacity: 0.62;
+}
+
+@media (prefers-color-scheme: light) {
+  .new-sim-overlay {
+    --new-sim-overlay-bg: rgba(0, 0, 0, 0.18);
+    --new-sim-window-bg: #ececee;
+    --new-sim-titlebar-bg: #f3f3f4;
+    --new-sim-window-border: #b7b7bb;
+    --new-sim-titlebar-border: #d7d7da;
+    --new-sim-panel-bg: #f7f7f8;
+    --new-sim-panel-border: #cfcfd3;
+    --new-sim-control-bg: #ffffff;
+    --new-sim-control-border: #c9c9ce;
+    --new-sim-input-bg: #ffffff;
+    --new-sim-button-bg: #e1e1e4;
+    --new-sim-button-hover-bg: #d6d6da;
+    --new-sim-text: #242426;
+    --new-sim-title-text: #58585c;
+    --new-sim-muted-text: #6f6f73;
+    --new-sim-disabled-text: #9a9a9f;
+    --new-sim-focus: #0066d9;
+    --new-sim-error-text: #c8232b;
+    --new-sim-checkbox-bg: #ffffff;
+    --new-sim-checkbox-border: #8e8e93;
+    --new-sim-checkbox-checked: #007aff;
+    --new-sim-window-shadow:
+      0 30px 80px rgba(0, 0, 0, 0.24),
+      0 10px 28px rgba(0, 0, 0, 0.16);
+  }
+
+  .new-sim-window {
+    color-scheme: light;
+  }
+
+  .new-sim-window-dot {
+    background: #d0d0d3;
+  }
+}
+
+@media (max-width: 720px) {
+  .new-sim-overlay {
+    padding: 12px;
+  }
+
+  .new-sim-window {
+    width: calc(100vw - 24px);
+    max-height: calc(100dvh - 24px);
+  }
+
+  .new-sim-titlebar {
+    gap: 12px;
+    height: 42px;
+    padding: 0 14px;
+  }
+
+  .new-sim-window-controls {
+    gap: 8px;
+  }
+
+  .new-sim-window-dot {
+    width: 12px;
+    height: 12px;
+  }
+
+  .new-sim-body {
+    padding: 20px 16px 18px;
+  }
+
+  .new-sim-platform-switcher {
+    width: 100%;
+  }
+
+  .new-sim-fieldset {
+    height: 296px;
+    padding: 18px 14px;
+  }
+
+  .new-sim-field {
+    grid-template-columns: 1fr;
+    gap: 6px;
+    margin: 10px 0;
+  }
+
+  .new-sim-field span {
+    font-size: 13px;
+    text-align: left;
+  }
+
+  .new-sim-checkbox {
+    padding-left: 0;
+    font-size: 13px;
+  }
+
+  .new-sim-actions {
+    flex-wrap: wrap;
+    gap: 10px;
+    padding: 0 16px 16px;
+  }
+
+  .new-sim-action-spacer {
+    display: none;
+  }
+
+  .new-sim-button {
+    flex: 1 1 120px;
+    min-width: 0;
+  }
 }
 
 .sim-item {

--- a/client/src/styles/components.css
+++ b/client/src/styles/components.css
@@ -510,8 +510,7 @@
   --new-sim-checkbox-border: #77777b;
   --new-sim-checkbox-checked: #0a84ff;
   --new-sim-window-shadow:
-    0 34px 90px rgba(0, 0, 0, 0.52),
-    0 12px 32px rgba(0, 0, 0, 0.34);
+    0 34px 90px rgba(0, 0, 0, 0.52), 0 12px 32px rgba(0, 0, 0, 0.34);
   position: fixed;
   inset: 0;
   z-index: 50;
@@ -689,7 +688,8 @@
 .new-sim-field input:focus,
 .new-sim-field select:focus {
   border-color: var(--new-sim-focus);
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--new-sim-focus) 28%, transparent);
+  box-shadow: 0 0 0 2px
+    color-mix(in srgb, var(--new-sim-focus) 28%, transparent);
 }
 
 .new-sim-checkbox {
@@ -814,8 +814,7 @@
     --new-sim-checkbox-border: #8e8e93;
     --new-sim-checkbox-checked: #007aff;
     --new-sim-window-shadow:
-      0 30px 80px rgba(0, 0, 0, 0.24),
-      0 10px 28px rgba(0, 0, 0, 0.16);
+      0 30px 80px rgba(0, 0, 0, 0.24), 0 10px 28px rgba(0, 0, 0, 0.16);
   }
 
   .new-sim-window {

--- a/docs/api/rest.md
+++ b/docs/api/rest.md
@@ -52,7 +52,7 @@ See [Health & Metrics](/api/health) for details.
 | Method | Path                                       | Purpose                                   |
 | ------ | ------------------------------------------ | ----------------------------------------- |
 | `GET`  | `/api/simulators`                          | List iOS Simulators and Android emulators |
-| `POST` | `/api/simulators`                          | Create an iOS Simulator                   |
+| `POST` | `/api/simulators`                          | Create and boot a simulator or emulator   |
 | `GET`  | `/api/simulators/create-options`           | List device types and runtimes for create |
 | `GET`  | `/api/simulators/{udid}/state`             | Get one device state                      |
 | `POST` | `/api/simulators/{udid}/boot`              | Boot a simulator or emulator              |
@@ -61,12 +61,18 @@ See [Health & Metrics](/api/health) for details.
 | `POST` | `/api/simulators/{udid}/toggle-appearance` | Toggle light/dark appearance              |
 
 Device IDs come from `/api/simulators`. Android IDs use the `android:` prefix.
+Booted devices are listed first. Paired iPhone and Apple Watch entries include
+`pairedWatchUDID` or `pairedPhoneUDID` when CoreSimulator reports a pairing.
 
-Create requests use CoreSimulator device type and runtime identifiers from
-`/api/simulators/create-options`:
+Create requests use identifiers from `/api/simulators/create-options`. New
+devices are booted before the response is returned. If an iOS simulator is
+created with `pairedWatch`, the watch is created, paired, and booted too.
+
+iOS:
 
 ```json
 {
+  "platform": "ios",
   "name": "iPhone Air",
   "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-Air",
   "runtimeIdentifier": "com.apple.CoreSimulator.SimRuntime.iOS-26-4",
@@ -75,6 +81,17 @@ Create requests use CoreSimulator device type and runtime identifiers from
     "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.Apple-Watch-Series-11-46mm",
     "runtimeIdentifier": "com.apple.CoreSimulator.SimRuntime.watchOS-26-4"
   }
+}
+```
+
+Android:
+
+```json
+{
+  "platform": "android",
+  "name": "Pixel_8_API_36",
+  "deviceTypeIdentifier": "pixel_8",
+  "runtimeIdentifier": "system-images;android-36;google_apis;arm64-v8a"
 }
 ```
 

--- a/docs/api/rest.md
+++ b/docs/api/rest.md
@@ -52,6 +52,8 @@ See [Health & Metrics](/api/health) for details.
 | Method | Path                                       | Purpose                                   |
 | ------ | ------------------------------------------ | ----------------------------------------- |
 | `GET`  | `/api/simulators`                          | List iOS Simulators and Android emulators |
+| `POST` | `/api/simulators`                          | Create an iOS Simulator                   |
+| `GET`  | `/api/simulators/create-options`           | List device types and runtimes for create |
 | `GET`  | `/api/simulators/{udid}/state`             | Get one device state                      |
 | `POST` | `/api/simulators/{udid}/boot`              | Boot a simulator or emulator              |
 | `POST` | `/api/simulators/{udid}/shutdown`          | Shut it down                              |
@@ -59,6 +61,22 @@ See [Health & Metrics](/api/health) for details.
 | `POST` | `/api/simulators/{udid}/toggle-appearance` | Toggle light/dark appearance              |
 
 Device IDs come from `/api/simulators`. Android IDs use the `android:` prefix.
+
+Create requests use CoreSimulator device type and runtime identifiers from
+`/api/simulators/create-options`:
+
+```json
+{
+  "name": "iPhone Air",
+  "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-Air",
+  "runtimeIdentifier": "com.apple.CoreSimulator.SimRuntime.iOS-26-4",
+  "pairedWatch": {
+    "name": "Apple Watch Series 11 (46mm)",
+    "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.Apple-Watch-Series-11-46mm",
+    "runtimeIdentifier": "com.apple.CoreSimulator.SimRuntime.watchOS-26-4"
+  }
+}
+```
 
 ## Apps
 

--- a/server/native_stubs.c
+++ b/server/native_stubs.c
@@ -79,6 +79,28 @@ char *xcw_native_list_simulators(char **error_message) {
   return xcw_strdup("{\"simulators\":[]}");
 }
 
+char *xcw_native_simulator_creation_options(char **error_message) {
+  (void)error_message;
+  return xcw_strdup("{\"deviceTypes\":[],\"runtimes\":[]}");
+}
+
+char *xcw_native_create_simulator(const char *name,
+                                  const char *device_type_identifier,
+                                  const char *runtime_identifier,
+                                  const char *paired_watch_name,
+                                  const char *paired_watch_device_type_identifier,
+                                  const char *paired_watch_runtime_identifier,
+                                  char **error_message) {
+  (void)name;
+  (void)device_type_identifier;
+  (void)runtime_identifier;
+  (void)paired_watch_name;
+  (void)paired_watch_device_type_identifier;
+  (void)paired_watch_runtime_identifier;
+  xcw_unsupported(error_message);
+  return NULL;
+}
+
 bool xcw_native_boot_simulator(const char *udid, char **error_message) {
   (void)udid;
   return xcw_unsupported(error_message);

--- a/server/src/android.rs
+++ b/server/src/android.rs
@@ -5,7 +5,7 @@ use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::env;
 use std::ffi::OsString;
-use std::io::Read;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::{Mutex, OnceLock};
@@ -76,6 +76,13 @@ pub struct AndroidDevice {
     pub serial: Option<String>,
     pub is_booted: bool,
     pub grpc_port: u16,
+}
+
+#[derive(Clone, Debug)]
+pub struct AndroidEmulatorSpec {
+    pub name: String,
+    pub device_profile_identifier: String,
+    pub system_image_identifier: String,
 }
 
 #[derive(Debug)]
@@ -242,6 +249,68 @@ impl AndroidBridge {
             .into_iter()
             .map(|device| self.device_value(device))
             .collect()
+    }
+
+    pub fn creation_options(&self) -> Result<Value, AppError> {
+        if !self.avdmanager_path().exists() || !self.sdkmanager_path().exists() {
+            return Ok(json!({
+                "deviceTypes": [],
+                "systemImages": [],
+                "unavailableReason": format!(
+                    "Android SDK command line tools were not found under {}.",
+                    sdk_root().display()
+                ),
+            }));
+        }
+
+        let device_output = self.run_avdmanager(["list", "device"])?;
+        let system_image_output = self.run_sdkmanager(["--list_installed"])?;
+        Ok(json!({
+            "deviceTypes": parse_avdmanager_devices(&device_output),
+            "systemImages": parse_installed_system_images(&system_image_output),
+        }))
+    }
+
+    pub fn create_emulator(&self, spec: AndroidEmulatorSpec) -> Result<Value, AppError> {
+        validate_avd_name(&spec.name)?;
+        if spec.device_profile_identifier.trim().is_empty() {
+            return Err(AppError::bad_request(
+                "Android emulator creation requires `deviceTypeIdentifier`.",
+            ));
+        }
+        if spec.system_image_identifier.trim().is_empty() {
+            return Err(AppError::bad_request(
+                "Android emulator creation requires `runtimeIdentifier`.",
+            ));
+        }
+        if self
+            .run_emulator(["-list-avds"])?
+            .lines()
+            .map(str::trim)
+            .any(|avd_name| avd_name == spec.name)
+        {
+            return Err(AppError::bad_request(format!(
+                "Android emulator `{}` already exists.",
+                spec.name
+            )));
+        }
+
+        self.run_avdmanager_with_stdin(
+            [
+                "create",
+                "avd",
+                "--name",
+                &spec.name,
+                "--package",
+                &spec.system_image_identifier,
+                "--device",
+                &spec.device_profile_identifier,
+            ],
+            "no\n",
+        )?;
+        Ok(json!({
+            "udid": id_for_avd(&spec.name),
+        }))
     }
 
     pub fn boot(&self, id: &str) -> Result<bool, AppError> {
@@ -1038,12 +1107,36 @@ impl AndroidBridge {
         run_command_text(self.emulator_path(), args)
     }
 
+    fn run_avdmanager<const N: usize>(&self, args: [&str; N]) -> Result<String, AppError> {
+        run_command_text(self.avdmanager_path(), args)
+    }
+
+    fn run_avdmanager_with_stdin<const N: usize>(
+        &self,
+        args: [&str; N],
+        stdin: &str,
+    ) -> Result<String, AppError> {
+        run_command_text_with_stdin(self.avdmanager_path(), args, stdin)
+    }
+
+    fn run_sdkmanager<const N: usize>(&self, args: [&str; N]) -> Result<String, AppError> {
+        run_command_text(self.sdkmanager_path(), args)
+    }
+
     fn adb_path(&self) -> PathBuf {
         sdk_root().join("platform-tools/adb")
     }
 
     fn emulator_path(&self) -> PathBuf {
         sdk_root().join("emulator/emulator")
+    }
+
+    fn avdmanager_path(&self) -> PathBuf {
+        android_cmdline_tool_path("avdmanager")
+    }
+
+    fn sdkmanager_path(&self) -> PathBuf {
+        android_cmdline_tool_path("sdkmanager")
     }
 
     fn avd_dir(&self, avd_name: &str) -> PathBuf {
@@ -1230,6 +1323,16 @@ fn run_command_text<const N: usize>(program: PathBuf, args: [&str; N]) -> Result
         .map_err(|error| AppError::native(format!("Command returned non-UTF8 output: {error}")))
 }
 
+fn run_command_text_with_stdin<const N: usize>(
+    program: PathBuf,
+    args: [&str; N],
+    stdin: &str,
+) -> Result<String, AppError> {
+    let output = run_command_with_stdin(program, args, Some(stdin.as_bytes()))?;
+    String::from_utf8(output)
+        .map_err(|error| AppError::native(format!("Command returned non-UTF8 output: {error}")))
+}
+
 fn run_command_bytes<const N: usize>(
     program: PathBuf,
     args: [&str; N],
@@ -1238,6 +1341,14 @@ fn run_command_bytes<const N: usize>(
 }
 
 fn run_command<const N: usize>(program: PathBuf, args: [&str; N]) -> Result<Vec<u8>, AppError> {
+    run_command_with_stdin(program, args, None)
+}
+
+fn run_command_with_stdin<const N: usize>(
+    program: PathBuf,
+    args: [&str; N],
+    stdin_input: Option<&[u8]>,
+) -> Result<Vec<u8>, AppError> {
     if !program.exists() {
         return Err(AppError::native(format!(
             "Android SDK binary not found at {}.",
@@ -1249,12 +1360,28 @@ fn run_command<const N: usize>(program: PathBuf, args: [&str; N]) -> Result<Vec<
         .env("ANDROID_HOME", sdk_root())
         .env("ANDROID_SDK_ROOT", sdk_root())
         .env("JAVA_HOME", java_home())
+        .stdin(if stdin_input.is_some() {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        })
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
         .map_err(|error| {
             AppError::native(format!("Unable to run {}: {error}", program.display()))
         })?;
+    if let Some(input) = stdin_input {
+        let mut stdin = child.stdin.take().ok_or_else(|| {
+            AppError::native(format!("Unable to open stdin for {}.", program.display()))
+        })?;
+        stdin.write_all(input).map_err(|error| {
+            AppError::native(format!(
+                "Unable to write stdin for {}: {error}",
+                program.display()
+            ))
+        })?;
+    }
     let stdout = child.stdout.take().ok_or_else(|| {
         AppError::native(format!(
             "Unable to capture stdout from {}.",
@@ -1319,6 +1446,125 @@ fn run_command<const N: usize>(program: PathBuf, args: [&str; N]) -> Result<Vec<
     )))
 }
 
+fn parse_avdmanager_devices(output: &str) -> Vec<Value> {
+    let mut devices = Vec::new();
+    let mut identifier = String::new();
+    let mut name = String::new();
+    let mut oem = String::new();
+    let mut tag = String::new();
+
+    for line in output.lines().map(str::trim) {
+        if let Some(rest) = line.strip_prefix("id:") {
+            if !identifier.is_empty() && !name.is_empty() {
+                devices.push(android_device_type_value(&identifier, &name, &oem, &tag));
+            }
+            identifier = parse_quoted_identifier(rest).unwrap_or_else(|| rest.trim().to_owned());
+            name.clear();
+            oem.clear();
+            tag.clear();
+        } else if let Some(rest) = line.strip_prefix("Name:") {
+            name = rest.trim().to_owned();
+        } else if let Some(rest) = line.strip_prefix("OEM :") {
+            oem = rest.trim().to_owned();
+        } else if let Some(rest) = line.strip_prefix("Tag :") {
+            tag = rest.trim().to_owned();
+        } else if line.starts_with("----") && !identifier.is_empty() && !name.is_empty() {
+            devices.push(android_device_type_value(&identifier, &name, &oem, &tag));
+            identifier.clear();
+            name.clear();
+            oem.clear();
+            tag.clear();
+        }
+    }
+
+    if !identifier.is_empty() && !name.is_empty() {
+        devices.push(android_device_type_value(&identifier, &name, &oem, &tag));
+    }
+    devices
+}
+
+fn android_device_type_value(identifier: &str, name: &str, oem: &str, tag: &str) -> Value {
+    json!({
+        "identifier": identifier,
+        "name": name,
+        "oem": empty_to_null(oem),
+        "tag": empty_to_null(tag),
+    })
+}
+
+fn parse_quoted_identifier(input: &str) -> Option<String> {
+    let start = input.find('"')?;
+    let rest = &input[start + 1..];
+    let end = rest.find('"')?;
+    Some(rest[..end].to_owned())
+}
+
+fn parse_installed_system_images(output: &str) -> Vec<Value> {
+    output
+        .lines()
+        .map(str::trim)
+        .filter(|line| line.starts_with("system-images;"))
+        .filter_map(|line| {
+            let columns = line.split('|').map(str::trim).collect::<Vec<_>>();
+            let identifier = *columns.first()?;
+            let description = columns.get(2).copied().unwrap_or(identifier);
+            let parts = identifier.split(';').collect::<Vec<_>>();
+            let api_level = parts
+                .get(1)
+                .and_then(|value| value.strip_prefix("android-"))
+                .and_then(|value| value.parse::<u32>().ok());
+            let tag = parts.get(2).copied().unwrap_or("");
+            let abi = parts.get(3).copied().unwrap_or("");
+            Some(json!({
+                "identifier": identifier,
+                "name": android_system_image_name(description, api_level, tag, abi),
+                "description": description,
+                "apiLevel": api_level,
+                "tag": tag,
+                "abi": abi,
+            }))
+        })
+        .collect()
+}
+
+fn android_system_image_name(
+    description: &str,
+    api_level: Option<u32>,
+    tag: &str,
+    abi: &str,
+) -> String {
+    let api = api_level
+        .map(|level| format!("API {level}"))
+        .unwrap_or_else(|| "Android".to_owned());
+    if description.is_empty() {
+        return format!("{api} {tag} {abi}").trim().to_owned();
+    }
+    format!("{description} ({api})")
+}
+
+fn empty_to_null(value: &str) -> Value {
+    if value.is_empty() {
+        Value::Null
+    } else {
+        Value::String(value.to_owned())
+    }
+}
+
+fn validate_avd_name(name: &str) -> Result<(), AppError> {
+    if name.is_empty() {
+        return Err(AppError::bad_request("Request body must include `name`."));
+    }
+    if !name
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | '.'))
+    {
+        return Err(AppError::bad_request(
+            "Android emulator names may only contain letters, numbers, dots, dashes, and underscores.",
+        ));
+    }
+    Ok(())
+}
+
 fn read_command_stream(mut stream: impl Read) -> std::io::Result<Vec<u8>> {
     let mut buffer = Vec::new();
     stream.read_to_end(&mut buffer)?;
@@ -1372,6 +1618,31 @@ fn sdk_root() -> PathBuf {
         .map(PathBuf::from)
         .filter(|path| path.exists())
         .unwrap_or_else(|| home_dir().join("Library/Android/sdk"))
+}
+
+fn android_cmdline_tool_path(name: &str) -> PathBuf {
+    let root = sdk_root();
+    let latest = root.join("cmdline-tools/latest/bin").join(name);
+    if latest.exists() {
+        return latest;
+    }
+    let cmdline_tools = root.join("cmdline-tools");
+    if let Ok(entries) = std::fs::read_dir(&cmdline_tools) {
+        let mut candidates = entries
+            .filter_map(Result::ok)
+            .map(|entry| entry.path().join("bin").join(name))
+            .filter(|path| path.exists())
+            .collect::<Vec<_>>();
+        candidates.sort();
+        if let Some(path) = candidates.pop() {
+            return path;
+        }
+    }
+    let legacy = root.join("tools/bin").join(name);
+    if legacy.exists() {
+        return legacy;
+    }
+    latest
 }
 
 fn java_home() -> OsString {

--- a/server/src/api/routes.rs
+++ b/server/src/api/routes.rs
@@ -1,4 +1,4 @@
-use crate::android::{self, AndroidBridge};
+use crate::android::{self, AndroidBridge, AndroidEmulatorSpec};
 use crate::api::json::json;
 use crate::auth;
 use crate::config::Config;
@@ -7,7 +7,7 @@ use crate::error::AppError;
 use crate::inspector::{InspectorHub, PublishedInspector};
 use crate::logs::LogRegistry;
 use crate::metrics::counters::{ClientStreamStats, Metrics};
-use crate::native::bridge::{LogFilters, NativeBridge};
+use crate::native::bridge::{LogFilters, NativeBridge, NativePairedWatchSpec};
 use crate::performance::{
     sample_stack, DisplaySignal, ForegroundProcess, PerformanceQuery, PerformanceRegistry,
 };
@@ -182,6 +182,24 @@ struct UninstallPayload {
 #[derive(Deserialize)]
 struct PasteboardPayload {
     text: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateSimulatorPayload {
+    platform: Option<String>,
+    name: String,
+    device_type_identifier: String,
+    runtime_identifier: Option<String>,
+    paired_watch: Option<CreatePairedWatchPayload>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreatePairedWatchPayload {
+    name: String,
+    device_type_identifier: String,
+    runtime_identifier: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -668,7 +686,14 @@ pub fn router(state: AppState) -> Router {
             "/webkit-inspector-ui/{*path}",
             get(webkit_inspector_ui_file),
         )
-        .route("/api/simulators", get(list_simulators))
+        .route(
+            "/api/simulators",
+            get(list_simulators).post(create_simulator),
+        )
+        .route(
+            "/api/simulators/create-options",
+            get(simulator_create_options),
+        )
         .route("/api/simulators/{udid}/state", get(simulator_state))
         .route("/api/simulators/{udid}/processes", get(simulator_processes))
         .route(
@@ -1658,6 +1683,144 @@ async fn list_simulators(State(state): State<AppState>) -> Result<Json<Value>, A
     let simulators = all_device_values(state.clone(), false).await?;
     Ok(json(json_value!({
         "simulators": simulators,
+    })))
+}
+
+async fn simulator_create_options(State(state): State<AppState>) -> Result<Json<Value>, AppError> {
+    let mut options =
+        run_bridge_action(state.clone(), |bridge| bridge.simulator_creation_options()).await?;
+    let android_options =
+        match run_android_action(state, |android| android.creation_options()).await {
+            Ok(options) => options,
+            Err(error) => json_value!({
+                "deviceTypes": [],
+                "systemImages": [],
+                "unavailableReason": error.to_string(),
+            }),
+        };
+    if let Some(map) = options.as_object_mut() {
+        map.insert("android".to_owned(), android_options);
+    }
+    Ok(json(options))
+}
+
+async fn create_simulator(
+    State(state): State<AppState>,
+    Json(payload): Json<CreateSimulatorPayload>,
+) -> Result<Json<Value>, AppError> {
+    let platform = payload.platform.as_deref().map(str::trim).unwrap_or("ios");
+    let name = payload.name.trim().to_owned();
+    let device_type_identifier = payload.device_type_identifier.trim().to_owned();
+    if name.is_empty() {
+        return Err(AppError::bad_request("Request body must include `name`."));
+    }
+    if device_type_identifier.is_empty() {
+        return Err(AppError::bad_request(
+            "Request body must include `deviceTypeIdentifier`.",
+        ));
+    }
+
+    let runtime_identifier = trimmed_optional_string(payload.runtime_identifier);
+    if platform.eq_ignore_ascii_case("android") {
+        let system_image_identifier = runtime_identifier.ok_or_else(|| {
+            AppError::bad_request("Android emulator creation requires `runtimeIdentifier`.")
+        })?;
+        if payload.paired_watch.is_some() {
+            return Err(AppError::bad_request(
+                "Android emulator creation does not support `pairedWatch`.",
+            ));
+        }
+        let spec = AndroidEmulatorSpec {
+            name,
+            device_profile_identifier: device_type_identifier,
+            system_image_identifier,
+        };
+        let created =
+            run_android_action(state.clone(), move |android| android.create_emulator(spec)).await?;
+        let udid = created
+            .get("udid")
+            .and_then(Value::as_str)
+            .ok_or_else(|| AppError::internal("Android create did not return an emulator ID."))?
+            .to_owned();
+        let devices = all_device_values(state, true).await?;
+        let simulator = devices
+            .iter()
+            .find(|entry| entry.get("udid").and_then(Value::as_str) == Some(udid.as_str()))
+            .cloned()
+            .ok_or_else(|| {
+                AppError::not_found(format!("Created emulator {udid} was not found."))
+            })?;
+        return Ok(json(json_value!({
+            "ok": true,
+            "created": created,
+            "simulator": simulator,
+            "pairedWatchSimulator": null,
+        })));
+    }
+
+    let paired_watch = payload
+        .paired_watch
+        .map(|watch| {
+            let watch_name = watch.name.trim().to_owned();
+            let watch_device_type_identifier = watch.device_type_identifier.trim().to_owned();
+            if watch_name.is_empty() {
+                return Err(AppError::bad_request(
+                    "Paired watch creation requires `pairedWatch.name`.",
+                ));
+            }
+            if watch_device_type_identifier.is_empty() {
+                return Err(AppError::bad_request(
+                    "Paired watch creation requires `pairedWatch.deviceTypeIdentifier`.",
+                ));
+            }
+            Ok(NativePairedWatchSpec {
+                name: watch_name,
+                device_type_identifier: watch_device_type_identifier,
+                runtime_identifier: trimmed_optional_string(watch.runtime_identifier),
+            })
+        })
+        .transpose()?;
+    let action_name = name.clone();
+    let action_device_type_identifier = device_type_identifier.clone();
+    let action_runtime_identifier = runtime_identifier.clone();
+    let action_paired_watch = paired_watch.clone();
+    let created = run_bridge_action(state.clone(), move |bridge| {
+        bridge.create_simulator(
+            &action_name,
+            &action_device_type_identifier,
+            action_runtime_identifier.as_deref(),
+            action_paired_watch.as_ref(),
+        )
+    })
+    .await?;
+
+    let udid = created
+        .get("udid")
+        .and_then(Value::as_str)
+        .ok_or_else(|| AppError::internal("Native create did not return a simulator UDID."))?
+        .to_owned();
+    let paired_watch_udid = created
+        .get("pairedWatchUDID")
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    let devices = all_device_values(state, true).await?;
+    let simulator = devices
+        .iter()
+        .find(|entry| entry.get("udid").and_then(Value::as_str) == Some(udid.as_str()))
+        .cloned()
+        .ok_or_else(|| AppError::not_found(format!("Created simulator {udid} was not found.")))?;
+    let paired_watch_simulator = paired_watch_udid.as_deref().and_then(|watch_udid| {
+        devices
+            .iter()
+            .find(|entry| entry.get("udid").and_then(Value::as_str) == Some(watch_udid))
+            .cloned()
+    });
+
+    Ok(json(json_value!({
+        "ok": true,
+        "created": created,
+        "simulator": simulator,
+        "pairedWatchSimulator": paired_watch_simulator,
     })))
 }
 
@@ -6203,6 +6366,12 @@ fn first_non_empty_string(values: impl IntoIterator<Item = Option<String>>) -> S
         .map(|value| value.trim().to_owned())
         .find(|value| !value.is_empty())
         .unwrap_or_default()
+}
+
+fn trimmed_optional_string(value: Option<String>) -> Option<String> {
+    value
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
 }
 
 fn split_filter_values(value: Option<&str>) -> Vec<String> {

--- a/server/src/api/routes.rs
+++ b/server/src/api/routes.rs
@@ -1742,6 +1742,7 @@ async fn create_simulator(
             .and_then(Value::as_str)
             .ok_or_else(|| AppError::internal("Android create did not return an emulator ID."))?
             .to_owned();
+        boot_android_device(state.clone(), udid.clone()).await?;
         let devices = all_device_values(state, true).await?;
         let simulator = devices
             .iter()
@@ -1803,6 +1804,10 @@ async fn create_simulator(
         .get("pairedWatchUDID")
         .and_then(Value::as_str)
         .map(str::to_owned);
+    boot_ios_device(state.clone(), udid.clone()).await?;
+    if let Some(watch_udid) = paired_watch_udid.clone() {
+        boot_ios_device(state.clone(), watch_udid).await?;
+    }
     let devices = all_device_values(state, true).await?;
     let simulator = devices
         .iter()
@@ -2096,26 +2101,29 @@ fn performance_log_entry_matches(
     .any(|needle| haystack.contains(needle))
 }
 
+async fn boot_android_device(state: AppState, udid: String) -> Result<(), AppError> {
+    run_android_action(state, move |android| {
+        android.boot(&udid)?;
+        android.wait_until_booted(&udid, Duration::from_secs(240))?;
+        Ok(())
+    })
+    .await
+}
+
+async fn boot_ios_device(state: AppState, udid: String) -> Result<(), AppError> {
+    forget_lifecycle_session(&state, &udid);
+    run_bridge_action(state, move |bridge| bridge.boot_simulator(&udid)).await
+}
+
 async fn boot_simulator(
     State(state): State<AppState>,
     Path(udid): Path<String>,
 ) -> Result<Json<Value>, AppError> {
     if android::is_android_id(&udid) {
-        let action_udid = udid.clone();
-        run_android_action(state.clone(), move |android| {
-            android.boot(&action_udid)?;
-            android.wait_until_booted(&action_udid, Duration::from_secs(240))?;
-            Ok(())
-        })
-        .await?;
+        boot_android_device(state.clone(), udid.clone()).await?;
         return android_simulator_payload(state, udid).await;
     }
-    forget_lifecycle_session(&state, &udid);
-    let action_udid = udid.clone();
-    run_bridge_action(state.clone(), move |bridge| {
-        bridge.boot_simulator(&action_udid)
-    })
-    .await?;
+    boot_ios_device(state.clone(), udid.clone()).await?;
     simulator_payload(state, udid).await
 }
 
@@ -6416,7 +6424,25 @@ async fn all_device_values(state: AppState, force_refresh: bool) -> Result<Vec<V
     let android_devices =
         run_android_action(state.clone(), |android| android.list_devices()).await?;
     values.extend(state.android.enrich_devices(android_devices));
-    Ok(values)
+    Ok(booted_first(values))
+}
+
+fn booted_first(values: Vec<Value>) -> Vec<Value> {
+    let mut indexed_values = values.into_iter().enumerate().collect::<Vec<_>>();
+    indexed_values.sort_by(|(left_index, left), (right_index, right)| {
+        let left_booted = left
+            .get("isBooted")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let right_booted = right
+            .get("isBooted")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        right_booted
+            .cmp(&left_booted)
+            .then_with(|| left_index.cmp(right_index))
+    });
+    indexed_values.into_iter().map(|(_, value)| value).collect()
 }
 
 async fn list_simulators_cached(

--- a/server/src/native/bridge.rs
+++ b/server/src/native/bridge.rs
@@ -2,7 +2,7 @@ use crate::error::AppError;
 use crate::native::ffi;
 use serde::de::Error as DeError;
 use serde::{Deserialize, Serialize};
-use std::ffi::{c_void, CStr, CString};
+use std::ffi::{c_char, c_void, CStr, CString};
 use std::ptr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
@@ -40,6 +40,13 @@ pub struct Simulator {
     pub runtime_identifier: serde_json::Value,
     #[serde(rename = "runtimeName")]
     pub runtime_name: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct NativePairedWatchSpec {
+    pub name: String,
+    pub device_type_identifier: String,
+    pub runtime_identifier: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -174,6 +181,48 @@ impl NativeBridge {
         let payload: SimulatorsEnvelope =
             serde_json::from_str(&json).map_err(|e| AppError::internal(e.to_string()))?;
         Ok(payload.simulators)
+    }
+
+    pub fn simulator_creation_options(&self) -> Result<serde_json::Value, AppError> {
+        let json = unsafe {
+            let mut error = ptr::null_mut();
+            let raw = ffi::xcw_native_simulator_creation_options(&mut error);
+            string_from_raw(raw, error)?
+        };
+        serde_json::from_str(&json).map_err(|e| AppError::internal(e.to_string()))
+    }
+
+    pub fn create_simulator(
+        &self,
+        name: &str,
+        device_type_identifier: &str,
+        runtime_identifier: Option<&str>,
+        paired_watch: Option<&NativePairedWatchSpec>,
+    ) -> Result<serde_json::Value, AppError> {
+        let name = CString::new(name).map_err(|e| AppError::bad_request(e.to_string()))?;
+        let device_type_identifier = CString::new(device_type_identifier)
+            .map_err(|e| AppError::bad_request(e.to_string()))?;
+        let runtime_identifier = optional_c_string(runtime_identifier)?;
+        let paired_watch_name = optional_c_string(paired_watch.map(|watch| watch.name.as_str()))?;
+        let paired_watch_device_type_identifier =
+            optional_c_string(paired_watch.map(|watch| watch.device_type_identifier.as_str()))?;
+        let paired_watch_runtime_identifier =
+            optional_c_string(paired_watch.and_then(|watch| watch.runtime_identifier.as_deref()))?;
+
+        let json = unsafe {
+            let mut error = ptr::null_mut();
+            let raw = ffi::xcw_native_create_simulator(
+                name.as_ptr(),
+                device_type_identifier.as_ptr(),
+                optional_c_ptr(&runtime_identifier),
+                optional_c_ptr(&paired_watch_name),
+                optional_c_ptr(&paired_watch_device_type_identifier),
+                optional_c_ptr(&paired_watch_runtime_identifier),
+                &mut error,
+            );
+            string_from_raw(raw, error)?
+        };
+        serde_json::from_str(&json).map_err(|e| AppError::internal(e.to_string()))
     }
 
     pub fn boot_simulator(&self, udid: &str) -> Result<(), AppError> {
@@ -596,6 +645,16 @@ impl NativeBridge {
             Ok(NativeSession { handle })
         }
     }
+}
+
+fn optional_c_string(value: Option<&str>) -> Result<Option<CString>, AppError> {
+    value
+        .map(|value| CString::new(value).map_err(|e| AppError::bad_request(e.to_string())))
+        .transpose()
+}
+
+fn optional_c_ptr(value: &Option<CString>) -> *const c_char {
+    value.as_ref().map_or(ptr::null(), |value| value.as_ptr())
 }
 
 pub fn log_entry_matches(entry: &LogEntry, filters: &LogFilters) -> bool {

--- a/server/src/native/bridge.rs
+++ b/server/src/native/bridge.rs
@@ -40,6 +40,42 @@ pub struct Simulator {
     pub runtime_identifier: serde_json::Value,
     #[serde(rename = "runtimeName")]
     pub runtime_name: String,
+    #[serde(
+        rename = "pairedWatchUDID",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub paired_watch_udid: Option<String>,
+    #[serde(
+        rename = "pairedWatchName",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub paired_watch_name: Option<String>,
+    #[serde(
+        rename = "pairedPhoneUDID",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub paired_phone_udid: Option<String>,
+    #[serde(
+        rename = "pairedPhoneName",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub paired_phone_name: Option<String>,
+    #[serde(
+        rename = "devicePairIdentifier",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub device_pair_identifier: Option<String>,
+    #[serde(
+        rename = "devicePairState",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub device_pair_state: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/server/src/native/ffi.rs
+++ b/server/src/native/ffi.rs
@@ -35,6 +35,16 @@ unsafe extern "C" {
     pub fn xcw_native_run_main_loop_slice(duration_seconds: f64);
 
     pub fn xcw_native_list_simulators(error_message: *mut *mut c_char) -> *mut c_char;
+    pub fn xcw_native_simulator_creation_options(error_message: *mut *mut c_char) -> *mut c_char;
+    pub fn xcw_native_create_simulator(
+        name: *const c_char,
+        device_type_identifier: *const c_char,
+        runtime_identifier: *const c_char,
+        paired_watch_name: *const c_char,
+        paired_watch_device_type_identifier: *const c_char,
+        paired_watch_runtime_identifier: *const c_char,
+        error_message: *mut *mut c_char,
+    ) -> *mut c_char;
     pub fn xcw_native_boot_simulator(udid: *const c_char, error_message: *mut *mut c_char) -> bool;
     pub fn xcw_native_shutdown_simulator(
         udid: *const c_char,

--- a/server/src/simulators/registry.rs
+++ b/server/src/simulators/registry.rs
@@ -169,21 +169,11 @@ impl SessionRegistry<SimulatorSession> {
                             "rotationQuarterTurns": 0,
                         })
                     });
-                json!({
-                    "udid": simulator.udid,
-                    "name": simulator.name,
-                    "state": simulator.state,
-                    "isBooted": simulator.is_booted,
-                    "isAvailable": simulator.is_available,
-                    "lastBootedAt": simulator.last_booted_at,
-                    "dataPath": simulator.data_path,
-                    "logPath": simulator.log_path,
-                    "deviceTypeIdentifier": simulator.device_type_identifier,
-                    "deviceTypeName": simulator.device_type_name,
-                    "runtimeIdentifier": simulator.runtime_identifier,
-                    "runtimeName": simulator.runtime_name,
-                    "privateDisplay": private_display,
-                })
+                let mut entry = serde_json::to_value(&simulator).unwrap_or_else(|_| json!({}));
+                if let Some(object) = entry.as_object_mut() {
+                    object.insert("privateDisplay".to_owned(), private_display);
+                }
+                entry
             })
             .collect()
     }


### PR DESCRIPTION
## Summary
- Add a native-backed New Simulator flow in the menu with an iOS/Android switcher and macOS-style modal controls
- Support creating iOS simulators, paired Apple Watch simulators, and Android emulators from the same API path
- Auto-boot newly created simulators and keep the newly created device selected in the UI
- Surface booted simulators first in device lists
- Update API docs for the expanded create flow and options endpoint

## Testing
- Ran Rust and client builds/type checks successfully
- Validated the updated simulator creation options and modal flow in the local browser UI
- Confirmed the device list ordering and post-create selection behavior during local verification