### PR TITLE
fix: packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,11 @@ server/target/
 client/dist/
 packages/inspector-agent/.build/
 packages/inspector-agent/.swiftpm/
+packages/nativescript-inspector/build/
 packages/nativescript-inspector/dist/
+packages/nativescript-inspector/index.js
+packages/nativescript-inspector/index.mjs
+packages/nativescript-inspector/index.d.ts
 packages/react-native-inspector/dist/
 packages/flutter-inspector/.dart_tool/
 packages/flutter-inspector/pubspec.lock

--- a/packages/nativescript-inspector/package.json
+++ b/packages/nativescript-inspector/package.json
@@ -8,20 +8,27 @@
     "url": "https://github.com/NativeScript/SimDeck",
     "directory": "packages/nativescript-inspector"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./index.js",
+  "module": "./index.mjs",
+  "types": "./index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
-    }
+      "types": "./index.d.ts",
+      "import": "./index.mjs",
+      "require": "./index.js",
+      "default": "./index.js"
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json",
-    "prepack": "npm run build"
+    "build": "node ./scripts/build.mjs",
+    "clean": "node ./scripts/clean.mjs",
+    "prepack": "npm run clean && npm run build"
   },
   "files": [
-    "dist",
+    "index.js",
+    "index.mjs",
+    "index.d.ts",
     "README.md",
     "src"
   ],

--- a/packages/nativescript-inspector/scripts/build.mjs
+++ b/packages/nativescript-inspector/scripts/build.mjs
@@ -31,4 +31,6 @@ copyFileSync("build/types/index.d.ts", "index.d.ts");
 
 rmSync("build", { recursive: true, force: true });
 
-console.log("✓ built @nativescript/simdeck-inspector (index.js, index.mjs, index.d.ts)");
+console.log(
+  "✓ built @nativescript/simdeck-inspector (index.js, index.mjs, index.d.ts)",
+);

--- a/packages/nativescript-inspector/scripts/build.mjs
+++ b/packages/nativescript-inspector/scripts/build.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { copyFileSync, existsSync, rmSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = resolve(here, "..");
+process.chdir(root);
+
+function run(cmd, args, label) {
+  const result = spawnSync(cmd, args, {
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  });
+  if (result.status !== 0) {
+    console.error(`[${label}] failed with status ${result.status}`);
+    process.exit(result.status ?? 1);
+  }
+}
+
+rmSync("build", { recursive: true, force: true });
+
+run("npx", ["tsc", "-p", "tsconfig.cjs.json"], "cjs");
+run("npx", ["tsc", "-p", "tsconfig.esm.json"], "esm");
+run("npx", ["tsc", "-p", "tsconfig.types.json"], "types");
+
+copyFileSync("build/cjs/index.js", "index.js");
+copyFileSync("build/esm/index.js", "index.mjs");
+copyFileSync("build/types/index.d.ts", "index.d.ts");
+
+rmSync("build", { recursive: true, force: true });
+
+console.log("✓ built @nativescript/simdeck-inspector (index.js, index.mjs, index.d.ts)");

--- a/packages/nativescript-inspector/scripts/clean.mjs
+++ b/packages/nativescript-inspector/scripts/clean.mjs
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+import { rmSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = resolve(here, "..");
+process.chdir(root);
+
+for (const target of ["build", "dist", "index.js", "index.mjs", "index.d.ts"]) {
+  rmSync(target, { recursive: true, force: true });
+}

--- a/packages/nativescript-inspector/tsconfig.cjs.json
+++ b/packages/nativescript-inspector/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "node10",
+    "ignoreDeprecations": "5.0",
+    "outDir": "./build/cjs"
+  }
+}

--- a/packages/nativescript-inspector/tsconfig.esm.json
+++ b/packages/nativescript-inspector/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ES2020",
+    "outDir": "./build/esm"
+  }
+}

--- a/packages/nativescript-inspector/tsconfig.json
+++ b/packages/nativescript-inspector/tsconfig.json
@@ -1,16 +1,16 @@
 {
   "compilerOptions": {
-    "declaration": true,
-    "emitDeclarationOnly": false,
     "lib": ["ES2020", "DOM"],
+    "target": "ES2020",
     "module": "ES2020",
-    "moduleResolution": "node",
-    "noEmitOnError": true,
-    "outDir": "dist",
+    "moduleResolution": "bundler",
     "rootDir": "src",
-    "skipLibCheck": true,
     "strict": true,
-    "target": "ES2020"
+    "skipLibCheck": true,
+    "noEmitOnError": true,
+    "declaration": false,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true
   },
   "include": ["src/**/*.ts"]
 }

--- a/packages/nativescript-inspector/tsconfig.types.json
+++ b/packages/nativescript-inspector/tsconfig.types.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ES2020",
+    "outDir": "./build/types",
+    "declaration": true,
+    "emitDeclarationOnly": true
+  }
+}


### PR DESCRIPTION
Refactors the build and packaging process for the `nativescript-inspector` package to improve compatibility and clarity for consumers. The main changes include switching to a dual CommonJS/ESM output, updating the build scripts, and restructuring TypeScript configurations.

* Updated `package.json` to export both CommonJS (`index.js`) and ESM (`index.mjs`) entry points, as well as type definitions, and added new scripts for building and cleaning using Node scripts. The output files are now at the package root instead of in a `dist` folder.

* Added new build (`scripts/build.mjs`) and clean (`scripts/clean.mjs`) scripts to handle compilation for CommonJS, ESM, and types, and to clean up generated files. These scripts replace the previous TypeScript-only build step. [[1]](diffhunk://#diff-93f339f769da75100cb1e228e1305f40b0cb50fb4bc820ca8c8495e5d56a1835R1-R34) [[2]](diffhunk://#diff-a6020ceefbfc8529ddc9afecae83948e50f73c566f01eea9847f6a2319f33dfaR1-R12)
