### PR TITLE
feat: add drag-and-drop app install for selected simulators

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ simdeck boot <udid>
 simdeck shutdown <udid>
 simdeck erase <udid>
 simdeck install <udid> /path/to/App.app
+simdeck install <udid> /path/to/App.ipa
 simdeck install android:<avd-name> /path/to/app.apk
 simdeck uninstall <udid> com.example.App
 simdeck open-url <udid> https://example.com

--- a/cli/XCWSimctl.m
+++ b/cli/XCWSimctl.m
@@ -5,6 +5,10 @@
 #import "XCWPrivateSimulatorBooter.h"
 #import "XCWProcessRunner.h"
 
+#import <errno.h>
+#import <stdlib.h>
+#import <string.h>
+
 static NSString * const XCWSimctlErrorDomain = @"SimDeck.Simctl";
 
 @interface XCWSimctl ()
@@ -19,6 +23,9 @@ static NSString * const XCWSimctlErrorDomain = @"SimDeck.Simctl";
                               timeoutSec:(NSTimeInterval)timeoutSec
                                    error:(NSError * _Nullable __autoreleasing *)error;
 + (nullable NSDictionary *)listJSONPayloadWithError:(NSError * _Nullable __autoreleasing *)error;
++ (NSError *)errorWithDescription:(NSString *)description code:(NSInteger)code;
+- (BOOL)installAppBundleAtPath:(NSString *)appPath simulatorUDID:(NSString *)udid error:(NSError * _Nullable __autoreleasing *)error;
+- (BOOL)installIPAAtPath:(NSString *)ipaPath simulatorUDID:(NSString *)udid error:(NSError * _Nullable __autoreleasing *)error;
 
 @end
 
