### PR TITLE
Add bezel-aware screenshots and screen recording support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,8 @@ Useful direct commands:
 ./build/simdeck pasteboard set <udid> "hello"
 ./build/simdeck pasteboard get <udid>
 ./build/simdeck screenshot <udid> --output screen.png
+./build/simdeck screenshot <udid> --with-bezel --output screen-bezel.png
+./build/simdeck record <udid> --seconds 5 --output screen-recording.mp4
 ./build/simdeck describe <udid>
 ./build/simdeck tap <udid> 120 240
 ./build/simdeck tap <udid> --label "Continue" --wait-timeout-ms 5000

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ simdeck toggle-appearance <udid>
 simdeck pasteboard set <udid> "hello"
 simdeck pasteboard get <udid>
 simdeck screenshot <udid> --output screen.png
+simdeck screenshot <udid> --with-bezel --output screen-bezel.png
+simdeck record <udid> --seconds 5 --output screen-recording.mp4
 simdeck stream <udid> --frames 120 > stream.h264
 simdeck describe <udid>
 simdeck describe <udid> --format agent --max-depth 4
@@ -206,6 +208,8 @@ try {
   await sim.tap(0.5, 0.5);
   await sim.waitFor({ label: "Continue" });
   await sim.screenshot();
+  await sim.screenshot({ withBezel: true });
+  await sim.record({ seconds: 5 });
 } finally {
   sim.close();
 }

--- a/cli/XCWChromeRenderer.h
+++ b/cli/XCWChromeRenderer.h
@@ -15,6 +15,9 @@ NS_ASSUME_NONNULL_BEGIN
                                           error:(NSError * _Nullable * _Nullable)error;
 + (nullable NSData *)screenMaskPNGDataForDeviceName:(NSString *)deviceName
                                               error:(NSError * _Nullable * _Nullable)error;
++ (nullable NSData *)screenshotPNGDataForDeviceName:(NSString *)deviceName
+                                      screenPNGData:(NSData *)screenPNGData
+                                              error:(NSError * _Nullable * _Nullable)error;
 + (nullable NSDictionary<NSString *, id> *)profileForDeviceName:(NSString *)deviceName
                                                           error:(NSError * _Nullable * _Nullable)error;
 

--- a/cli/XCWChromeRenderer.m
+++ b/cli/XCWChromeRenderer.m
@@ -249,6 +249,111 @@ static NSString * const XCWChromeRendererErrorDomain = @"SimDeck.ChromeRenderer"
     return [self PNGDataForPDFAtPath:maskPath scale:1.0 error:error];
 }
 
