### PR TITLE
fix: websocket check to prevent runtime conflict on network framework

### DIFF
--- a/packages/nativescript-inspector/src/index.ts
+++ b/packages/nativescript-inspector/src/index.ts
@@ -891,7 +891,7 @@ function createInspectorSocket(
   url: string,
   handlers: InspectorSocketHandlers,
 ): InspectorSocket {
-  if (isBrowserWebSocket(WebSocket)) {
+  if (typeof WebSocket !== "undefined" && isBrowserWebSocket(WebSocket)) {
     const socket = new WebSocket(url) as any;
     socket.onmessage = (event: { data: string }) => {
       handlers.onMessage(String(event.data));

--- a/packages/nativescript-inspector/src/index.ts
+++ b/packages/nativescript-inspector/src/index.ts
@@ -891,7 +891,7 @@ function createInspectorSocket(
   url: string,
   handlers: InspectorSocketHandlers,
 ): InspectorSocket {
-  if (typeof WebSocket === "function") {
+  if (isBrowserWebSocket(WebSocket)) {
     const socket = new WebSocket(url) as any;
     socket.onmessage = (event: { data: string }) => {
       handlers.onMessage(String(event.data));
@@ -909,6 +909,23 @@ function createInspectorSocket(
   throw new InspectorFailure(
     -32011,
     "No WebSocket implementation is available in this NativeScript runtime.",
+  );
+}
+
+// NativeScript exposes Objective-C class as a global "function", and
+// recent iOS SDKs ship a top-level `WebSocket` class in Network.framework.
+// `typeof WebSocket === "function"` therefore matches that native class and
+// `new WebSocket(url)` fails with "No initializer found that matches
+// constructor invocation." Require browser-style readyState constants and a
+// `send`/`close` prototype to confirm the global is a real WebSocket polyfill
+// (e.g. @valor/nativescript-websockets) before using it.
+function isBrowserWebSocket(ctor: any): boolean {
+  return (
+    typeof ctor === "function" &&
+    ctor.CONNECTING === 0 &&
+    ctor.OPEN === 1 &&
+    typeof ctor.prototype?.send === "function" &&
+    typeof ctor.prototype?.close === "function"
   );
 }
 


### PR DESCRIPTION
Browser-compatible `WebSocket` implementation in the `createInspectorSocket` function to prevent runtime errors when running in environments where a non-browser global `WebSocket` is present, such as NativeScript on iOS. The main change is the introduction of a stricter check for a browser-style `WebSocket` before attempting to instantiate it.

**WebSocket environment detection improvements:**

* Replaced the previous `typeof WebSocket === "function"` check with a new `isBrowserWebSocket` function in `index.ts` to ensure the global `WebSocket` is compatible with browser APIs before using it. This prevents instantiation errors with native classes that are not true WebSocket polyfills.
* Added the `isBrowserWebSocket` helper function, which checks for browser-style readyState constants (`CONNECTING`, `OPEN`) and the presence of `send` and `close` methods on the prototype, ensuring only real browser WebSocket polyfills are used.