@@ -41,6 +48,70 @@ static NSString *XCWStringValue(id value) {
 
 static NSNumber *XCWNumberValue(id value) {
     return [value isKindOfClass:[NSNumber class]] ? value : nil;
+}
+
+static NSString * _Nullable XCWCreateTemporaryDirectory(NSString *prefix, NSError * _Nullable __autoreleasing *error) {
+    NSString *templatePath = [NSTemporaryDirectory() stringByAppendingPathComponent:[NSString stringWithFormat:@"%@-XXXXXX", prefix]];
+    char *directoryTemplate = strdup(templatePath.fileSystemRepresentation);
+    if (directoryTemplate == NULL) {
+        if (error != NULL) {
+            *error = [XCWSimctl errorWithDescription:@"Failed to allocate temporary IPA extraction path." code:15];
+        }
+        return nil;
+    }
+
+    char *createdPath = mkdtemp(directoryTemplate);
+    if (createdPath == NULL) {
+        if (error != NULL) {
+            *error = [XCWSimctl errorWithDescription:[NSString stringWithFormat:@"Failed to create temporary IPA extraction directory: %s", strerror(errno)] code:15];
+        }
+        free(directoryTemplate);
+        return nil;
+    }
+
+    NSString *path = [[NSFileManager defaultManager] stringWithFileSystemRepresentation:createdPath
+                                                                                 length:strlen(createdPath)];
+    free(directoryTemplate);
+    return path;
+}
+
+static NSString * _Nullable XCWAppBundlePathInExtractedIPA(NSString *extractedPath, NSError * _Nullable __autoreleasing *error) {
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSString *payloadPath = [extractedPath stringByAppendingPathComponent:@"Payload"];
+    BOOL isDirectory = NO;
+    if (![fileManager fileExistsAtPath:payloadPath isDirectory:&isDirectory] || !isDirectory) {
+        if (error != NULL) {
+            *error = [XCWSimctl errorWithDescription:@"IPA archive did not contain a Payload directory." code:15];
+        }
+        return nil;
+    }
+
+    NSArray<NSString *> *entries = [fileManager contentsOfDirectoryAtPath:payloadPath error:error];
+    if (entries == nil) {
+        return nil;
+    }
+
+    NSMutableArray<NSString *> *appPaths = [NSMutableArray array];
+    for (NSString *entry in entries) {
+        if ([entry.pathExtension caseInsensitiveCompare:@"app"] != NSOrderedSame) {
+            continue;
+        }
+        NSString *candidatePath = [payloadPath stringByAppendingPathComponent:entry];
+        BOOL candidateIsDirectory = NO;
+        if ([fileManager fileExistsAtPath:candidatePath isDirectory:&candidateIsDirectory] && candidateIsDirectory) {
+            [appPaths addObject:candidatePath];
+        }
+    }
+
+    if (appPaths.count == 0) {
+        if (error != NULL) {
+            *error = [XCWSimctl errorWithDescription:@"IPA archive did not contain a Payload/*.app bundle." code:15];
+        }
+        return nil;
+    }
+
+    [appPaths sortUsingSelector:@selector(localizedStandardCompare:)];
+    return appPaths.firstObject;
 }
 
 static NSString *XCWRuntimeDisplayName(NSDictionary *runtime, NSString *runtimeIdentifier) {
@@ -591,6 +662,54 @@ static NSString *XCWRuntimeDisplayName(NSDictionary *runtime, NSString *runtimeI
 }
 
 - (BOOL)installAppAtPath:(NSString *)appPath simulatorUDID:(NSString *)udid error:(NSError * _Nullable __autoreleasing *)error {
+    NSString *extension = appPath.pathExtension.lowercaseString;
+    if ([extension isEqualToString:@"ipa"]) {
+        return [self installIPAAtPath:appPath simulatorUDID:udid error:error];
+    }
+    if (![extension isEqualToString:@"app"]) {
+        if (error != NULL) {
+            *error = [self.class errorWithDescription:@"iOS simulator install expects an `.app` bundle or `.ipa` archive." code:15];
+        }
+        return NO;
+    }
+    return [self installAppBundleAtPath:appPath simulatorUDID:udid error:error];
+}
+
+- (BOOL)installIPAAtPath:(NSString *)ipaPath simulatorUDID:(NSString *)udid error:(NSError * _Nullable __autoreleasing *)error {
+    NSString *extractedPath = XCWCreateTemporaryDirectory(@"simdeck-ipa", error);
+    if (extractedPath == nil) {
+        return NO;
+    }
+
+    XCWProcessResult *extractResult = [XCWProcessRunner runLaunchPath:@"/usr/bin/ditto"
+                                                            arguments:@[@"-x", @"-k", ipaPath, extractedPath]
+                                                            inputData:nil
+                                                           timeoutSec:180
+                                                                error:error];
+    if (extractResult == nil) {
+        [[NSFileManager defaultManager] removeItemAtPath:extractedPath error:nil];
+        return NO;
+    }
+    if (extractResult.terminationStatus != 0) {
+        if (error != NULL) {
+            *error = [self.class errorWithDescription:extractResult.stderrString.length > 0 ? extractResult.stderrString : @"Unable to extract IPA archive." code:15];
+        }
+        [[NSFileManager defaultManager] removeItemAtPath:extractedPath error:nil];
+        return NO;
+    }
+
+    NSString *appBundlePath = XCWAppBundlePathInExtractedIPA(extractedPath, error);
+    if (appBundlePath == nil) {
+        [[NSFileManager defaultManager] removeItemAtPath:extractedPath error:nil];
+        return NO;
+    }
+
+    BOOL ok = [self installAppBundleAtPath:appBundlePath simulatorUDID:udid error:error];
+    [[NSFileManager defaultManager] removeItemAtPath:extractedPath error:nil];
+    return ok;
+}
+
+- (BOOL)installAppBundleAtPath:(NSString *)appPath simulatorUDID:(NSString *)udid error:(NSError * _Nullable __autoreleasing *)error {
     XCWProcessResult *result = [self.class runSimctl:@[@"install", udid, appPath] error:error];
     if (result == nil) {
         return NO;

--- a/client/src/api/controls.ts
+++ b/client/src/api/controls.ts
@@ -4,6 +4,7 @@ import type {
   ButtonPayload,
   CrownPayload,
   EdgeTouchPayload,
+  InstallUploadResponse,
   KeyPayload,
   LaunchPayload,
   MultiTouchPayload,
@@ -67,6 +68,23 @@ export function openSimulatorUrl(udid: string, payload: OpenUrlPayload) {
 
 export function launchSimulatorBundle(udid: string, payload: LaunchPayload) {
   return postSimulatorAction(udid, "launch", payload);
+}
+
+export function uploadSimulatorApp(
+  udid: string,
+  file: File,
+): Promise<InstallUploadResponse> {
+  return apiRequest<InstallUploadResponse>(
+    `/api/simulators/${encodeURIComponent(udid)}/install-upload`,
+    {
+      body: file,
+      headers: {
+        "Content-Type": "application/octet-stream",
+        "X-SimDeck-Filename": encodeURIComponent(file.name || "app-upload"),
+      },
+      method: "POST",
+    },
+  );
 }
 
 export function sendTouch(udid: string, payload: TouchPayload) {

--- a/client/src/api/types.ts
+++ b/client/src/api/types.ts
@@ -199,6 +199,13 @@ export interface SimulatorResponse {
   simulator: SimulatorMetadata;
 }
 
+export interface InstallUploadResponse {
+  action: "install";
+  fileName: string;
+  ok: boolean;
+  udid: string;
+}
+
 export interface SimulatorForegroundApp {
   appName?: string | null;
   bundleIdentifier?: string | null;

--- a/client/src/app/AppShell.tsx
+++ b/client/src/app/AppShell.tsx
@@ -28,6 +28,7 @@ import {
   simulatorControlSocketUrl,
   shutdownSimulator,
   toggleAppearance,
+  uploadSimulatorApp,
   type ControlMessage,
 } from "../api/controls";
 import {
@@ -331,6 +332,11 @@ type SimulatorTransition = {
   udid: string;
 };
 
+type AppInstallState = {
+  fileName?: string;
+  phase: "dragging" | "installing" | "installed";
+};
+
 export interface AppShellProps {
   apiRoot?: string;
   fixedSimulatorUDID?: string | null;
@@ -399,6 +405,8 @@ export function AppShell({
   const [pairingBusy, setPairingBusy] = useState(false);
   const [simulatorTransition, setSimulatorTransition] =
     useState<SimulatorTransition | null>(null);
+  const [appInstallState, setAppInstallState] =
+    useState<AppInstallState | null>(null);
   const [rotationQuarterTurns, setRotationQuarterTurns] = useState(
     initialViewportState.rotationQuarterTurns,
   );
@@ -456,6 +464,9 @@ export function AppShell({
     useState<SimulatorStateResponse | null>(null);
 
   const menuRef = useRef<HTMLDivElement | null>(null);
+  const appInstallInputRef = useRef<HTMLInputElement | null>(null);
+  const appInstallDragDepthRef = useRef(0);
+  const appInstallStatusTimeoutRef = useRef(0);
   const outerCanvasRef = useRef<HTMLDivElement | null>(null);
   const streamCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const [outerCanvasElement, setOuterCanvasElement] =
@@ -853,6 +864,18 @@ export function AppShell({
   }, [pan]);
 
   const isBooted = Boolean(selectedSimulator?.isBooted);
+  const isInstallingApp = appInstallState?.phase === "installing";
+  const canInstallApp = Boolean(
+    selectedSimulator?.isBooted && !isInstallingApp,
+  );
+  const appInstallAccept = isAndroidViewport ? ".apk" : ".ipa";
+  const appInstallOverlayLabel = appInstallState
+    ? appInstallStatusLabel(
+        appInstallState,
+        selectedSimulator,
+        isAndroidViewport,
+      )
+    : "";
   const autoViewportOffsetY =
     viewMode === "manual" ? 0 : -zoomDockReservedHeight / 2;
   const screenAspect = screenAspectRatio(effectiveDeviceNaturalSize);
@@ -1487,6 +1510,9 @@ export function AppShell({
       }
       if (touchIndicatorTimeoutRef.current) {
         clearTimeout(touchIndicatorTimeoutRef.current);
+      }
+      if (appInstallStatusTimeoutRef.current) {
+        clearTimeout(appInstallStatusTimeoutRef.current);
       }
     };
   }, []);
@@ -2210,6 +2236,152 @@ export function AppShell({
     void refresh();
   }
 
+  function openInstallAppPicker() {
+    if (!selectedSimulator) {
+      setLocalError("Select a simulator before installing an app.");
+      return;
+    }
+    if (!selectedSimulator.isBooted) {
+      setLocalError("Boot the selected simulator before installing an app.");
+      return;
+    }
+    appInstallInputRef.current?.click();
+  }
+
+  function handleInstallInputChange(
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) {
+    const file = event.currentTarget.files?.[0];
+    event.currentTarget.value = "";
+    if (!file) {
+      return;
+    }
+    void installAppFile(file, selectedSimulator);
+  }
+
+  function handleAppInstallDragEnter(event: React.DragEvent<HTMLElement>) {
+    if (!dragEventHasFiles(event.dataTransfer)) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    appInstallDragDepthRef.current += 1;
+    if (appInstallState?.phase !== "installing") {
+      setAppInstallState({ phase: "dragging" });
+    }
+  }
+
+  function handleAppInstallDragOver(event: React.DragEvent<HTMLElement>) {
+    if (!dragEventHasFiles(event.dataTransfer)) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    event.dataTransfer.dropEffect = canInstallApp ? "copy" : "none";
+  }
+
+  function handleAppInstallDragLeave(event: React.DragEvent<HTMLElement>) {
+    if (!dragEventHasFiles(event.dataTransfer)) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    appInstallDragDepthRef.current = Math.max(
+      0,
+      appInstallDragDepthRef.current - 1,
+    );
+    if (appInstallDragDepthRef.current === 0) {
+      setAppInstallState((current) =>
+        current?.phase === "dragging" ? null : current,
+      );
+    }
+  }
+
+  function handleAppInstallDrop(event: React.DragEvent<HTMLElement>) {
+    if (!dragEventHasFiles(event.dataTransfer)) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    appInstallDragDepthRef.current = 0;
+    const files = Array.from(event.dataTransfer.files);
+    if (files.length !== 1) {
+      setAppInstallState(null);
+      setLocalError("Drop one `.ipa` or `.apk` file at a time.");
+      return;
+    }
+    void installAppFile(files[0], selectedSimulator);
+  }
+
+  async function installAppFile(
+    file: File,
+    simulator: SimulatorMetadata | null,
+  ) {
+    if (appInstallState?.phase === "installing") {
+      setLocalError("Wait for the current app install to finish.");
+      return;
+    }
+    if (!simulator) {
+      setAppInstallState(null);
+      setLocalError("Select a simulator before installing an app.");
+      return;
+    }
+    if (!simulator.isBooted) {
+      setAppInstallState(null);
+      setLocalError("Boot the selected simulator before installing an app.");
+      return;
+    }
+
+    const appKind = installableAppKind(file.name);
+    const simulatorIsAndroid = isAndroidSimulator(simulator);
+    if (!appKind) {
+      setAppInstallState(null);
+      setLocalError(
+        simulatorIsAndroid
+          ? "Drop an `.apk` file for Android emulators."
+          : "Drop an `.ipa` file for iOS simulators.",
+      );
+      return;
+    }
+    if (simulatorIsAndroid && appKind !== "apk") {
+      setAppInstallState(null);
+      setLocalError("Android emulators can only install `.apk` files.");
+      return;
+    }
+    if (!simulatorIsAndroid && appKind !== "ipa") {
+      setAppInstallState(null);
+      setLocalError("iOS simulators can only install `.ipa` files.");
+      return;
+    }
+
+    const fileName = file.name || "app";
+    setLocalError("");
+    setAppInstallState({ fileName, phase: "installing" });
+    try {
+      await uploadSimulatorApp(simulator.udid, file);
+      setAppInstallState({ fileName, phase: "installed" });
+      clearAppInstallStatusLater(fileName);
+      await refresh();
+    } catch (error) {
+      setAppInstallState(null);
+      setLocalError(error instanceof Error ? error.message : "Install failed.");
+    }
+  }
+
+  function clearAppInstallStatusLater(fileName: string) {
+    if (appInstallStatusTimeoutRef.current) {
+      window.clearTimeout(appInstallStatusTimeoutRef.current);
+    }
+    appInstallStatusTimeoutRef.current = window.setTimeout(() => {
+      appInstallStatusTimeoutRef.current = 0;
+      setAppInstallState((current) =>
+        current?.phase === "installed" && current.fileName === fileName
+          ? null
+          : current,
+      );
+    }, 1800);
+  }
+
   async function submitPairing(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     const code = pairingCode.trim();
@@ -2262,7 +2434,17 @@ export function AppShell({
           </form>
         </div>
       ) : null}
+      <input
+        accept={appInstallAccept}
+        aria-hidden="true"
+        onChange={handleInstallInputChange}
+        ref={appInstallInputRef}
+        style={{ display: "none" }}
+        tabIndex={-1}
+        type="file"
+      />
       <Toolbar
+        canInstallApp={canInstallApp}
         closeMenu={() => setMenuOpen(false)}
         debugVisible={debugVisible}
         error={toolbarError}
@@ -2305,6 +2487,7 @@ export function AppShell({
             void runAction(() => pressHome(selectedSimulator.udid), false);
           }
         }}
+        onInstallAppPrompt={openInstallAppPicker}
         onOpenAppSwitcher={() => {
           if (!selectedSimulator) {
             return;
@@ -2415,6 +2598,7 @@ export function AppShell({
       />
       <SimulatorViewport
         accessibilityHoveredId={accessibilityHoveredId}
+        appInstallOverlayLabel={appInstallOverlayLabel}
         accessibilityPanel={
           <AccessibilityInspector
             availableSources={accessibilityAvailableSources}
@@ -2470,6 +2654,12 @@ export function AppShell({
         isLoading={isLoading}
         isStreamError={viewportHasStreamError}
         isPanning={pointerInput.isPanning}
+        isAppInstallDragging={appInstallState?.phase === "dragging"}
+        isAppInstalling={appInstallState?.phase === "installing"}
+        onAppInstallDragEnter={handleAppInstallDragEnter}
+        onAppInstallDragLeave={handleAppInstallDragLeave}
+        onAppInstallDragOver={handleAppInstallDragOver}
+        onAppInstallDrop={handleAppInstallDrop}
         onChromeButtonEvent={sendHardwareButtonEvent}
         onPanPointerMove={pointerInput.handlePanPointerMove}
         onPanPointerUp={pointerInput.handlePanPointerUp}
@@ -2851,6 +3041,42 @@ function isAndroidSimulator(simulator: SimulatorMetadata | null): boolean {
     simulator?.deviceTypeIdentifier === "android-emulator" ||
     simulator?.udid.startsWith("android:"),
   );
+}
+
+function dragEventHasFiles(dataTransfer: DataTransfer): boolean {
+  return Array.from(dataTransfer.types).includes("Files");
+}
+
+function installableAppKind(fileName: string): "apk" | "ipa" | null {
+  const lower = fileName.trim().toLowerCase();
+  if (lower.endsWith(".apk")) {
+    return "apk";
+  }
+  if (lower.endsWith(".ipa")) {
+    return "ipa";
+  }
+  return null;
+}
+
+function appInstallStatusLabel(
+  state: AppInstallState,
+  simulator: SimulatorMetadata | null,
+  android: boolean,
+): string {
+  const expected = android ? "APK" : "IPA";
+  if (state.phase === "dragging") {
+    if (!simulator) {
+      return "Select a simulator before installing";
+    }
+    if (!simulator.isBooted) {
+      return "Boot selected simulator before installing";
+    }
+    return `Drop ${expected} to install on ${simulator.name}`;
+  }
+  if (state.phase === "installing") {
+    return `Installing ${state.fileName ?? expected}...`;
+  }
+  return `Installed ${state.fileName ?? expected}`;
 }
 
 function streamConfigsEqual(left: StreamConfig, right: StreamConfig): boolean {

--- a/client/src/features/simulators/SimulatorMenu.tsx
+++ b/client/src/features/simulators/SimulatorMenu.tsx
@@ -19,6 +19,7 @@ interface SimulatorMenuProps {
   filteredSimulators: SimulatorMetadata[];
   hideSimulatorSelection?: boolean;
   isLoading: boolean;
+  canInstallApp: boolean;
   menuOpen: boolean;
   menuRef: RefObject<HTMLDivElement | null>;
   onBoot: () => void;
@@ -26,6 +27,7 @@ interface SimulatorMenuProps {
   onCloseMenu: () => void;
   onDismissKeyboard: () => void;
   onHome: () => void;
+  onInstallAppPrompt: () => void;
   onOpenAppSwitcher: () => void;
   onOpenBundlePrompt: () => void;
   onOpenNewSimulator: () => void;
@@ -56,6 +58,7 @@ export function SimulatorMenu({
   filteredSimulators,
   hideSimulatorSelection = false,
   isLoading,
+  canInstallApp,
   menuOpen,
   menuRef,
   onBoot,
@@ -63,6 +66,7 @@ export function SimulatorMenu({
   onCloseMenu,
   onDismissKeyboard,
   onHome,
+  onInstallAppPrompt,
   onOpenAppSwitcher,
   onOpenBundlePrompt,
   onOpenNewSimulator,
@@ -262,6 +266,16 @@ export function SimulatorMenu({
                 ) : null}
                 <button className="menu-action" onClick={onOpenUrlPrompt}>
                   Open URL…
+                </button>
+                <button
+                  className="menu-action"
+                  disabled={!canInstallApp}
+                  onClick={() => {
+                    onInstallAppPrompt();
+                    onCloseMenu();
+                  }}
+                >
+                  Install App…
                 </button>
                 <button className="menu-action" onClick={onOpenBundlePrompt}>
                   Launch Bundle…

--- a/client/src/features/toolbar/Toolbar.tsx
+++ b/client/src/features/toolbar/Toolbar.tsx
@@ -29,10 +29,12 @@ interface ToolbarProps {
   hierarchyVisible: boolean;
   hideSimulatorSelection?: boolean;
   isLoading: boolean;
+  canInstallApp: boolean;
   onBoot: () => void;
   onChangeSearch: (value: string) => void;
   onDismissKeyboard: () => void;
   onHome: () => void;
+  onInstallAppPrompt: () => void;
   onOpenAppSwitcher: () => void;
   onOpenBundlePrompt: () => void;
   onOpenNewSimulator: () => void;
@@ -73,12 +75,14 @@ export function Toolbar({
   hierarchyVisible,
   hideSimulatorSelection = false,
   isLoading,
+  canInstallApp,
   menuOpen,
   menuRef,
   onBoot,
   onChangeSearch,
   onDismissKeyboard,
   onHome,
+  onInstallAppPrompt,
   onOpenAppSwitcher,
   onOpenBundlePrompt,
   onOpenNewSimulator,
@@ -149,6 +153,7 @@ export function Toolbar({
           onCloseMenu={closeMenu}
           onDismissKeyboard={onDismissKeyboard}
           onHome={onHome}
+          onInstallAppPrompt={onInstallAppPrompt}
           onOpenAppSwitcher={onOpenAppSwitcher}
           onOpenBundlePrompt={onOpenBundlePrompt}
           onOpenNewSimulator={onOpenNewSimulator}
@@ -169,6 +174,7 @@ export function Toolbar({
           setSelectedUDID={setSelectedUDID}
           showBootButton={showBootButton}
           showStopButton={showStopButton}
+          canInstallApp={canInstallApp}
           streamConfig={streamConfig}
           streamTransport={streamTransport}
           touchOverlayVisible={touchOverlayVisible}

--- a/client/src/features/viewport/SimulatorViewport.tsx
+++ b/client/src/features/viewport/SimulatorViewport.tsx
@@ -11,6 +11,7 @@ import type { TouchIndicator, ViewMode } from "./types";
 
 interface SimulatorViewportProps {
   accessibilityHoveredId: string | null;
+  appInstallOverlayLabel: string;
   debugPanel: ReactNode;
   accessibilityPanel: ReactNode;
   accessibilityPickerActive: boolean;
@@ -30,6 +31,12 @@ interface SimulatorViewportProps {
   isLoading: boolean;
   isStreamError: boolean;
   isPanning: boolean;
+  isAppInstallDragging: boolean;
+  isAppInstalling: boolean;
+  onAppInstallDragEnter: (event: React.DragEvent<HTMLElement>) => void;
+  onAppInstallDragLeave: (event: React.DragEvent<HTMLElement>) => void;
+  onAppInstallDragOver: (event: React.DragEvent<HTMLElement>) => void;
+  onAppInstallDrop: (event: React.DragEvent<HTMLElement>) => void;
   onChromeButtonEvent: (
     button: string,
     phase: "down" | "up",
@@ -74,6 +81,7 @@ interface SimulatorViewportProps {
 
 export function SimulatorViewport({
   accessibilityHoveredId,
+  appInstallOverlayLabel,
   accessibilityPanel,
   accessibilityPickerActive,
   accessibilityRoots,
@@ -93,6 +101,12 @@ export function SimulatorViewport({
   isLoading,
   isStreamError,
   isPanning,
+  isAppInstallDragging,
+  isAppInstalling,
+  onAppInstallDragEnter,
+  onAppInstallDragLeave,
+  onAppInstallDragOver,
+  onAppInstallDrop,
   onChromeButtonEvent,
   chromeButtonUrl,
   onPanPointerMove,
@@ -152,6 +166,10 @@ export function SimulatorViewport({
       <div
         className={`canvas ${effectiveZoom > fitScale + 0.001 ? "pan-enabled" : ""} ${isPanning ? "panning" : ""}`}
         onContextMenu={(event) => event.preventDefault()}
+        onDragEnter={onAppInstallDragEnter}
+        onDragLeave={onAppInstallDragLeave}
+        onDragOver={onAppInstallDragOver}
+        onDrop={onAppInstallDrop}
         onPointerCancel={onPanPointerUp}
         onPointerDown={(event) => {
           if (event.target !== event.currentTarget) {
@@ -229,6 +247,20 @@ export function SimulatorViewport({
             role="status"
           >
             <span className="loading-spinner" aria-hidden="true" />
+          </div>
+        ) : null}
+        {appInstallOverlayLabel ? (
+          <div
+            aria-live="polite"
+            className={`app-install-overlay ${
+              isAppInstallDragging ? "dragging" : ""
+            } ${isAppInstalling ? "installing" : ""}`}
+            role="status"
+          >
+            {isAppInstalling ? (
+              <span className="loading-spinner" aria-hidden="true" />
+            ) : null}
+            <span>{appInstallOverlayLabel}</span>
           </div>
         ) : null}
         {debugPanel ? <div className="debug-overlay">{debugPanel}</div> : null}

--- a/client/src/styles/components.css
+++ b/client/src/styles/components.css
@@ -483,6 +483,16 @@
   color: var(--text);
 }
 
+.menu-action:disabled {
+  color: var(--text-muted);
+  cursor: default;
+  opacity: 0.55;
+}
+
+.menu-action:disabled:hover {
+  background: transparent;
+}
+
 .mobile-menu-action {
   display: none;
 }
@@ -2636,6 +2646,34 @@
 
 .canvas-loading p {
   margin: 0;
+}
+
+.app-install-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 13;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 24px;
+  background: color-mix(in srgb, var(--canvas-bg) 68%, transparent);
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 650;
+  line-height: 1.35;
+  text-align: center;
+  pointer-events: none;
+}
+
+.app-install-overlay.dragging {
+  background: color-mix(in srgb, var(--accent) 16%, var(--canvas-bg));
+  outline: 2px solid color-mix(in srgb, var(--accent) 65%, transparent);
+  outline-offset: -10px;
+}
+
+.app-install-overlay.installing {
+  background: color-mix(in srgb, var(--canvas-bg) 76%, transparent);
 }
 
 .loading-spinner {

--- a/docs/api/rest.md
+++ b/docs/api/rest.md
@@ -97,12 +97,16 @@ Android:
 
 ## Apps
 
-| Method | Path                               | Body                                |
-| ------ | ---------------------------------- | ----------------------------------- |
-| `POST` | `/api/simulators/{udid}/install`   | `{ "appPath": "/path/to/App.app" }` |
-| `POST` | `/api/simulators/{udid}/uninstall` | `{ "bundleId": "com.example.App" }` |
-| `POST` | `/api/simulators/{udid}/launch`    | `{ "bundleId": "com.example.App" }` |
-| `POST` | `/api/simulators/{udid}/open-url`  | `{ "url": "https://example.com" }`  |
+| Method | Path                                    | Body                                                 |
+| ------ | --------------------------------------- | ---------------------------------------------------- |
+| `POST` | `/api/simulators/{udid}/install`        | `{ "appPath": "/path/to/App.app" }`                  |
+| `POST` | `/api/simulators/{udid}/install-upload` | Raw `.ipa` or `.apk` bytes with `x-simdeck-filename` |
+| `POST` | `/api/simulators/{udid}/uninstall`      | `{ "bundleId": "com.example.App" }`                  |
+| `POST` | `/api/simulators/{udid}/launch`         | `{ "bundleId": "com.example.App" }`                  |
+| `POST` | `/api/simulators/{udid}/open-url`       | `{ "url": "https://example.com" }`                   |
+
+`install-upload` is intended for browser clients. iOS simulator uploads must be
+`.ipa` archives; Android emulator uploads must be `.apk` files.
 
 ## Performance
 

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -43,6 +43,7 @@ inventory, including paths and display metadata.
 
 ```sh
 simdeck install <udid> /path/to/App.app
+simdeck install <udid> /path/to/App.ipa
 simdeck install android:<avd-name> /path/to/app.apk
 simdeck uninstall <udid> com.example.App
 simdeck launch <udid> com.example.App

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -33,6 +33,7 @@ SIMDECK_SERVER_URL=http://127.0.0.1:4310 simdeck list
 simdeck list
 simdeck boot <udid>
 simdeck install <udid> /path/to/App.app
+simdeck install <udid> /path/to/App.ipa
 simdeck launch <udid> com.example.App
 simdeck open-url <udid> https://example.com
 simdeck tap <udid> --label "Continue" --wait-timeout-ms 5000

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -27,6 +27,7 @@ Open the local URL, pick a device, and use the toolbar or CLI commands:
 simdeck list
 simdeck boot <udid>
 simdeck install <udid> /path/to/App.app
+simdeck install <udid> /path/to/App.ipa
 simdeck launch <udid> com.example.App
 simdeck tap <udid> --label "Continue" --wait-timeout-ms 5000
 simdeck describe <udid> --format agent --max-depth 3

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -40,6 +40,7 @@ Android emulator IDs are prefixed with `android:`.
 
 ```sh
 simdeck install <udid> /path/to/App.app
+simdeck install <udid> /path/to/App.ipa
 simdeck launch <udid> com.example.App
 simdeck open-url <udid> myapp://debug
 ```

--- a/server/src/api/routes.rs
+++ b/server/src/api/routes.rs
@@ -2254,7 +2254,7 @@ fn uploaded_app_file_name(headers: &HeaderMap) -> Result<String, AppError> {
 
 fn sanitize_upload_file_name(raw_name: &str) -> String {
     let candidate = raw_name
-        .rsplit(|ch| ch == '/' || ch == '\\')
+        .rsplit(['/', '\\'])
         .next()
         .unwrap_or(raw_name)
         .trim();

--- a/server/src/api/routes.rs
+++ b/server/src/api/routes.rs
@@ -19,7 +19,7 @@ use crate::transport::webrtc::AndroidWebRtcSource;
 use crate::webkit;
 use axum::body::Body;
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
-use axum::extract::{ConnectInfo, Path, Query, State};
+use axum::extract::{ConnectInfo, DefaultBodyLimit, Path, Query, State};
 use axum::http::{header, HeaderMap, Method, Request, StatusCode, Uri};
 use axum::middleware::{from_fn_with_state, Next};
 use axum::response::{IntoResponse, Redirect, Response};
@@ -58,6 +58,8 @@ const CHROME_DEVTOOLS_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(1);
 const FOREGROUND_APP_CACHE_TTL: Duration = Duration::from_secs(3);
 const FOREGROUND_APP_STALE_TTL: Duration = Duration::from_secs(30);
 const SAFARI_ACTIVE_TAB_HINT_TIMEOUT: Duration = Duration::from_millis(750);
+const APP_UPLOAD_FILE_NAME_HEADER: &str = "x-simdeck-filename";
+const MAX_APP_UPLOAD_BYTES: usize = 1024 * 1024 * 1024;
 
 static FOREGROUND_APP_CACHE: OnceLock<StdMutex<HashMap<String, CachedForegroundApp>>> =
     OnceLock::new();
@@ -712,6 +714,10 @@ pub fn router(state: AppState) -> Router {
         .route("/api/simulators/{udid}/shutdown", post(shutdown_simulator))
         .route("/api/simulators/{udid}/erase", post(erase_simulator))
         .route("/api/simulators/{udid}/install", post(install_app))
+        .route(
+            "/api/simulators/{udid}/install-upload",
+            post(upload_install_app).layer(DefaultBodyLimit::max(MAX_APP_UPLOAD_BYTES)),
+        )
         .route("/api/simulators/{udid}/uninstall", post(uninstall_app))
         .route(
             "/api/simulators/{udid}/pasteboard",
@@ -2178,20 +2184,164 @@ async fn install_app(
             "Request body must include `appPath`.",
         ));
     }
+    install_app_path(state, udid, payload.app_path).await?;
+    Ok(json(json_value!({ "ok": true })))
+}
+
+async fn upload_install_app(
+    State(state): State<AppState>,
+    Path(udid): Path<String>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Json<Value>, AppError> {
+    if body.is_empty() {
+        return Err(AppError::bad_request("Uploaded app file is empty."));
+    }
+    let file_name = uploaded_app_file_name(&headers)?;
+    let app_kind = uploaded_app_kind(&file_name)?;
+    validate_uploaded_app_target(&udid, app_kind)?;
+    let upload_path = write_uploaded_app_file(&file_name, &body).await?;
+    let app_path = upload_path.to_string_lossy().to_string();
+    let install_result = install_app_path(state, udid.clone(), app_path).await;
+    let _ = tokio::fs::remove_file(&upload_path).await;
+    install_result?;
+    Ok(json(json_value!({
+        "ok": true,
+        "udid": udid,
+        "action": "install",
+        "fileName": file_name,
+    })))
+}
+
+async fn install_app_path(state: AppState, udid: String, app_path: String) -> Result<(), AppError> {
     if android::is_android_id(&udid) {
         let action_udid = udid.clone();
+        let action_path = app_path.clone();
         run_android_action(state, move |android| {
-            android.install_app(&action_udid, &payload.app_path)
+            android.install_app(&action_udid, &action_path)
         })
         .await?;
-        return Ok(json(json_value!({ "ok": true })));
+        return Ok(());
     }
     let action_udid = udid.clone();
+    let action_path = app_path.clone();
     run_bridge_action(state, move |bridge| {
-        bridge.install_app(&action_udid, &payload.app_path)
+        bridge.install_app(&action_udid, &action_path)
     })
     .await?;
-    Ok(json(json_value!({ "ok": true })))
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum UploadedAppKind {
+    Apk,
+    Ipa,
+}
+
+fn uploaded_app_file_name(headers: &HeaderMap) -> Result<String, AppError> {
+    let raw_name = headers
+        .get(APP_UPLOAD_FILE_NAME_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("app-upload");
+    let file_name = sanitize_upload_file_name(raw_name);
+    if file_name.is_empty() {
+        return Err(AppError::bad_request(
+            "Uploaded app must include a valid file name.",
+        ));
+    }
+    Ok(file_name)
+}
+
+fn sanitize_upload_file_name(raw_name: &str) -> String {
+    let candidate = raw_name
+        .rsplit(|ch| ch == '/' || ch == '\\')
+        .next()
+        .unwrap_or(raw_name)
+        .trim();
+    let mut sanitized = String::with_capacity(candidate.len().min(160));
+    for ch in candidate.chars() {
+        if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-' | '_') {
+            sanitized.push(ch);
+        } else if ch.is_ascii_whitespace() {
+            sanitized.push('-');
+        }
+    }
+    while sanitized.starts_with('.') {
+        sanitized.remove(0);
+    }
+    while sanitized.contains("..") {
+        sanitized = sanitized.replace("..", ".");
+    }
+    if sanitized.len() > 160 {
+        let extension = std::path::Path::new(&sanitized)
+            .extension()
+            .and_then(|value| value.to_str())
+            .map(ToOwned::to_owned);
+        sanitized.truncate(140);
+        if let Some(extension) = extension {
+            let suffix = format!(".{extension}");
+            if !sanitized.ends_with(&suffix) {
+                sanitized.push_str(&suffix);
+            }
+        }
+    }
+    sanitized
+}
+
+fn uploaded_app_kind(file_name: &str) -> Result<UploadedAppKind, AppError> {
+    let extension = std::path::Path::new(file_name)
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    match extension.as_str() {
+        "apk" => Ok(UploadedAppKind::Apk),
+        "ipa" => Ok(UploadedAppKind::Ipa),
+        _ => Err(AppError::bad_request(
+            "Drop an `.ipa` for iOS simulators or an `.apk` for Android emulators.",
+        )),
+    }
+}
+
+fn validate_uploaded_app_target(udid: &str, app_kind: UploadedAppKind) -> Result<(), AppError> {
+    match (android::is_android_id(udid), app_kind) {
+        (true, UploadedAppKind::Apk) | (false, UploadedAppKind::Ipa) => Ok(()),
+        (true, UploadedAppKind::Ipa) => Err(AppError::bad_request(
+            "Android emulators can only install `.apk` uploads.",
+        )),
+        (false, UploadedAppKind::Apk) => Err(AppError::bad_request(
+            "iOS simulators can only install `.ipa` uploads.",
+        )),
+    }
+}
+
+async fn write_uploaded_app_file(
+    file_name: &str,
+    body: &Bytes,
+) -> Result<std::path::PathBuf, AppError> {
+    let upload_dir = env::temp_dir().join("simdeck").join("uploads");
+    tokio::fs::create_dir_all(&upload_dir)
+        .await
+        .map_err(|error| {
+            AppError::internal(format!(
+                "Unable to create upload directory {}: {error}",
+                upload_dir.display()
+            ))
+        })?;
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_nanos();
+    let path = upload_dir.join(format!("{}-{}-{file_name}", std::process::id(), timestamp));
+    tokio::fs::write(&path, body.as_ref())
+        .await
+        .map_err(|error| {
+            AppError::internal(format!(
+                "Unable to save uploaded app {}: {error}",
+                path.display()
+            ))
+        })?;
+    Ok(path)
 }
 
 async fn uninstall_app(

--- a/server/src/auth.rs
+++ b/server/src/auth.rs
@@ -126,7 +126,9 @@ pub fn append_cors_headers(
     );
     response_headers.insert(
         header::ACCESS_CONTROL_ALLOW_HEADERS,
-        HeaderValue::from_static("content-type, authorization, x-simdeck-token"),
+        HeaderValue::from_static(
+            "content-type, authorization, x-simdeck-token, x-simdeck-filename",
+        ),
     );
     response_headers.insert(
         header::ACCESS_CONTROL_ALLOW_CREDENTIALS,

--- a/skills/simdeck/SKILL.md
+++ b/skills/simdeck/SKILL.md
@@ -46,6 +46,7 @@ simdeck shutdown <UDID>
 simdeck erase <UDID>
 simdeck core-simulator restart
 simdeck install <UDID> /path/to/App.app
+simdeck install <UDID> /path/to/App.ipa
 simdeck install android:<AVD_NAME> /path/to/app.apk
 simdeck launch <UDID> com.example.App
 simdeck uninstall <UDID> com.example.App


### PR DESCRIPTION
## Summary
- Add a browser upload install route for dropped `.ipa` and `.apk` files on the selected booted simulator
- Expand iOS installs to accept `.ipa` archives by extracting `Payload/*.app` before `simctl install`
- Wire the React client to support menu-only install actions, file picking, and drag/drop feedback on the viewport
- Update REST, CLI, README, and SimDeck skill docs to reflect the new install flow

## Testing
- `cargo test --manifest-path server/Cargo.toml`
- `npm run --prefix client typecheck`
- `npm run --prefix client test`
- `npm run build:client`
- `npm run build:cli`
- `git diff --check`