++ (nullable NSData *)screenshotPNGDataForDeviceName:(NSString *)deviceName
+                                      screenPNGData:(NSData *)screenPNGData
+                                              error:(NSError * _Nullable __autoreleasing *)error {
+    NSDictionary *profile = [self profileForDeviceName:deviceName error:error];
+    if (profile == nil) {
+        return nil;
+    }
+
+    NSData *chromePNGData = [self PNGDataForDeviceName:deviceName includeButtons:YES error:error];
+    if (chromePNGData == nil) {
+        return nil;
+    }
+
+    NSImage *screenImage = [[NSImage alloc] initWithData:screenPNGData];
+    NSImage *chromeImage = [[NSImage alloc] initWithData:chromePNGData];
+    if (screenImage == nil || chromeImage == nil) {
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:XCWChromeRendererErrorDomain
+                                         code:15
+                                     userInfo:@{
+                NSLocalizedDescriptionKey: @"Unable to decode simulator screenshot or chrome PNG data.",
+            }];
+        }
+        return nil;
+    }
+
+    CGFloat scale = 3.0;
+    CGFloat totalWidth = [self numberValue:profile[@"totalWidth"]];
+    CGFloat totalHeight = [self numberValue:profile[@"totalHeight"]];
+    CGFloat screenX = [self numberValue:profile[@"screenX"]];
+    CGFloat screenY = [self numberValue:profile[@"screenY"]];
+    CGFloat screenWidth = [self numberValue:profile[@"screenWidth"]];
+    CGFloat screenHeight = [self numberValue:profile[@"screenHeight"]];
+    NSInteger pixelWidth = MAX((NSInteger)ceil(totalWidth * scale), 1);
+    NSInteger pixelHeight = MAX((NSInteger)ceil(totalHeight * scale), 1);
+    if (totalWidth <= 0.0 || totalHeight <= 0.0 || screenWidth <= 0.0 || screenHeight <= 0.0) {
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:XCWChromeRendererErrorDomain
+                                         code:16
+                                     userInfo:@{
+                NSLocalizedDescriptionKey: @"Device chrome profile did not include usable screenshot geometry.",
+            }];
+        }
+        return nil;
+    }
+
+    NSBitmapImageRep *bitmap = [[NSBitmapImageRep alloc] initWithBitmapDataPlanes:NULL
+                                                                       pixelsWide:pixelWidth
+                                                                       pixelsHigh:pixelHeight
+                                                                    bitsPerSample:8
+                                                                  samplesPerPixel:4
+                                                                         hasAlpha:YES
+                                                                         isPlanar:NO
+                                                                   colorSpaceName:NSDeviceRGBColorSpace
+                                                                      bytesPerRow:0
+                                                                     bitsPerPixel:32];
+    if (bitmap == nil) {
+        if (error != NULL) {
+            *error = [NSError errorWithDomain:XCWChromeRendererErrorDomain
+                                         code:17
+                                     userInfo:@{
+                NSLocalizedDescriptionKey: @"Unable to create a bitmap for bezeled screenshot rendering.",
+            }];
+        }
+        return nil;
+    }
+
+    NSGraphicsContext *graphicsContext = [NSGraphicsContext graphicsContextWithBitmapImageRep:bitmap];
+    [NSGraphicsContext saveGraphicsState];
+    [NSGraphicsContext setCurrentContext:graphicsContext];
+    graphicsContext.imageInterpolation = NSImageInterpolationHigh;
+    NSRect outputRect = NSMakeRect(0.0, 0.0, pixelWidth, pixelHeight);
+    [[NSColor clearColor] setFill];
+    NSRectFillUsingOperation(outputRect, NSCompositingOperationClear);
+
+    NSRect screenRect = NSMakeRect(screenX * scale,
+                                   pixelHeight - ((screenY + screenHeight) * scale),
+                                   screenWidth * scale,
+                                   screenHeight * scale);
+    NSDictionary *hints = @{ NSImageHintInterpolation: @(NSImageInterpolationHigh) };
+    [screenImage drawInRect:screenRect
+                   fromRect:NSZeroRect
+                  operation:NSCompositingOperationSourceOver
+                   fraction:1.0
+             respectFlipped:NO
+                      hints:hints];
+    [chromeImage drawInRect:outputRect
+                   fromRect:NSZeroRect
+                  operation:NSCompositingOperationSourceOver
+                   fraction:1.0
+             respectFlipped:NO
+                      hints:hints];
+    [NSGraphicsContext restoreGraphicsState];
+
+    NSData *pngData = [bitmap representationUsingType:NSBitmapImageFileTypePNG properties:@{}];
+    if (pngData.length == 0 && error != NULL) {
+        *error = [NSError errorWithDomain:XCWChromeRendererErrorDomain
+                                     code:18
+                                 userInfo:@{
+            NSLocalizedDescriptionKey: @"Unable to encode bezeled simulator screenshot PNG.",
+        }];
+    }
+    return pngData.length > 0 ? pngData : nil;
+}
+
 + (nullable NSDictionary<NSString *, id> *)profileForChromeInfo:(NSDictionary *)chromeInfo
                                                           error:(NSError * _Nullable __autoreleasing *)error {
     NSDictionary *plist = chromeInfo[@"plist"];

--- a/cli/XCWProcessRunner.h
+++ b/cli/XCWProcessRunner.h
@@ -31,6 +31,13 @@ NS_ASSUME_NONNULL_BEGIN
                          timeoutSec:(NSTimeInterval)timeoutSec
                               error:(NSError * _Nullable * _Nullable)error;
 
++ (XCWProcessResult *)runLaunchPath:(NSString *)launchPath
+                          arguments:(NSArray<NSString *> *)arguments
+                          inputData:(nullable NSData *)inputData
+                         timeoutSec:(NSTimeInterval)timeoutSec
+                      timeoutSignal:(int)timeoutSignal
+                              error:(NSError * _Nullable * _Nullable)error;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/cli/XCWProcessRunner.m
+++ b/cli/XCWProcessRunner.m
@@ -119,6 +119,20 @@ static int XCWCreateTemporaryOutputFile(NSString **path, NSError * _Nullable __a
                           inputData:(NSData *)inputData
                          timeoutSec:(NSTimeInterval)timeoutSec
                               error:(NSError * _Nullable __autoreleasing *)error {
+    return [self runLaunchPath:launchPath
+                     arguments:arguments
+                     inputData:inputData
+                    timeoutSec:timeoutSec
+                 timeoutSignal:SIGTERM
+                         error:error];
+}
+
++ (XCWProcessResult *)runLaunchPath:(NSString *)launchPath
+                          arguments:(NSArray<NSString *> *)arguments
+                          inputData:(NSData *)inputData
+                         timeoutSec:(NSTimeInterval)timeoutSec
+                      timeoutSignal:(int)timeoutSignal
+                              error:(NSError * _Nullable __autoreleasing *)error {
     int stdoutFD = -1;
     int stderrFD = -1;
     int stdinPipe[2] = { -1, -1 };
@@ -244,8 +258,10 @@ static int XCWCreateTemporaryOutputFile(NSString **path, NSError * _Nullable __a
         }
         if (hasTimeout && [deadline timeIntervalSinceNow] <= 0) {
             timedOut = YES;
-            kill(pid, SIGTERM);
-            NSDate *killDeadline = [NSDate dateWithTimeIntervalSinceNow:2.0];
+            int signalToSend = timeoutSignal > 0 ? timeoutSignal : SIGTERM;
+            kill(pid, signalToSend);
+            NSTimeInterval graceSeconds = signalToSend == SIGINT ? 10.0 : 2.0;
+            NSDate *killDeadline = [NSDate dateWithTimeIntervalSinceNow:graceSeconds];
             do {
                 waitResult = waitpid(pid, &waitStatus, WNOHANG);
                 if (waitResult == pid || (waitResult < 0 && errno != EINTR)) {

--- a/cli/XCWSimctl.h
+++ b/cli/XCWSimctl.h
@@ -19,6 +19,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)openURL:(NSString *)urlString simulatorUDID:(NSString *)udid error:(NSError * _Nullable * _Nullable)error;
 - (BOOL)launchBundleID:(NSString *)bundleID simulatorUDID:(NSString *)udid error:(NSError * _Nullable * _Nullable)error;
 - (nullable NSData *)screenshotPNGForSimulatorUDID:(NSString *)udid error:(NSError * _Nullable * _Nullable)error;
+- (nullable NSData *)screenshotPNGForSimulatorUDID:(NSString *)udid
+                                      includeBezel:(BOOL)includeBezel
+                                             error:(NSError * _Nullable * _Nullable)error;
+- (nullable NSData *)screenRecordingMP4ForSimulatorUDID:(NSString *)udid
+                                        durationSeconds:(NSTimeInterval)durationSeconds
+                                                  error:(NSError * _Nullable * _Nullable)error;
 - (BOOL)eraseSimulatorWithUDID:(NSString *)udid error:(NSError * _Nullable * _Nullable)error;
 - (BOOL)installAppAtPath:(NSString *)appPath simulatorUDID:(NSString *)udid error:(NSError * _Nullable * _Nullable)error;
 - (BOOL)uninstallBundleID:(NSString *)bundleID simulatorUDID:(NSString *)udid error:(NSError * _Nullable * _Nullable)error;

--- a/cli/XCWSimctl.m
+++ b/cli/XCWSimctl.m
@@ -815,13 +815,18 @@ static NSString *XCWRuntimeDisplayName(NSDictionary *runtime, NSString *runtimeI
     }
     if (!XCWWaitForTaskExit(task, didStart ? 10.0 : 2.0) && task.running) {
         [task terminate];
-        XCWWaitForTaskExit(task, 2.0);
+        if (!XCWWaitForTaskExit(task, 2.0) && task.running) {
+            kill(task.processIdentifier, SIGKILL);
+            XCWWaitForTaskExit(task, 2.0);
+        }
     }
 
     stdoutHandle.readabilityHandler = nil;
     stderrHandle.readabilityHandler = nil;
-    XCWAppendAvailableData(stdoutHandle, stdoutData);
-    XCWAppendAvailableData(stderrHandle, stderrData);
+    if (!task.running) {
+        XCWAppendAvailableData(stdoutHandle, stdoutData);
+        XCWAppendAvailableData(stderrHandle, stderrData);
+    }
 
     NSError *readError = nil;
     NSData *data = nil;

--- a/cli/XCWSimctl.m
+++ b/cli/XCWSimctl.m
@@ -6,6 +6,7 @@
 #import "XCWPrivateSimulatorBooter.h"
 #import "XCWProcessRunner.h"
 
+#import <dispatch/dispatch.h>
 #import <errno.h>
 #import <math.h>
 #import <signal.h>
@@ -53,8 +54,45 @@ static NSString *XCWStringValue(id value) {
     return [value isKindOfClass:[NSString class]] ? value : @"";
 }
 
+static NSString *XCWTrimmedString(NSString *value) {
+    return [value stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+}
+
 static NSNumber *XCWNumberValue(id value) {
     return [value isKindOfClass:[NSNumber class]] ? value : nil;
+}
+
+static NSString *XCWStringFromData(NSData *data) {
+    return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] ?: @"";
+}
+
+static NSData *XCWDataSnapshot(NSMutableData *data) {
+    @synchronized(data) {
+        return [data copy];
+    }
+}
+
+static void XCWAppendAvailableData(NSFileHandle *handle, NSMutableData *destination) {
+    @try {
+        NSData *chunk = [handle availableData];
+        if (chunk.length > 0) {
+            @synchronized(destination) {
+                [destination appendData:chunk];
+            }
+        }
+    } @catch (NSException *exception) {
+    }
+}
+
+static BOOL XCWWaitForTaskExit(NSTask *task, NSTimeInterval timeoutSeconds) {
+    NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:timeoutSeconds];
+    while (task.running && [deadline timeIntervalSinceNow] > 0) {
+        usleep(10 * 1000);
+    }
+    if (!task.running) {
+        return YES;
+    }
+    return NO;
 }
 
 static NSString * _Nullable XCWCreateTemporaryDirectory(NSString *prefix, NSError * _Nullable __autoreleasing *error) {
@@ -682,38 +720,136 @@ static NSString *XCWRuntimeDisplayName(NSDictionary *runtime, NSString *runtimeI
 
     NSString *filename = [NSString stringWithFormat:@"simdeck-%@.mp4", NSUUID.UUID.UUIDString];
     NSString *path = [NSTemporaryDirectory() stringByAppendingPathComponent:filename];
-    XCWProcessResult *result = [self.class runSimctl:@[
-        @"io",
-        udid,
-        @"recordVideo",
-        @"--codec=h264",
-        @"--force",
-        path,
-    ]
-                                          timeoutSec:durationSeconds
-                                       timeoutSignal:SIGINT
-                                               error:error];
-    if (result == nil) {
+    XCWProcessResult *resolvedSimctl = [XCWProcessRunner runLaunchPath:@"/usr/bin/xcrun"
+                                                             arguments:@[@"-f", @"simctl"]
+                                                             inputData:nil
+                                                                 error:error];
+    if (resolvedSimctl == nil) {
         [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
         return nil;
     }
-
-    BOOL expectedStop = result.terminationStatus == 0 || result.terminationStatus == 124 || result.terminationStatus == 130;
-    if (expectedStop) {
-        NSData *data = [NSData dataWithContentsOfFile:path options:0 error:error];
+    NSString *simctlPath = XCWTrimmedString(XCWStringFromData(resolvedSimctl.stdoutData));
+    if (resolvedSimctl.terminationStatus != 0 || simctlPath.length == 0) {
         [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
+        if (error != NULL) {
+            NSString *message = resolvedSimctl.stderrString.length > 0 ? resolvedSimctl.stderrString : @"Unable to locate simctl.";
+            *error = [self.class errorWithDescription:message code:34];
+        }
+        return nil;
+    }
+
+    NSTask *task = [[NSTask alloc] init];
+    task.launchPath = simctlPath;
+    task.arguments = @[@"io", udid, @"recordVideo", @"--codec=h264", @"--force", path];
+    task.standardInput = NSFileHandle.fileHandleWithNullDevice;
+    NSPipe *stdoutPipe = [NSPipe pipe];
+    NSPipe *stderrPipe = [NSPipe pipe];
+    task.standardOutput = stdoutPipe;
+    task.standardError = stderrPipe;
+
+    NSMutableData *stdoutData = [NSMutableData data];
+    NSMutableData *stderrData = [NSMutableData data];
+    NSFileHandle *stdoutHandle = stdoutPipe.fileHandleForReading;
+    NSFileHandle *stderrHandle = stderrPipe.fileHandleForReading;
+    dispatch_semaphore_t recordingStartedSemaphore = dispatch_semaphore_create(0);
+    __block BOOL recordingStarted = NO;
+
+    stdoutHandle.readabilityHandler = ^(NSFileHandle *handle) {
+        XCWAppendAvailableData(handle, stdoutData);
+    };
+    stderrHandle.readabilityHandler = ^(NSFileHandle *handle) {
+        @try {
+            NSData *chunk = [handle availableData];
+            if (chunk.length == 0) {
+                return;
+            }
+            BOOL shouldSignal = NO;
+            @synchronized(stderrData) {
+                [stderrData appendData:chunk];
+                NSString *text = XCWStringFromData(stderrData);
+                if (!recordingStarted && [text rangeOfString:@"Recording started"].location != NSNotFound) {
+                    recordingStarted = YES;
+                    shouldSignal = YES;
+                }
+            }
+            if (shouldSignal) {
+                dispatch_semaphore_signal(recordingStartedSemaphore);
+            }
+        } @catch (NSException *exception) {
+        }
+    };
+
+    NSError *launchError = nil;
+    if (![task launchAndReturnError:&launchError]) {
+        stdoutHandle.readabilityHandler = nil;
+        stderrHandle.readabilityHandler = nil;
+        [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
+        if (error != NULL) {
+            *error = launchError ?: [self.class errorWithDescription:@"Unable to launch simulator screen recording." code:34];
+        }
+        return nil;
+    }
+
+    NSTimeInterval startTimeout = MAX(10.0, MIN(30.0, durationSeconds + 10.0));
+    NSDate *startDeadline = [NSDate dateWithTimeIntervalSinceNow:startTimeout];
+    BOOL didStart = NO;
+    while ([startDeadline timeIntervalSinceNow] > 0) {
+        if (dispatch_semaphore_wait(recordingStartedSemaphore, DISPATCH_TIME_NOW) == 0) {
+            didStart = YES;
+            break;
+        }
+        if (!task.running) {
+            break;
+        }
+        usleep(10 * 1000);
+    }
+
+    if (didStart) {
+        NSDate *stopAt = [NSDate dateWithTimeIntervalSinceNow:durationSeconds];
+        while (task.running && [stopAt timeIntervalSinceNow] > 0) {
+            usleep(10 * 1000);
+        }
+    }
+    if (task.running) {
+        [task interrupt];
+    }
+    if (!XCWWaitForTaskExit(task, didStart ? 10.0 : 2.0) && task.running) {
+        [task terminate];
+        XCWWaitForTaskExit(task, 2.0);
+    }
+
+    stdoutHandle.readabilityHandler = nil;
+    stderrHandle.readabilityHandler = nil;
+    XCWAppendAvailableData(stdoutHandle, stdoutData);
+    XCWAppendAvailableData(stderrHandle, stderrData);
+
+    NSError *readError = nil;
+    NSData *data = nil;
+    NSDate *fileDeadline = [NSDate dateWithTimeIntervalSinceNow:2.0];
+    do {
+        data = [NSData dataWithContentsOfFile:path options:0 error:&readError];
         if (data.length > 0) {
-            return data;
+            break;
         }
-        if (error != NULL && *error == nil) {
-            *error = [self.class errorWithDescription:@"Simulator screen recording command produced an empty MP4." code:34];
-        }
-        return nil;
+        usleep(50 * 1000);
+    } while ([fileDeadline timeIntervalSinceNow] > 0);
+    [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
+    if (data.length > 0) {
+        return data;
     }
 
-    [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
     if (error != NULL) {
-        *error = [self.class errorWithDescription:result.stderrString.length > 0 ? result.stderrString : @"Unable to record simulator screen." code:34];
+        NSString *stderrString = XCWStringFromData(XCWDataSnapshot(stderrData));
+        NSString *stdoutString = XCWStringFromData(XCWDataSnapshot(stdoutData));
+        NSString *details = stderrString.length > 0 ? stderrString : stdoutString;
+        if (!didStart && details.length == 0) {
+            details = @"Simulator screen recording did not start before the timeout.";
+        } else if (details.length == 0 && readError.localizedDescription.length > 0) {
+            details = readError.localizedDescription;
+        } else if (details.length == 0) {
+            details = @"Simulator screen recording command produced an empty MP4.";
+        }
+        *error = [self.class errorWithDescription:details code:34];
     }
     return nil;
 }

--- a/cli/XCWSimctl.m
+++ b/cli/XCWSimctl.m
@@ -2,10 +2,13 @@
 
 #import <AppKit/AppKit.h>
 
+#import "XCWChromeRenderer.h"
 #import "XCWPrivateSimulatorBooter.h"
 #import "XCWProcessRunner.h"
 
 #import <errno.h>
+#import <math.h>
+#import <signal.h>
 #import <stdlib.h>
 #import <string.h>
 
@@ -21,6 +24,10 @@ static NSString * const XCWSimctlErrorDomain = @"SimDeck.Simctl";
                                    error:(NSError * _Nullable __autoreleasing *)error;
 + (nullable XCWProcessResult *)runSimctl:(NSArray<NSString *> *)arguments
                               timeoutSec:(NSTimeInterval)timeoutSec
+                                   error:(NSError * _Nullable __autoreleasing *)error;
++ (nullable XCWProcessResult *)runSimctl:(NSArray<NSString *> *)arguments
+                              timeoutSec:(NSTimeInterval)timeoutSec
+                           timeoutSignal:(int)timeoutSignal
                                    error:(NSError * _Nullable __autoreleasing *)error;
 + (nullable NSDictionary *)listJSONPayloadWithError:(NSError * _Nullable __autoreleasing *)error;
 + (NSError *)errorWithDescription:(NSString *)description code:(NSInteger)code;
@@ -623,6 +630,12 @@ static NSString *XCWRuntimeDisplayName(NSDictionary *runtime, NSString *runtimeI
 }
 
 - (nullable NSData *)screenshotPNGForSimulatorUDID:(NSString *)udid error:(NSError * _Nullable __autoreleasing *)error {
+    return [self screenshotPNGForSimulatorUDID:udid includeBezel:NO error:error];
+}
+
+- (nullable NSData *)screenshotPNGForSimulatorUDID:(NSString *)udid
+                                      includeBezel:(BOOL)includeBezel
+                                             error:(NSError * _Nullable __autoreleasing *)error {
     NSString *filename = [NSString stringWithFormat:@"simdeck-%@.png", NSUUID.UUID.UUIDString];
     NSString *path = [NSTemporaryDirectory() stringByAppendingPathComponent:filename];
     XCWProcessResult *result = [self.class runSimctl:@[@"io", udid, @"screenshot", @"--type=png", path] error:error];
@@ -633,7 +646,17 @@ static NSString *XCWRuntimeDisplayName(NSDictionary *runtime, NSString *runtimeI
         NSData *data = [NSData dataWithContentsOfFile:path options:0 error:error];
         [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
         if (data.length > 0) {
-            return data;
+            if (!includeBezel) {
+                return data;
+            }
+            NSDictionary *simulator = [self simulatorWithUDID:udid error:error];
+            if (simulator == nil) {
+                return nil;
+            }
+            NSString *deviceName = simulator[@"deviceTypeName"] ?: simulator[@"name"] ?: @"";
+            return [XCWChromeRenderer screenshotPNGDataForDeviceName:deviceName
+                                                       screenPNGData:data
+                                                               error:error];
         }
         if (error != NULL && *error == nil) {
             *error = [self.class errorWithDescription:@"Simulator screenshot command produced an empty PNG." code:13];
@@ -643,6 +666,54 @@ static NSString *XCWRuntimeDisplayName(NSDictionary *runtime, NSString *runtimeI
     [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
     if (error != NULL) {
         *error = [self.class errorWithDescription:result.stderrString.length > 0 ? result.stderrString : @"Unable to capture simulator screenshot." code:13];
+    }
+    return nil;
+}
+
+- (nullable NSData *)screenRecordingMP4ForSimulatorUDID:(NSString *)udid
+                                        durationSeconds:(NSTimeInterval)durationSeconds
+                                                  error:(NSError * _Nullable __autoreleasing *)error {
+    if (!isfinite(durationSeconds) || durationSeconds <= 0.0) {
+        if (error != NULL) {
+            *error = [self.class errorWithDescription:@"Screen recording duration must be finite and greater than zero." code:33];
+        }
+        return nil;
+    }
+
+    NSString *filename = [NSString stringWithFormat:@"simdeck-%@.mp4", NSUUID.UUID.UUIDString];
+    NSString *path = [NSTemporaryDirectory() stringByAppendingPathComponent:filename];
+    XCWProcessResult *result = [self.class runSimctl:@[
+        @"io",
+        udid,
+        @"recordVideo",
+        @"--codec=h264",
+        @"--force",
+        path,
+    ]
+                                          timeoutSec:durationSeconds
+                                       timeoutSignal:SIGINT
+                                               error:error];
+    if (result == nil) {
+        [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
+        return nil;
+    }
+
+    BOOL expectedStop = result.terminationStatus == 0 || result.terminationStatus == 124 || result.terminationStatus == 130;
+    if (expectedStop) {
+        NSData *data = [NSData dataWithContentsOfFile:path options:0 error:error];
+        [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
+        if (data.length > 0) {
+            return data;
+        }
+        if (error != NULL && *error == nil) {
+            *error = [self.class errorWithDescription:@"Simulator screen recording command produced an empty MP4." code:34];
+        }
+        return nil;
+    }
+
+    [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
+    if (error != NULL) {
+        *error = [self.class errorWithDescription:result.stderrString.length > 0 ? result.stderrString : @"Unable to record simulator screen." code:34];
     }
     return nil;
 }
@@ -863,10 +934,18 @@ static NSString *XCWRuntimeDisplayName(NSDictionary *runtime, NSString *runtimeI
 + (nullable XCWProcessResult *)runSimctl:(NSArray<NSString *> *)arguments
                               timeoutSec:(NSTimeInterval)timeoutSec
                                    error:(NSError * _Nullable __autoreleasing *)error {
+    return [self runSimctl:arguments timeoutSec:timeoutSec timeoutSignal:SIGTERM error:error];
+}
+
++ (nullable XCWProcessResult *)runSimctl:(NSArray<NSString *> *)arguments
+                              timeoutSec:(NSTimeInterval)timeoutSec
+                           timeoutSignal:(int)timeoutSignal
+                                   error:(NSError * _Nullable __autoreleasing *)error {
     return [XCWProcessRunner runLaunchPath:@"/usr/bin/xcrun"
                                  arguments:[@[@"simctl"] arrayByAddingObjectsFromArray:arguments]
                                  inputData:nil
                                 timeoutSec:timeoutSec
+                             timeoutSignal:timeoutSignal
                                      error:error];
 }
 

--- a/cli/native/XCWNativeBridge.h
+++ b/cli/native/XCWNativeBridge.h
@@ -51,7 +51,8 @@ char * _Nullable xcw_native_get_chrome_profile(const char * _Nonnull udid, char 
 xcw_native_owned_bytes xcw_native_render_chrome_png(const char * _Nonnull udid, bool include_buttons, char * _Nullable * _Nullable error_message);
 xcw_native_owned_bytes xcw_native_render_chrome_button_png(const char * _Nonnull udid, const char * _Nonnull button_name, bool pressed, char * _Nullable * _Nullable error_message);
 xcw_native_owned_bytes xcw_native_render_screen_mask_png(const char * _Nonnull udid, char * _Nullable * _Nullable error_message);
-xcw_native_owned_bytes xcw_native_screenshot_png(const char * _Nonnull udid, char * _Nullable * _Nullable error_message);
+xcw_native_owned_bytes xcw_native_screenshot_png(const char * _Nonnull udid, bool include_bezel, char * _Nullable * _Nullable error_message);
+xcw_native_owned_bytes xcw_native_screen_recording_mp4(const char * _Nonnull udid, double duration_seconds, char * _Nullable * _Nullable error_message);
 char * _Nullable xcw_native_recent_logs(const char * _Nonnull udid, double seconds, size_t limit, char * _Nullable * _Nullable error_message);
 char * _Nullable xcw_native_accessibility_snapshot(const char * _Nonnull udid, bool has_point, double x, double y, size_t max_depth, char * _Nullable * _Nullable error_message);
 bool xcw_native_send_touch(const char * _Nonnull udid, double x, double y, const char * _Nonnull phase, char * _Nullable * _Nullable error_message);

--- a/cli/native/XCWNativeBridge.m
+++ b/cli/native/XCWNativeBridge.m
@@ -532,16 +532,33 @@ xcw_native_owned_bytes xcw_native_render_screen_mask_png(const char *udid, char 
     }
 }
 
-xcw_native_owned_bytes xcw_native_screenshot_png(const char *udid, char **error_message) {
+xcw_native_owned_bytes xcw_native_screenshot_png(const char *udid, bool include_bezel, char **error_message) {
     @autoreleasepool {
         XCWSimctl *simctl = [[XCWSimctl alloc] init];
         NSError *error = nil;
-        NSData *png = [simctl screenshotPNGForSimulatorUDID:XCWStringFromCString(udid) error:&error];
+        NSData *png = [simctl screenshotPNGForSimulatorUDID:XCWStringFromCString(udid)
+                                               includeBezel:include_bezel
+                                                      error:&error];
         if (png == nil) {
             XCWSetErrorMessage(error_message, error);
             return (xcw_native_owned_bytes){0};
         }
         return XCWOwnedBytesFromData(png);
+    }
+}
+
+xcw_native_owned_bytes xcw_native_screen_recording_mp4(const char *udid, double duration_seconds, char **error_message) {
+    @autoreleasepool {
+        XCWSimctl *simctl = [[XCWSimctl alloc] init];
+        NSError *error = nil;
+        NSData *mp4 = [simctl screenRecordingMP4ForSimulatorUDID:XCWStringFromCString(udid)
+                                                 durationSeconds:duration_seconds
+                                                           error:&error];
+        if (mp4 == nil) {
+            XCWSetErrorMessage(error_message, error);
+            return (xcw_native_owned_bytes){0};
+        }
+        return XCWOwnedBytesFromData(mp4);
     }
 }
 

--- a/client/src/api/controls.ts
+++ b/client/src/api/controls.ts
@@ -1,4 +1,4 @@
-import { accessTokenFromLocation, apiRequest } from "./client";
+import { accessTokenFromLocation, apiHeaders, apiRequest } from "./client";
 import { apiUrl } from "./config";
 import type {
   ButtonPayload,
@@ -134,4 +134,52 @@ export function rotateLeft(udid: string) {
 
 export function rotateRight(udid: string) {
   return postSimulatorAction(udid, "rotate-right");
+}
+
+async function fetchSimulatorBlob(
+  path: string,
+  options: RequestInit = {},
+): Promise<Blob> {
+  const { headers, ...rest } = options;
+  const response = await fetch(apiUrl(path), {
+    ...rest,
+    headers: apiHeaders(headers),
+  });
+  if (!response.ok) {
+    const contentType = response.headers.get("content-type") ?? "";
+    if (contentType.includes("application/json")) {
+      const body = (await response.json()) as { error?: string };
+      throw new Error(
+        body.error ?? `Request failed with status ${response.status}`,
+      );
+    }
+    throw new Error(
+      (await response.text()) ||
+        `Request failed with status ${response.status}`,
+    );
+  }
+  return response.blob();
+}
+
+export function captureSimulatorScreenshot(
+  udid: string,
+  options: { withBezel?: boolean } = {},
+): Promise<Blob> {
+  const params = options.withBezel ? "?bezel=true" : "";
+  return fetchSimulatorBlob(
+    `/api/simulators/${encodeURIComponent(udid)}/screenshot.png${params}`,
+  );
+}
+
+export function recordSimulatorScreen(
+  udid: string,
+  seconds = 5,
+): Promise<Blob> {
+  return fetchSimulatorBlob(
+    `/api/simulators/${encodeURIComponent(udid)}/screen-recording`,
+    {
+      body: JSON.stringify({ seconds }),
+      method: "POST",
+    },
+  );
 }

--- a/client/src/app/AppShell.tsx
+++ b/client/src/app/AppShell.tsx
@@ -17,12 +17,14 @@ import {
 import { apiUrl, configureSimDeckClient } from "../api/config";
 import {
   bootSimulator,
+  captureSimulatorScreenshot,
   dismissKeyboard,
   launchSimulatorBundle,
   openAppSwitcher,
   openSimulatorUrl,
   pressHome,
   pressSimulatorButton,
+  recordSimulatorScreen,
   rotateDigitalCrown,
   rotateRight,
   simulatorControlSocketUrl,
@@ -266,6 +268,25 @@ function writeStreamTransportQueryParam(transport: StreamTransport) {
     "",
     `${url.pathname}${url.search}${url.hash}`,
   );
+}
+
+function downloadBlob(blob: Blob, fileName: string) {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = fileName;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
+function captureFileBaseName(
+  simulator: SimulatorMetadata,
+  artifact: "Recording" | "Screenshot",
+): string {
+  const safeName = simulator.name.replace(/[^A-Za-z0-9._-]+/g, "-");
+  return `SimDeck ${artifact} - ${safeName || simulator.udid}`;
 }
 
 function simulatorDisplaySize(
@@ -1746,6 +1767,48 @@ export function AppShell({
     }
   }
 
+  async function downloadSimulatorScreenshot(withBezel: boolean) {
+    if (!selectedSimulator) {
+      return;
+    }
+    setLocalError("");
+    try {
+      const blob = await captureSimulatorScreenshot(selectedSimulator.udid, {
+        withBezel,
+      });
+      downloadBlob(
+        blob,
+        `${captureFileBaseName(selectedSimulator, "Screenshot")}${withBezel ? " Bezel" : ""}.png`,
+      );
+    } catch (captureError) {
+      setLocalError(
+        captureError instanceof Error
+          ? captureError.message
+          : "Capture failed.",
+      );
+    }
+  }
+
+  async function downloadSimulatorRecording() {
+    if (!selectedSimulator) {
+      return;
+    }
+    setLocalError("");
+    try {
+      const blob = await recordSimulatorScreen(selectedSimulator.udid, 5);
+      downloadBlob(
+        blob,
+        `${captureFileBaseName(selectedSimulator, "Recording")}.mp4`,
+      );
+    } catch (captureError) {
+      setLocalError(
+        captureError instanceof Error
+          ? captureError.message
+          : "Recording failed.",
+      );
+    }
+  }
+
   function selectedStateFromSimulator(
     simulator: SimulatorMetadata,
     current: SimulatorStateResponse | null,
@@ -2478,6 +2541,12 @@ export function AppShell({
             bootSimulator(udid),
           );
         }}
+        onCaptureScreenshot={() => {
+          void downloadSimulatorScreenshot(false);
+        }}
+        onCaptureScreenshotWithBezel={() => {
+          void downloadSimulatorScreenshot(true);
+        }}
         onChangeSearch={setSearch}
         onDismissKeyboard={() => {
           if (!selectedSimulator) {
@@ -2545,6 +2614,9 @@ export function AppShell({
             await rotateRight(selectedSimulator.udid);
             setRotationQuarterTurns((current) => (current + 1) % 4);
           }, false);
+        }}
+        onRecordScreen={() => {
+          void downloadSimulatorRecording();
         }}
         onStreamEncoderChange={updateStreamEncoder}
         onStreamFpsChange={updateStreamFps}

--- a/client/src/features/simulators/SimulatorMenu.tsx
+++ b/client/src/features/simulators/SimulatorMenu.tsx
@@ -23,6 +23,8 @@ interface SimulatorMenuProps {
   menuOpen: boolean;
   menuRef: RefObject<HTMLDivElement | null>;
   onBoot: () => void;
+  onCaptureScreenshot: () => void;
+  onCaptureScreenshotWithBezel: () => void;
   onChangeSearch: (value: string) => void;
   onCloseMenu: () => void;
   onDismissKeyboard: () => void;
@@ -33,6 +35,7 @@ interface SimulatorMenuProps {
   onOpenNewSimulator: () => void;
   onOpenUrlPrompt: () => void;
   onRotateRight: () => void;
+  onRecordScreen: () => void;
   onShutdown: () => void;
   onStreamEncoderChange: (encoder: StreamEncoder) => void;
   onStreamFpsChange: (fps: StreamFps) => void;
@@ -62,6 +65,8 @@ export function SimulatorMenu({
   menuOpen,
   menuRef,
   onBoot,
+  onCaptureScreenshot,
+  onCaptureScreenshotWithBezel,
   onChangeSearch,
   onCloseMenu,
   onDismissKeyboard,
@@ -72,6 +77,7 @@ export function SimulatorMenu({
   onOpenNewSimulator,
   onOpenUrlPrompt,
   onRotateRight,
+  onRecordScreen,
   onShutdown,
   onStreamEncoderChange,
   onStreamFpsChange,
@@ -279,6 +285,33 @@ export function SimulatorMenu({
                 </button>
                 <button className="menu-action" onClick={onOpenBundlePrompt}>
                   Launch Bundle…
+                </button>
+                <button
+                  className="menu-action"
+                  onClick={() => {
+                    onCaptureScreenshot();
+                    onCloseMenu();
+                  }}
+                >
+                  Screenshot
+                </button>
+                <button
+                  className="menu-action"
+                  onClick={() => {
+                    onCaptureScreenshotWithBezel();
+                    onCloseMenu();
+                  }}
+                >
+                  Screenshot With Bezel
+                </button>
+                <button
+                  className="menu-action"
+                  onClick={() => {
+                    onRecordScreen();
+                    onCloseMenu();
+                  }}
+                >
+                  Record 5s Video
                 </button>
                 <button
                   className="menu-action mobile-menu-action"

--- a/client/src/features/toolbar/Toolbar.tsx
+++ b/client/src/features/toolbar/Toolbar.tsx
@@ -31,6 +31,8 @@ interface ToolbarProps {
   isLoading: boolean;
   canInstallApp: boolean;
   onBoot: () => void;
+  onCaptureScreenshot: () => void;
+  onCaptureScreenshotWithBezel: () => void;
   onChangeSearch: (value: string) => void;
   onDismissKeyboard: () => void;
   onHome: () => void;
@@ -40,6 +42,7 @@ interface ToolbarProps {
   onOpenNewSimulator: () => void;
   onOpenUrlPrompt: () => void;
   onRotateRight: () => void;
+  onRecordScreen: () => void;
   onShutdown: () => void;
   onStreamEncoderChange: (encoder: StreamEncoder) => void;
   onStreamFpsChange: (fps: StreamFps) => void;
@@ -79,6 +82,8 @@ export function Toolbar({
   menuOpen,
   menuRef,
   onBoot,
+  onCaptureScreenshot,
+  onCaptureScreenshotWithBezel,
   onChangeSearch,
   onDismissKeyboard,
   onHome,
@@ -88,6 +93,7 @@ export function Toolbar({
   onOpenNewSimulator,
   onOpenUrlPrompt,
   onRotateRight,
+  onRecordScreen,
   onShutdown,
   onStreamEncoderChange,
   onStreamFpsChange,
@@ -149,6 +155,8 @@ export function Toolbar({
           menuOpen={menuOpen}
           menuRef={menuRef}
           onBoot={onBoot}
+          onCaptureScreenshot={onCaptureScreenshot}
+          onCaptureScreenshotWithBezel={onCaptureScreenshotWithBezel}
           onChangeSearch={onChangeSearch}
           onCloseMenu={closeMenu}
           onDismissKeyboard={onDismissKeyboard}
@@ -159,6 +167,7 @@ export function Toolbar({
           onOpenNewSimulator={onOpenNewSimulator}
           onOpenUrlPrompt={onOpenUrlPrompt}
           onRotateRight={onRotateRight}
+          onRecordScreen={onRecordScreen}
           onShutdown={onShutdown}
           onStreamEncoderChange={onStreamEncoderChange}
           onStreamFpsChange={onStreamFpsChange}

--- a/docs/api/rest.md
+++ b/docs/api/rest.md
@@ -227,7 +227,8 @@ For app-owned `WKWebView` on iOS 16.4 or newer, the app must set `isInspectable 
 
 | Method | Path                                            | Purpose                                        |
 | ------ | ----------------------------------------------- | ---------------------------------------------- |
-| `GET`  | `/api/simulators/{udid}/screenshot.png`         | PNG screenshot                                 |
+| `GET`  | `/api/simulators/{udid}/screenshot.png`         | PNG screenshot, with `?bezel=true` for chrome  |
+| `POST` | `/api/simulators/{udid}/screen-recording`       | MP4 recording with `{ "seconds": 5 }`          |
 | `GET`  | `/api/simulators/{udid}/pasteboard`             | Get pasteboard text                            |
 | `POST` | `/api/simulators/{udid}/pasteboard`             | Set pasteboard text with `{ "text": "hello" }` |
 | `GET`  | `/api/simulators/{udid}/logs`                   | Recent logs                                    |

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -131,7 +131,10 @@ Use `wait-for` or `assert` steps instead of fixed sleeps when possible.
 
 ```sh
 simdeck screenshot <udid> --output screen.png
+simdeck screenshot <udid> --with-bezel --output screen-bezel.png
 simdeck screenshot <udid> --stdout > screen.png
+simdeck record <udid> --seconds 5 --output screen-recording.mp4
+simdeck record <udid> --seconds 5 --stdout > screen-recording.mp4
 simdeck pasteboard set <udid> "hello"
 simdeck pasteboard get <udid>
 simdeck logs <udid> --seconds 30 --limit 200

--- a/docs/cli/flags.md
+++ b/docs/cli/flags.md
@@ -61,7 +61,8 @@ Used by `simdeck ui`, `daemon start`, `daemon restart`, `service on`, and `servi
 
 | Command          | Flags                                                |
 | ---------------- | ---------------------------------------------------- |
-| `screenshot`     | `--output <path>`, `--stdout`                        |
+| `screenshot`     | `--output <path>`, `--stdout`, `--with-bezel`        |
+| `record`         | `--seconds <seconds>`, `--output <path>`, `--stdout` |
 | `logs`           | `--seconds <seconds>`, `--limit <count>`             |
 | `stats`          | `--pid <pid>`, `--watch`, `--interval <seconds>`     |
 | `sample`         | `--pid <pid>`, `--seconds <seconds>`                 |

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -39,6 +39,8 @@ simdeck open-url <udid> https://example.com
 simdeck tap <udid> --label "Continue" --wait-timeout-ms 5000
 simdeck describe <udid> --format agent --max-depth 3
 simdeck screenshot <udid> --output screen.png
+simdeck screenshot <udid> --with-bezel --output screen-bezel.png
+simdeck record <udid> --seconds 5 --output screen-recording.mp4
 simdeck logs <udid> --seconds 30 --limit 200
 simdeck stats <udid>
 simdeck sample <udid> --seconds 3

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -20,7 +20,7 @@ Most user actions follow the same path:
 1. Browser, CLI, or test sends a command to the daemon.
 2. The daemon checks the selected device and starts a warm session when needed.
 3. SimDeck performs the requested simulator or emulator action.
-4. The command returns JSON, a screenshot, logs, or updated stream state.
+4. The command returns JSON, a screenshot, a recording, logs, or updated stream state.
 
 This is why a long-lived daemon feels faster than repeatedly calling lower-level simulator tools.
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -9,7 +9,7 @@ Run `simdeck` from your project. It starts a local server, serves a browser UI, 
 - View a live iOS Simulator or Android emulator in a browser.
 - Tap, swipe, type, press hardware buttons, rotate, and open URLs.
 - Install, launch, uninstall, boot, shut down, and erase devices.
-- Capture screenshots, logs, pasteboard text, and accessibility trees.
+- Capture screenshots, recordings, logs, pasteboard text, and accessibility trees.
 - Inspect app UI through built-in accessibility or optional in-app inspectors.
 - Write JS/TS automation with `simdeck/test`.
 - Share a paired browser session over your LAN.

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -18,6 +18,8 @@ try {
   await sim.tap(0.5, 0.5);
   await sim.waitFor({ label: "Continue" });
   await sim.screenshot();
+  await sim.screenshot({ withBezel: true });
+  await sim.record({ seconds: 5 });
 } finally {
   sim.close();
 }
@@ -37,7 +39,7 @@ try {
 | `typeText()`, `key()`, `keySequence()`          | Text and keyboard input        |
 | `button()`, `home()`, `appSwitcher()`           | System controls                |
 | `tree()`, `query()`, `waitFor()`, `assert()`    | UI state checks                |
-| `screenshot()`, `logs()`                        | Evidence capture               |
+| `screenshot()`, `record()`, `logs()`            | Evidence capture               |
 | `batch()`                                       | Multi-step actions             |
 
 Selectors can match `id`, `label`, `value`, or `type`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ features:
       width: 28
       height: 28
     title: Fast local control
-    details: Boot devices, install apps, open URLs, type, tap, swipe, rotate, capture screenshots, and read logs from the CLI.
+    details: Boot devices, install apps, open URLs, type, tap, swipe, rotate, capture screenshots and recordings, and read logs from the CLI.
   - icon:
       src: /icons/scan-search.svg
       width: 28

--- a/packages/simdeck-test/dist/index.d.ts
+++ b/packages/simdeck-test/dist/index.d.ts
@@ -51,6 +51,13 @@ export type LogsOptions = {
   processes?: string[];
   q?: string;
 };
+export type ScreenshotOptions = {
+  bezel?: boolean;
+  withBezel?: boolean;
+};
+export type ScreenRecordingOptions = {
+  seconds?: number;
+};
 type DeviceMethod<TArgs extends unknown[], TResult> = {
   (udid: string, ...args: TArgs): TResult;
   (...args: TArgs): TResult;
@@ -130,7 +137,8 @@ export type SimDeckSession = {
     [steps: unknown[], continueOnError?: boolean],
     Promise<unknown>
   >;
-  screenshot: DeviceMethod<[], Promise<Buffer>>;
+  screenshot: DeviceMethod<[options?: ScreenshotOptions], Promise<Buffer>>;
+  record: DeviceMethod<[options?: ScreenRecordingOptions], Promise<Buffer>>;
   close(): void;
 };
 export declare function connect(

--- a/packages/simdeck-test/dist/index.js
+++ b/packages/simdeck-test/dist/index.js
@@ -48,6 +48,12 @@ export async function connect(options = {}) {
     }
     return { udid: requireUdid(), value: args[0], rest: args.slice(1) };
   };
+  const resolveOptionalObjectDeviceCall = (args) => {
+    if (typeof args[0] === "string") {
+      return { udid: args[0], options: args[1] };
+    }
+    return { udid: requireUdid(), options: args[0] };
+  };
   const session = {
     endpoint,
     pid: result.pid,
@@ -311,8 +317,27 @@ export async function connect(options = {}) {
       });
     },
     screenshot: (...args) => {
-      const { udid } = resolveNoArgDeviceCall(args);
-      return requestBuffer(endpoint, simulatorPath(udid, "/screenshot.png"));
+      const { udid, options } = resolveOptionalObjectDeviceCall(args);
+      const params = new URLSearchParams();
+      if (options?.withBezel ?? options?.bezel) {
+        params.set("bezel", "true");
+      }
+      const query = params.toString();
+      return requestBuffer(
+        endpoint,
+        simulatorPath(udid, `/screenshot.png${query ? `?${query}` : ""}`),
+      );
+    },
+    record: (...args) => {
+      const { udid, options } = resolveOptionalObjectDeviceCall(args);
+      return requestBuffer(
+        endpoint,
+        simulatorPath(udid, "/screen-recording"),
+        "POST",
+        {
+          seconds: options?.seconds ?? 5,
+        },
+      );
     },
     close: () => {
       if (options.keepDaemon) {

--- a/packages/simdeck-test/src/index.ts
+++ b/packages/simdeck-test/src/index.ts
@@ -68,6 +68,15 @@ export type LogsOptions = {
   q?: string;
 };
 
+export type ScreenshotOptions = {
+  bezel?: boolean;
+  withBezel?: boolean;
+};
+
+export type ScreenRecordingOptions = {
+  seconds?: number;
+};
+
 type DeviceMethod<TArgs extends unknown[], TResult> = {
   (udid: string, ...args: TArgs): TResult;
   (...args: TArgs): TResult;
@@ -145,7 +154,8 @@ export type SimDeckSession = {
     [steps: unknown[], continueOnError?: boolean],
     Promise<unknown>
   >;
-  screenshot: DeviceMethod<[], Promise<Buffer>>;
+  screenshot: DeviceMethod<[options?: ScreenshotOptions], Promise<Buffer>>;
+  record: DeviceMethod<[options?: ScreenRecordingOptions], Promise<Buffer>>;
   close(): void;
 };
 
@@ -206,6 +216,12 @@ export async function connect(
       return { udid: args[0], value: args[1] as T, rest: args.slice(2) };
     }
     return { udid: requireUdid(), value: args[0] as T, rest: args.slice(1) };
+  };
+  const resolveOptionalObjectDeviceCall = <T>(args: unknown[]) => {
+    if (typeof args[0] === "string") {
+      return { udid: args[0], options: args[1] as T | undefined };
+    }
+    return { udid: requireUdid(), options: args[0] as T | undefined };
   };
   const session: SimDeckSession = {
     endpoint,
@@ -514,9 +530,34 @@ export async function connect(
         continueOnError,
       });
     },
-    screenshot: (...args: [] | [string]) => {
-      const { udid } = resolveNoArgDeviceCall(args);
-      return requestBuffer(endpoint, simulatorPath(udid, "/screenshot.png"));
+    screenshot: (
+      ...args: [string, ScreenshotOptions?] | [ScreenshotOptions?]
+    ) => {
+      const { udid, options } =
+        resolveOptionalObjectDeviceCall<ScreenshotOptions>(args);
+      const params = new URLSearchParams();
+      if (options?.withBezel ?? options?.bezel) {
+        params.set("bezel", "true");
+      }
+      const query = params.toString();
+      return requestBuffer(
+        endpoint,
+        simulatorPath(udid, `/screenshot.png${query ? `?${query}` : ""}`),
+      );
+    },
+    record: (
+      ...args: [string, ScreenRecordingOptions?] | [ScreenRecordingOptions?]
+    ) => {
+      const { udid, options } =
+        resolveOptionalObjectDeviceCall<ScreenRecordingOptions>(args);
+      return requestBuffer(
+        endpoint,
+        simulatorPath(udid, "/screen-recording"),
+        "POST",
+        {
+          seconds: options?.seconds ?? 5,
+        },
+      );
     },
     close: () => {
       if (options.keepDaemon) {

--- a/scripts/integration/cli.mjs
+++ b/scripts/integration/cli.mjs
@@ -216,6 +216,37 @@ async function main() {
     },
     { phase: phaseCommandSmoke },
   );
+  const bezeledScreenshotPath = path.join(tempRoot, "screen-bezel.png");
+  await measuredStep(
+    "CLI screenshot with bezel",
+    async () => {
+      simdeckJson([
+        "screenshot",
+        simulatorUDID,
+        "--with-bezel",
+        "--output",
+        bezeledScreenshotPath,
+      ]);
+      assertPng(bezeledScreenshotPath);
+    },
+    { phase: phaseCommandSmoke },
+  );
+  const recordingPath = path.join(tempRoot, "screen-recording.mp4");
+  await measuredStep(
+    "CLI screen recording",
+    async () => {
+      simdeckJson([
+        "record",
+        simulatorUDID,
+        "--seconds",
+        "1",
+        "--output",
+        recordingPath,
+      ]);
+      assertMp4(recordingPath);
+    },
+    { phase: phaseCommandSmoke },
+  );
 
   await measuredStep(
     "CLI pasteboard set",
@@ -1758,10 +1789,23 @@ function assertPng(filePath) {
   assertPngBuffer(fs.readFileSync(filePath));
 }
 
+function assertMp4(filePath) {
+  assertMp4Buffer(fs.readFileSync(filePath));
+}
+
 function assertPngBuffer(buffer) {
   const pngSignature = "89504e470d0a1a0a";
   if (buffer.subarray(0, 8).toString("hex") !== pngSignature) {
     throw new Error("Expected PNG data.");
+  }
+}
+
+function assertMp4Buffer(buffer) {
+  if (
+    buffer.length < 12 ||
+    buffer.subarray(4, 8).toString("ascii") !== "ftyp"
+  ) {
+    throw new Error("Expected MP4 data.");
   }
 }
 

--- a/scripts/integration/js-api.mjs
+++ b/scripts/integration/js-api.mjs
@@ -267,6 +267,16 @@ async function main() {
     "JS screenshot",
     async () => {
       assertPngBuffer(await session.screenshot(simulatorUDID));
+      assertPngBuffer(
+        await session.screenshot(simulatorUDID, { withBezel: true }),
+      );
+    },
+    { phase: phaseCommandSmoke },
+  );
+  await measuredStep(
+    "JS screen recording",
+    async () => {
+      assertMp4Buffer(await session.record(simulatorUDID, { seconds: 1 }));
     },
     { phase: phaseCommandSmoke },
   );
@@ -433,6 +443,15 @@ function assertJson(payload, label) {
 function assertPngBuffer(buffer) {
   if (buffer.subarray(0, 8).toString("hex") !== "89504e470d0a1a0a") {
     throw new Error("Expected PNG data.");
+  }
+}
+
+function assertMp4Buffer(buffer) {
+  if (
+    buffer.length < 12 ||
+    buffer.subarray(4, 8).toString("ascii") !== "ftyp"
+  ) {
+    throw new Error("Expected MP4 data.");
   }
 }
 

--- a/server/native_stubs.c
+++ b/server/native_stubs.c
@@ -160,8 +160,17 @@ xcw_native_owned_bytes xcw_native_render_screen_mask_png(
 }
 
 xcw_native_owned_bytes xcw_native_screenshot_png(const char *udid,
+                                                 bool include_bezel,
                                                  char **error_message) {
   (void)udid;
+  (void)include_bezel;
+  return xcw_empty_bytes(error_message);
+}
+
+xcw_native_owned_bytes xcw_native_screen_recording_mp4(
+    const char *udid, double duration_seconds, char **error_message) {
+  (void)udid;
+  (void)duration_seconds;
   return xcw_empty_bytes(error_message);
 }
 

--- a/server/src/api/routes.rs
+++ b/server/src/api/routes.rs
@@ -187,6 +187,17 @@ struct PasteboardPayload {
     text: String,
 }
 
+#[derive(Deserialize)]
+struct ScreenshotPngQuery {
+    bezel: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ScreenRecordingPayload {
+    seconds: Option<f64>,
+}
+
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct CreateSimulatorPayload {
@@ -727,6 +738,10 @@ pub fn router(state: AppState) -> Router {
             get(get_pasteboard).post(set_pasteboard),
         )
         .route("/api/simulators/{udid}/screenshot.png", get(screenshot_png))
+        .route(
+            "/api/simulators/{udid}/screen-recording",
+            post(screen_recording),
+        )
         .route(
             "/api/simulators/{udid}/toggle-appearance",
             post(toggle_appearance),
@@ -2254,11 +2269,25 @@ async fn set_pasteboard(
 async fn screenshot_png(
     State(state): State<AppState>,
     Path(udid): Path<String>,
+    Query(query): Query<ScreenshotPngQuery>,
 ) -> Result<(StatusCode, HeaderMap, Vec<u8>), AppError> {
+    let include_bezel = query
+        .bezel
+        .as_deref()
+        .map(parse_asset_bool)
+        .unwrap_or(false);
     let png = if android::is_android_id(&udid) {
+        if include_bezel {
+            return Err(AppError::bad_request(
+                "Android emulators do not support bezeled screenshots.",
+            ));
+        }
         run_android_action(state, move |android| android.screenshot_png(&udid)).await?
     } else {
-        run_bridge_action(state, move |bridge| bridge.screenshot_png(&udid)).await?
+        run_bridge_action(state, move |bridge| {
+            bridge.screenshot_png(&udid, include_bezel)
+        })
+        .await?
     };
     let mut headers = HeaderMap::new();
     headers.insert(header::CONTENT_TYPE, "image/png".parse().unwrap());
@@ -2267,6 +2296,45 @@ async fn screenshot_png(
         "no-cache, no-store, must-revalidate".parse().unwrap(),
     );
     Ok((StatusCode::OK, headers, png))
+}
+
+async fn screen_recording(
+    State(state): State<AppState>,
+    Path(udid): Path<String>,
+    Json(payload): Json<ScreenRecordingPayload>,
+) -> Result<(StatusCode, HeaderMap, Vec<u8>), AppError> {
+    let seconds = validate_screen_recording_seconds(payload.seconds)?;
+    if android::is_android_id(&udid) {
+        return Err(AppError::bad_request(
+            "Screen recording is currently supported for iOS simulators only.",
+        ));
+    }
+    let mp4 = run_bridge_action(state, move |bridge| {
+        bridge.screen_recording_mp4(&udid, seconds)
+    })
+    .await?;
+    let mut headers = HeaderMap::new();
+    headers.insert(header::CONTENT_TYPE, "video/mp4".parse().unwrap());
+    headers.insert(
+        header::CACHE_CONTROL,
+        "no-cache, no-store, must-revalidate".parse().unwrap(),
+    );
+    Ok((StatusCode::OK, headers, mp4))
+}
+
+fn validate_screen_recording_seconds(seconds: Option<f64>) -> Result<f64, AppError> {
+    let seconds = seconds.unwrap_or(5.0);
+    if !seconds.is_finite() || seconds <= 0.0 {
+        return Err(AppError::bad_request(
+            "`seconds` must be finite and greater than zero.",
+        ));
+    }
+    if seconds > 120.0 {
+        return Err(AppError::bad_request(
+            "`seconds` must be 120 or less for API screen recordings.",
+        ));
+    }
+    Ok(seconds)
 }
 
 async fn toggle_appearance(

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -20,7 +20,7 @@ mod webkit;
 use anyhow::Context;
 use api::routes::{router, AppState};
 use axum::Router;
-use clap::{Args, Parser, Subcommand, ValueEnum};
+use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
 use config::Config;
 use inspector::{InspectorHub, InspectorRegistryAdvertisement};
 use logs::LogRegistry;
@@ -210,6 +210,17 @@ enum Command {
         output: Option<PathBuf>,
         #[arg(long)]
         stdout: bool,
+        #[arg(long = "with-bezel", visible_alias = "bezel", action = ArgAction::SetTrue)]
+        with_bezel: bool,
+    },
+    Record {
+        udid: String,
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+        #[arg(long)]
+        stdout: bool,
+        #[arg(long, default_value_t = 5.0, value_parser = parse_positive_seconds_arg)]
+        seconds: f64,
     },
     Stream {
         udid: String,
@@ -2400,13 +2411,16 @@ fn main() -> anyhow::Result<()> {
             udid,
             output,
             stdout,
+            with_bezel,
         } => {
             let service_url = command_service_url(explicit_server_url.as_deref())?;
+            let query = if with_bezel { "?bezel=true" } else { "" };
             let png = service_get_bytes(
                 &service_url,
                 &format!(
-                    "/api/simulators/{}/screenshot.png",
-                    url_path_component(&udid)
+                    "/api/simulators/{}/screenshot.png{}",
+                    url_path_component(&udid),
+                    query
                 ),
             )?;
             if stdout {
@@ -2422,6 +2436,38 @@ fn main() -> anyhow::Result<()> {
                 fs::write(&output, &png)?;
                 println_json(
                     &serde_json::json!({ "ok": true, "udid": udid, "action": "screenshot", "output": output }),
+                )?;
+            }
+            Ok(())
+        }
+        Command::Record {
+            udid,
+            output,
+            stdout,
+            seconds,
+        } => {
+            let service_url = command_service_url(explicit_server_url.as_deref())?;
+            let mp4 = service_post_bytes(
+                &service_url,
+                &format!(
+                    "/api/simulators/{}/screen-recording",
+                    url_path_component(&udid)
+                ),
+                &serde_json::json!({ "seconds": seconds }),
+            )?;
+            if stdout {
+                io::stdout().write_all(&mp4)?;
+            } else {
+                let output = output.unwrap_or_else(|| default_recording_path(&udid));
+                if let Some(parent) = output
+                    .parent()
+                    .filter(|parent| !parent.as_os_str().is_empty())
+                {
+                    fs::create_dir_all(parent)?;
+                }
+                fs::write(&output, &mp4)?;
+                println_json(
+                    &serde_json::json!({ "ok": true, "udid": udid, "action": "record", "output": output, "seconds": seconds }),
                 )?;
             }
             Ok(())
@@ -3456,6 +3502,14 @@ fn default_screenshot_path(udid: &str) -> PathBuf {
     PathBuf::from(format!("Simulator Screenshot - {udid} - {timestamp}.png"))
 }
 
+fn default_recording_path(udid: &str) -> PathBuf {
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0);
+    PathBuf::from(format!("Simulator Recording - {udid} - {timestamp}.mp4"))
+}
+
 fn run_stream_stdout(bridge: &NativeBridge, udid: String, frames: u64) -> anyhow::Result<()> {
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_time()
@@ -3640,6 +3694,10 @@ fn service_get_json(server_url: &str, path: &str) -> anyhow::Result<Value> {
 
 fn service_get_bytes(server_url: &str, path: &str) -> anyhow::Result<Vec<u8>> {
     http_request(server_url, "GET", path, None)
+}
+
+fn service_post_bytes(server_url: &str, path: &str, body: &Value) -> anyhow::Result<Vec<u8>> {
+    http_request(server_url, "POST", path, Some(body))
 }
 
 fn service_open_url(server_url: &str, udid: &str, url: &str) -> anyhow::Result<()> {
@@ -5700,6 +5758,17 @@ fn parse_point(value: &str) -> Result<(f64, f64), String> {
     Ok((x, y))
 }
 
+fn parse_positive_seconds_arg(value: &str) -> Result<f64, String> {
+    let seconds = value
+        .trim()
+        .parse::<f64>()
+        .map_err(|_| "seconds must be a number".to_owned())?;
+    if !seconds.is_finite() || seconds <= 0.0 {
+        return Err("seconds must be finite and greater than zero".to_owned());
+    }
+    Ok(seconds)
+}
+
 fn resolve_touch_point(
     bridge: &NativeBridge,
     udid: &str,
@@ -6093,6 +6162,58 @@ mod tests {
             Cli::try_parse_from(["simdeck", "daemon", "start", "--local-stream-fps", "241"])
                 .is_err()
         );
+    }
+
+    #[test]
+    fn screenshot_accepts_bezel_capture_flag() {
+        let cli = Cli::parse_from(["simdeck", "screenshot", "SIM-1", "--with-bezel"]);
+
+        let Command::Screenshot { with_bezel, .. } = cli.command else {
+            panic!("expected screenshot command");
+        };
+        assert!(with_bezel);
+
+        let cli = Cli::parse_from(["simdeck", "screenshot", "SIM-1", "--bezel"]);
+        let Command::Screenshot { with_bezel, .. } = cli.command else {
+            panic!("expected screenshot command");
+        };
+        assert!(with_bezel);
+    }
+
+    #[test]
+    fn record_accepts_duration_output_and_stdout() {
+        let cli = Cli::parse_from([
+            "simdeck",
+            "record",
+            "SIM-1",
+            "--seconds",
+            "2.5",
+            "--output",
+            "capture.mp4",
+        ]);
+
+        let Command::Record {
+            seconds,
+            output,
+            stdout,
+            ..
+        } = cli.command
+        else {
+            panic!("expected record command");
+        };
+        assert_eq!(seconds, 2.5);
+        assert_eq!(output, Some(PathBuf::from("capture.mp4")));
+        assert!(!stdout);
+
+        let cli = Cli::parse_from(["simdeck", "record", "SIM-1", "--stdout"]);
+        let Command::Record {
+            seconds, stdout, ..
+        } = cli.command
+        else {
+            panic!("expected record command");
+        };
+        assert_eq!(seconds, 5.0);
+        assert!(stdout);
     }
 
     #[test]

--- a/server/src/native/bridge.rs
+++ b/server/src/native/bridge.rs
@@ -393,11 +393,32 @@ impl NativeBridge {
         }
     }
 
-    pub fn screenshot_png(&self, udid: &str) -> Result<Vec<u8>, AppError> {
+    pub fn screenshot_png(&self, udid: &str, include_bezel: bool) -> Result<Vec<u8>, AppError> {
         let udid = CString::new(udid).map_err(|e| AppError::bad_request(e.to_string()))?;
         unsafe {
             let mut error = ptr::null_mut();
-            let bytes = ffi::xcw_native_screenshot_png(udid.as_ptr(), &mut error);
+            let bytes = ffi::xcw_native_screenshot_png(udid.as_ptr(), include_bezel, &mut error);
+            if bytes.data.is_null() {
+                return Err(
+                    take_error(error).unwrap_or_else(|| AppError::native("Unknown native error."))
+                );
+            }
+            let data = std::slice::from_raw_parts(bytes.data, bytes.length).to_vec();
+            ffi::xcw_native_free_bytes(bytes);
+            Ok(data)
+        }
+    }
+
+    pub fn screen_recording_mp4(
+        &self,
+        udid: &str,
+        duration_seconds: f64,
+    ) -> Result<Vec<u8>, AppError> {
+        let udid = CString::new(udid).map_err(|e| AppError::bad_request(e.to_string()))?;
+        unsafe {
+            let mut error = ptr::null_mut();
+            let bytes =
+                ffi::xcw_native_screen_recording_mp4(udid.as_ptr(), duration_seconds, &mut error);
             if bytes.data.is_null() {
                 return Err(
                     take_error(error).unwrap_or_else(|| AppError::native("Unknown native error."))

--- a/server/src/native/ffi.rs
+++ b/server/src/native/ffi.rs
@@ -85,6 +85,12 @@ unsafe extern "C" {
     ) -> xcw_native_owned_bytes;
     pub fn xcw_native_screenshot_png(
         udid: *const c_char,
+        include_bezel: bool,
+        error_message: *mut *mut c_char,
+    ) -> xcw_native_owned_bytes;
+    pub fn xcw_native_screen_recording_mp4(
+        udid: *const c_char,
+        duration_seconds: f64,
         error_message: *mut *mut c_char,
     ) -> xcw_native_owned_bytes;
     pub fn xcw_native_recent_logs(

--- a/skills/simdeck/SKILL.md
+++ b/skills/simdeck/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: simdeck
-description: Use for simulator lifecycle, app install/launch, live viewing, UI inspection, touch/keyboard automation, screenshots, logs, pasteboard, hardware controls, and repeatable simulator flows.
+description: Use for simulator lifecycle, app install/launch, live viewing, UI inspection, touch/keyboard automation, screenshots, recordings, logs, pasteboard, hardware controls, and repeatable simulator flows.
 ---
 
 # SimDeck Agent Guide
@@ -206,7 +206,10 @@ await simdeck.batch(udid, [
 
 ```bash
 simdeck screenshot <UDID> --output screen.png
+simdeck screenshot <UDID> --with-bezel --output screen-bezel.png
 simdeck screenshot <UDID> --stdout > screen.png
+simdeck record <UDID> --seconds 5 --output screen-recording.mp4
+simdeck record <UDID> --seconds 5 --stdout > screen-recording.mp4
 simdeck logs <UDID> --seconds 30 --limit 200
 simdeck chrome-profile <UDID>
 simdeck processes <UDID>
@@ -215,7 +218,7 @@ simdeck stats <UDID> --watch
 simdeck sample <UDID> --seconds 3
 ```
 
-Use screenshots for still evidence. Use `stats` for simulator app CPU, memory, disk write, network receive/send rates, connections, hang, and crash/termination signals. Use `sample` only when a short CPU stack capture is worth the extra pause. Prefer describe for token-efficient state dumps, if they have enough context.
+Use screenshots for still evidence, `--with-bezel` when the device frame matters, and `record` for short MP4 screen recordings. Use `stats` for simulator app CPU, memory, disk write, network receive/send rates, connections, hang, and crash/termination signals. Use `sample` only when a short CPU stack capture is worth the extra pause. Prefer describe for token-efficient state dumps, if they have enough context.
 
 ## Default Loop
 


### PR DESCRIPTION
## Summary
- Add `simdeck screenshot --with-bezel` / `--bezel` support and preserve the screen-only default
- Add `simdeck record` plus matching REST and native bridge endpoints for MP4 screen recording
- Expose the new capture flows in the browser UI, `simdeck/test`, docs, and integration smoke tests

## Testing
- `cargo test --manifest-path server/Cargo.toml`
- `npm run build:simdeck-test`
- `npm run --prefix client typecheck`
- `npm run --prefix client test`
- `npm run build:client`
- `npm run build:cli`