### PR TITLE
perf(android): improve emulator stream performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,11 @@ Use `simdeck service reset` only when you want to rotate the service token and
 restart the LaunchAgent.
 The service uses port 4310 unless you pass `-p` or `--port`, or set a default
 in `~/.simdeck/config.json`.
-SimDeck-owned Android emulator boots use host GPU rendering by default; use
+SimDeck-owned Android emulator boots use host GPU rendering by default; on macOS
+they start the emulator with `-qt-hide-window` so the Qt renderer stays active
+without showing the native emulator window. Managed boots also open the emulator
+gRPC endpoint for event-driven Android video capture, with shared-video polling
+kept as a fallback. Use
 `simdeck service restart --android-gpu auto` or
 `--android-gpu swiftshader_indirect` only as a machine-specific fallback.
 Managed Android boots also add `-no-audio` by default. Set

--- a/docs/api/health.md
+++ b/docs/api/health.md
@@ -61,18 +61,19 @@ GET /api/metrics
 
 Useful fields:
 
-| Field                              | What to look for                             |
-| ---------------------------------- | -------------------------------------------- |
-| `latest_first_frame_ms`            | First-frame startup time                     |
-| `frames_dropped_server`            | Server dropping stale frames to stay current |
-| `keyframe_requests`                | Stream refresh or recovery activity          |
-| `stream_pipeline_resets`           | Encoder resets after all viewers disconnect  |
-| `latest_accessibility_snapshot_ms` | Most recent native accessibility duration    |
-| `max_accessibility_snapshot_ms`    | Slowest native accessibility duration        |
-| `accessibility_snapshot_timeouts`  | Native accessibility calls that timed out    |
-| `active_streams`                   | Open browser streams                         |
-| `encoders[].encoder.overloadState` | `nominal`, `strained`, or `overloaded`       |
-| `client_streams`                   | Recent browser decoder and render reports    |
+| Field                              | What to look for                                           |
+| ---------------------------------- | ---------------------------------------------------------- |
+| `latest_first_frame_ms`            | First-frame startup time                                   |
+| `frames_dropped_server`            | Server dropping stale frames to stay current               |
+| `keyframe_requests`                | Stream refresh or recovery activity                        |
+| `stream_pipeline_resets`           | Encoder resets after all viewers disconnect                |
+| `latest_accessibility_snapshot_ms` | Most recent native accessibility duration                  |
+| `max_accessibility_snapshot_ms`    | Slowest native accessibility duration                      |
+| `accessibility_snapshot_timeouts`  | Native accessibility calls that timed out                  |
+| `active_streams`                   | Open browser streams                                       |
+| `encoders[].encoder.overloadState` | `nominal`, `strained`, or `overloaded`                     |
+| `androidEncoders[]`                | Android video source kind, `videoCodec`, and encoder stats |
+| `client_streams`                   | Recent browser decoder and render reports                  |
 
 If `overloadState` is `overloaded` or dropped frames keep increasing, lower stream quality or restart with software encoding:
 

--- a/docs/guide/video.md
+++ b/docs/guide/video.md
@@ -1,9 +1,9 @@
 # Video and streaming
 
-SimDeck streams live device video to the browser. Local sessions default to full-resolution 60 fps. Remote or constrained sessions can trade detail for lower CPU and latency.
+SimDeck streams live device video to the browser. Local iOS sessions default to full-resolution 60 fps. Android emulator browser sessions default to software H.264 with the `balanced` profile capped at 960px on the long edge because the host reads and encodes emulator RGBA frames from the emulator gRPC screenshot stream. Remote or constrained sessions can trade detail for lower CPU and latency.
 
 iOS simulator H.264 uses VideoToolbox for hardware encoding and x264 for software encoding.
-Android emulator H.264 uses the emulator `-share-vid` display surface. SimDeck reads BGRA frames from the `videmulator<console-port>` shared memory region and encodes them on the Mac, so normal Android live video stays on the native shared display path.
+Android emulator H.264 uses the emulator gRPC `streamScreenshot` API when SimDeck owns the boot. SimDeck receives raw RGBA frames, pads odd dimensions for H.264, and encodes them on the Mac. If the gRPC endpoint is unavailable, SimDeck falls back to the emulator `-share-vid` display surface and reads BGRA frames from the `videmulator<console-port>` shared memory region.
 
 ## When encoding runs
 
@@ -13,7 +13,10 @@ shared refresh pump active while frame subscribers exist.
 For Android, SimDeck starts emulators with `-share-vid`, maps the shared display
 region, and feeds changed BGRA frames into the native host H.264 encoder.
 SimDeck-owned Android boots also default to `-gpu host`, matching the native
-emulator app's accelerated renderer while staying in headless shared-video mode.
+emulator app's accelerated renderer while staying hidden. On macOS, managed
+boots use `-qt-hide-window` instead of `-no-window` so the Qt render loop stays
+active without showing the emulator window. Managed Android boots also reserve a
+per-AVD `-grpc` port for event-driven screenshot streaming.
 
 The browser reports whether the page and stream canvas are foreground. When all
 known viewers are hidden or the last frame subscriber disconnects, the native
@@ -38,17 +41,17 @@ simdeck service restart --stream-quality ci-software
 
 Common profiles:
 
-| Profile       | Use it for                              |
-| ------------- | --------------------------------------- |
-| `full`        | Default local full-resolution 60 fps    |
-| `smooth`      | Full-size 60 fps with lower bitrate     |
-| `balanced`    | Good local quality with less bandwidth  |
-| `economy`     | Remote browser or busy machine          |
-| `low`         | Slower Wi-Fi or shared hosts            |
-| `tiny`        | Pull request previews and low bandwidth |
-| `ci-software` | Virtualized CI Macs                     |
+| Profile       | Use it for                                            |
+| ------------- | ----------------------------------------------------- |
+| `full`        | Default local full-resolution 60 fps                  |
+| `smooth`      | 60 fps with lower bitrate; Android caps this at 960px |
+| `balanced`    | Good local quality with less bandwidth                |
+| `economy`     | Remote browser or busy machine                        |
+| `low`         | Slower Wi-Fi or shared hosts                          |
+| `tiny`        | Pull request previews and low bandwidth               |
+| `ci-software` | Virtualized CI Macs                                   |
 
-The browser also has stream controls for transport, resolution, FPS, and refresh.
+The browser also has stream controls for transport, resolution, FPS, encoder mode, and refresh. Choosing `Full res` for an Android emulator keeps the native shared-video dimensions, which can be expensive on tall phone profiles. Set `SIMDECK_ANDROID_VIDEO_CODEC=hardware` or choose Hardware in the browser when you explicitly want VideoToolbox for Android.
 
 ## Pick an Android GPU mode
 

--- a/packages/client/src/app/AppShell.tsx
+++ b/packages/client/src/app/AppShell.tsx
@@ -150,6 +150,11 @@ const LOCAL_STREAM_DEFAULTS: StreamConfig = {
   fps: 60,
   quality: "full",
 };
+const ANDROID_LOCAL_STREAM_DEFAULTS: StreamConfig = {
+  encoder: "software",
+  fps: 60,
+  quality: "balanced",
+};
 const REMOTE_STREAM_DEFAULTS: StreamConfig = {
   encoder: "software",
   fps: 30,
@@ -311,6 +316,34 @@ function defaultStreamConfigForTransport(
 ): StreamConfig {
   const base = remote ? REMOTE_STREAM_DEFAULTS : LOCAL_STREAM_DEFAULTS;
   return base;
+}
+
+function streamConfigForSelectedSimulator(
+  config: StreamConfig,
+  simulator: SimulatorMetadata | null,
+  remote: boolean,
+  userTouched: boolean,
+): StreamConfig {
+  if (remote || userTouched || !isAndroidSimulator(simulator)) {
+    return config;
+  }
+  const quality =
+    config.quality === "full" || config.quality === "quality"
+      ? ANDROID_LOCAL_STREAM_DEFAULTS.quality
+      : config.quality;
+  const encoder =
+    config.encoder === "auto"
+      ? ANDROID_LOCAL_STREAM_DEFAULTS.encoder
+      : config.encoder;
+  if (quality === config.quality && encoder === config.encoder) {
+    return config;
+  }
+  return {
+    ...config,
+    encoder,
+    maxEdge: undefined,
+    quality,
+  };
 }
 
 function shouldForceInitialFitMode(): boolean {
@@ -854,6 +887,37 @@ export function AppShell({
     };
   }, [remoteStream, syncStreamConfig]);
 
+  const effectiveStreamConfig = useMemo(
+    () =>
+      streamConfigForSelectedSimulator(
+        streamConfig,
+        selectedSimulator,
+        remoteStream,
+        streamConfigUserTouchedRef.current,
+      ),
+    [remoteStream, selectedSimulator, streamConfig],
+  );
+
+  useEffect(() => {
+    if (streamConfigUserTouchedRef.current) {
+      return;
+    }
+    setStreamConfig((current) => {
+      const next = streamConfigForSelectedSimulator(
+        current,
+        selectedSimulator,
+        remoteStream,
+        false,
+      );
+      return streamConfigsEqual(current, next) ? current : next;
+    });
+  }, [
+    remoteStream,
+    selectedSimulator?.platform,
+    selectedSimulator?.udid,
+    streamConfig.quality,
+  ]);
+
   const {
     deviceNaturalSize,
     error: streamError,
@@ -869,7 +933,7 @@ export function AppShell({
     paused: !streamConfigReady,
     remote: remoteStream,
     simulator: selectedSimulator,
-    streamConfig,
+    streamConfig: effectiveStreamConfig,
     streamConfigApplyKey,
     streamTransport,
   });
@@ -886,29 +950,42 @@ export function AppShell({
     void refreshRef.current();
   }, [streamStatus.error, streamStatus.state, syncStreamConfig]);
 
-  const updateStreamEncoder = useCallback((encoder: StreamEncoder) => {
-    streamConfigUserTouchedRef.current = true;
-    streamConfigUserChangeAtRef.current = Date.now();
-    setStreamConfigReady(true);
-    setStreamConfigApplyKey((current) => current + 1);
-    setStreamConfig((current) => ({ ...current, encoder }));
-  }, []);
+  const updateStreamEncoder = useCallback(
+    (encoder: StreamEncoder) => {
+      streamConfigUserTouchedRef.current = true;
+      streamConfigUserChangeAtRef.current = Date.now();
+      setStreamConfigReady(true);
+      setStreamConfigApplyKey((current) => current + 1);
+      setStreamConfig({ ...effectiveStreamConfig, encoder });
+    },
+    [effectiveStreamConfig],
+  );
 
-  const updateStreamFps = useCallback((fps: StreamFps) => {
-    streamConfigUserTouchedRef.current = true;
-    streamConfigUserChangeAtRef.current = Date.now();
-    setStreamConfigReady(true);
-    setStreamConfigApplyKey((current) => current + 1);
-    setStreamConfig((current) => ({ ...current, fps }));
-  }, []);
+  const updateStreamFps = useCallback(
+    (fps: StreamFps) => {
+      streamConfigUserTouchedRef.current = true;
+      streamConfigUserChangeAtRef.current = Date.now();
+      setStreamConfigReady(true);
+      setStreamConfigApplyKey((current) => current + 1);
+      setStreamConfig({ ...effectiveStreamConfig, fps });
+    },
+    [effectiveStreamConfig],
+  );
 
-  const updateStreamQuality = useCallback((quality: StreamQualityPreset) => {
-    streamConfigUserTouchedRef.current = true;
-    streamConfigUserChangeAtRef.current = Date.now();
-    setStreamConfigReady(true);
-    setStreamConfigApplyKey((current) => current + 1);
-    setStreamConfig((current) => ({ ...current, maxEdge: undefined, quality }));
-  }, []);
+  const updateStreamQuality = useCallback(
+    (quality: StreamQualityPreset) => {
+      streamConfigUserTouchedRef.current = true;
+      streamConfigUserChangeAtRef.current = Date.now();
+      setStreamConfigReady(true);
+      setStreamConfigApplyKey((current) => current + 1);
+      setStreamConfig({
+        ...effectiveStreamConfig,
+        maxEdge: undefined,
+        quality,
+      });
+    },
+    [effectiveStreamConfig],
+  );
 
   const updateStreamTransport = useCallback((transport: StreamTransport) => {
     setStreamTransport(transport);
@@ -3747,7 +3824,7 @@ export function AppShell({
           !selectedSimulator.isBooted &&
           !selectedSimulatorTransitionKind,
         )}
-        streamConfig={streamConfig}
+        streamConfig={effectiveStreamConfig}
         streamTransport={streamTransport}
         deviceChromeAvailable={selectedSupportsChrome}
         deviceChromeVisible={deviceChromeToggleActive}

--- a/packages/server/Cargo.lock
+++ b/packages/server/Cargo.lock
@@ -151,6 +151,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,11 +197,38 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.5",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "axum-core",
+ "axum-core 0.5.6",
  "base64",
  "bytes",
  "form_urlencoded",
@@ -190,7 +239,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "percent-encoding",
@@ -203,10 +252,30 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -574,6 +643,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
 name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,6 +686,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -631,6 +712,18 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -804,6 +897,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,6 +1027,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -917,6 +1036,20 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -926,12 +1059,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "libc",
  "pin-project-lite",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1057,6 +1195,16 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
@@ -1110,6 +1258,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1146,6 +1303,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1174,6 +1337,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matchit"
@@ -1248,6 +1417,12 @@ dependencies = [
  "num-traits",
  "pxfm",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nix"
@@ -1415,6 +1590,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.14.0",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1443,7 +1648,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64",
- "indexmap",
+ "indexmap 2.14.0",
  "quick-xml",
  "serde",
  "time",
@@ -1518,6 +1723,122 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck",
+ "itertools",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
+]
+
+[[package]]
+name = "protoc-bin-vendored"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c381df33c98266b5f08186583660090a4ffa0889e76c7e9a5e175f645a67fa"
+dependencies = [
+ "protoc-bin-vendored-linux-aarch_64",
+ "protoc-bin-vendored-linux-ppcle_64",
+ "protoc-bin-vendored-linux-s390_64",
+ "protoc-bin-vendored-linux-x86_32",
+ "protoc-bin-vendored-linux-x86_64",
+ "protoc-bin-vendored-macos-aarch_64",
+ "protoc-bin-vendored-macos-x86_64",
+ "protoc-bin-vendored-win32",
+]
+
+[[package]]
+name = "protoc-bin-vendored-linux-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c350df4d49b5b9e3ca79f7e646fde2377b199e13cfa87320308397e1f37e1a4c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-ppcle_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55a63e6c7244f19b5c6393f025017eb5d793fd5467823a099740a7a4222440c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-s390_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dba5565db4288e935d5330a07c264a4ee8e4a5b4a4e6f4e83fad824cc32f3b0"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8854774b24ee28b7868cd71dccaae8e02a2365e67a4a87a6cd11ee6cdbdf9cf5"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38b07546580df720fa464ce124c4b03630a6fb83e05c336fea2a241df7e5d78"
+
+[[package]]
+name = "protoc-bin-vendored-macos-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89278a9926ce312e51f1d999fee8825d324d603213344a9a706daa009f1d8092"
+
+[[package]]
+name = "protoc-bin-vendored-macos-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81745feda7ccfb9471d7a4de888f0652e806d5795b61480605d4943176299756"
+
+[[package]]
+name = "protoc-bin-vendored-win32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
 
 [[package]]
 name = "pxfm"
@@ -1750,6 +2071,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1905,7 +2239,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -1974,7 +2308,7 @@ name = "simdeck-server"
 version = "0.1.32"
 dependencies = [
  "anyhow",
- "axum",
+ "axum 0.8.9",
  "base64",
  "bytes",
  "cc",
@@ -1984,6 +2318,8 @@ dependencies = [
  "http",
  "libc",
  "plist",
+ "prost",
+ "protoc-bin-vendored",
  "qrcode",
  "regex",
  "roxmltree",
@@ -1994,6 +2330,8 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
+ "tonic",
+ "tonic-build",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -2126,6 +2464,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2244,6 +2595,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2266,6 +2628,70 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum 0.7.9",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2383,6 +2809,12 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
@@ -2524,6 +2956,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2609,7 +3050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -2622,7 +3063,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -2979,7 +3420,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -3010,7 +3451,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -3029,7 +3470,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",

--- a/packages/server/Cargo.toml
+++ b/packages/server/Cargo.toml
@@ -15,6 +15,7 @@ hex = "0.4"
 http = "1.1"
 libc = "0.2"
 plist = "1.7"
+prost = "0.13"
 qrcode = "0.14"
 roxmltree = "0.20"
 regex = "1.11"
@@ -25,6 +26,7 @@ sha2 = "0.10"
 thiserror = "2.0"
 tokio = { version = "1.42", features = ["fs", "io-util", "macros", "process", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-tungstenite = "0.29"
+tonic = { version = "0.12", default-features = false, features = ["transport", "codegen", "prost"] }
 tower-http = { version = "0.6", features = ["cors", "fs", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
@@ -32,3 +34,5 @@ webrtc = "0.12"
 
 [build-dependencies]
 cc = "1.2"
+protoc-bin-vendored = "3"
+tonic-build = "0.12"

--- a/packages/server/build.rs
+++ b/packages/server/build.rs
@@ -3,6 +3,15 @@ use std::process::Command;
 
 fn main() {
     let root = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    let android_proto = root.join("proto/android_emulation_control.proto");
+    let protoc = protoc_bin_vendored::protoc_bin_path().expect("unable to find vendored protoc");
+    std::env::set_var("PROTOC", protoc);
+    println!("cargo:rerun-if-changed={}", android_proto.display());
+    tonic_build::configure()
+        .build_server(false)
+        .compile_protos(&[android_proto], &[root.join("proto")])
+        .expect("unable to compile Android emulator gRPC proto");
+
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
     if target_os != "macos" {
         let stub = root.join("native_stubs.c");

--- a/packages/server/native/bridge/XCWNativeBridge.h
+++ b/packages/server/native/bridge/XCWNativeBridge.h
@@ -106,10 +106,12 @@ bool xcw_native_session_rotate_left(void * _Nonnull handle, char * _Nullable * _
 void xcw_native_session_set_frame_callback(void * _Nonnull handle, xcw_native_frame_callback _Nullable callback, void * _Nullable user_data);
 
 void * _Nullable xcw_native_h264_encoder_create(xcw_native_frame_callback _Nullable callback, void * _Nullable user_data, char * _Nullable * _Nullable error_message);
+void * _Nullable xcw_native_h264_encoder_create_with_video_codec(xcw_native_frame_callback _Nullable callback, void * _Nullable user_data, const char * _Nullable video_codec, char * _Nullable * _Nullable error_message);
 void xcw_native_h264_encoder_destroy(void * _Nullable handle);
 bool xcw_native_h264_encoder_encode_rgba(void * _Nonnull handle, const uint8_t * _Nonnull rgba, size_t length, uint32_t width, uint32_t height, uint64_t timestamp_us, char * _Nullable * _Nullable error_message);
 bool xcw_native_h264_encoder_encode_bgra(void * _Nonnull handle, const uint8_t * _Nonnull bgra, size_t length, uint32_t width, uint32_t height, uint64_t timestamp_us, char * _Nullable * _Nullable error_message);
 void xcw_native_h264_encoder_request_keyframe(void * _Nonnull handle);
+char * _Nullable xcw_native_h264_encoder_stats(void * _Nonnull handle, char * _Nullable * _Nullable error_message);
 
 void xcw_native_free_string(char * _Nullable value);
 void xcw_native_free_bytes(xcw_native_owned_bytes bytes);

--- a/packages/server/native/bridge/XCWNativeBridge.m
+++ b/packages/server/native/bridge/XCWNativeBridge.m
@@ -156,6 +156,9 @@ static XCWNativeSession *XCWNativeSessionFromHandle(void *handle) {
 
 - (instancetype)initWithFrameCallback:(xcw_native_frame_callback)callback
                              userData:(void *)userData;
+- (instancetype)initWithFrameCallback:(xcw_native_frame_callback)callback
+                             userData:(void *)userData
+                           videoCodec:(NSString *)videoCodec;
 - (BOOL)encodeRGBA:(const uint8_t *)rgba
             length:(size_t)length
              width:(uint32_t)width
@@ -167,6 +170,7 @@ static XCWNativeSession *XCWNativeSessionFromHandle(void *handle) {
             height:(uint32_t)height
              error:(NSError * _Nullable __autoreleasing *)error;
 - (void)requestKeyFrame;
+- (NSDictionary *)statsRepresentation;
 - (void)invalidate;
 
 @end
@@ -180,6 +184,12 @@ static XCWNativeSession *XCWNativeSessionFromHandle(void *handle) {
 
 - (instancetype)initWithFrameCallback:(xcw_native_frame_callback)callback
                              userData:(void *)userData {
+    return [self initWithFrameCallback:callback userData:userData videoCodec:nil];
+}
+
+- (instancetype)initWithFrameCallback:(xcw_native_frame_callback)callback
+                             userData:(void *)userData
+                           videoCodec:(NSString *)videoCodec {
     self = [super init];
     if (self == nil) {
         return nil;
@@ -193,7 +203,8 @@ static XCWNativeSession *XCWNativeSessionFromHandle(void *handle) {
         char *previousCodecCopy = previousCodec != NULL ? strdup(previousCodec) : NULL;
         const char *previousRealtimeStream = getenv("SIMDECK_REALTIME_STREAM");
         char *previousRealtimeStreamCopy = previousRealtimeStream != NULL ? strdup(previousRealtimeStream) : NULL;
-        const char *androidCodec = getenv("SIMDECK_ANDROID_VIDEO_CODEC");
+        NSString *explicitCodec = [videoCodec stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
+        const char *androidCodec = explicitCodec.length > 0 ? explicitCodec.UTF8String : getenv("SIMDECK_ANDROID_VIDEO_CODEC");
         if (androidCodec == NULL || strlen(androidCodec) == 0) {
             androidCodec = (previousCodec != NULL && strlen(previousCodec) > 0) ? previousCodec : "auto";
         }
@@ -391,6 +402,10 @@ static XCWNativeSession *XCWNativeSessionFromHandle(void *handle) {
 
 - (void)requestKeyFrame {
     [_encoder requestKeyFrame];
+}
+
+- (NSDictionary *)statsRepresentation {
+    return [_encoder statsRepresentation] ?: @{};
 }
 
 - (void)invalidate {
@@ -1411,9 +1426,14 @@ void xcw_native_session_set_frame_callback(void *handle, xcw_native_frame_callba
 }
 
 void *xcw_native_h264_encoder_create(xcw_native_frame_callback callback, void *user_data, char **error_message) {
+    return xcw_native_h264_encoder_create_with_video_codec(callback, user_data, NULL, error_message);
+}
+
+void *xcw_native_h264_encoder_create_with_video_codec(xcw_native_frame_callback callback, void *user_data, const char *video_codec, char **error_message) {
     @autoreleasepool {
         XCWNativeH264Encoder *encoder = [[XCWNativeH264Encoder alloc] initWithFrameCallback:callback
-                                                                                  userData:user_data];
+                                                                                  userData:user_data
+                                                                                videoCodec:XCWStringFromCString(video_codec)];
         if (encoder == nil) {
             if (error_message != NULL) {
                 *error_message = XCWCopyCString(@"Unable to create the native H.264 encoder.");
@@ -1481,6 +1501,13 @@ bool xcw_native_h264_encoder_encode_bgra(void *handle,
 void xcw_native_h264_encoder_request_keyframe(void *handle) {
     @autoreleasepool {
         [XCWNativeH264EncoderFromHandle(handle) requestKeyFrame];
+    }
+}
+
+char *xcw_native_h264_encoder_stats(void *handle, char **error_message) {
+    @autoreleasepool {
+        NSDictionary *stats = [XCWNativeH264EncoderFromHandle(handle) statsRepresentation];
+        return XCWJSONStringFromObject(stats ?: @{}, error_message);
     }
 }
 

--- a/packages/server/native_stubs.c
+++ b/packages/server/native_stubs.c
@@ -567,13 +567,21 @@ bool xcw_native_session_rotate_left(void *handle, char **error_message) {
   return xcw_unsupported(error_message);
 }
 
-void *xcw_native_h264_encoder_create(xcw_native_frame_callback callback,
-                                     void *user_data, char **error_message) {
+void *xcw_native_h264_encoder_create_with_video_codec(
+    xcw_native_frame_callback callback, void *user_data, const char *video_codec,
+    char **error_message) {
   (void)callback;
   (void)user_data;
+  (void)video_codec;
   xcw_set_error(error_message,
                 "H.264 encoding is only available in the macOS native bridge.");
   return NULL;
+}
+
+void *xcw_native_h264_encoder_create(xcw_native_frame_callback callback,
+                                     void *user_data, char **error_message) {
+  return xcw_native_h264_encoder_create_with_video_codec(callback, user_data,
+                                                         NULL, error_message);
 }
 
 void xcw_native_h264_encoder_destroy(void *handle) { (void)handle; }
@@ -611,6 +619,13 @@ bool xcw_native_h264_encoder_encode_bgra(void *handle, const uint8_t *bgra,
 }
 
 void xcw_native_h264_encoder_request_keyframe(void *handle) { (void)handle; }
+
+char *xcw_native_h264_encoder_stats(void *handle, char **error_message) {
+  (void)handle;
+  xcw_set_error(error_message,
+                "H.264 encoding is only available in the macOS native bridge.");
+  return NULL;
+}
 
 void xcw_native_free_string(char *value) { free(value); }
 

--- a/packages/server/proto/android_emulation_control.proto
+++ b/packages/server/proto/android_emulation_control.proto
@@ -1,0 +1,72 @@
+syntax = "proto3";
+
+package android.emulation.control;
+
+service EmulatorController {
+  rpc streamScreenshot(ImageFormat) returns (stream Image);
+}
+
+message ImageFormat {
+  enum ImgFormat {
+    PNG = 0;
+    RGBA8888 = 1;
+    RGB888 = 2;
+  }
+
+  ImgFormat format = 1;
+  Rotation rotation = 2;
+  uint32 width = 3;
+  uint32 height = 4;
+  uint32 display = 5;
+  ImageTransport transport = 6;
+  FoldedDisplay foldedDisplay = 7;
+  DisplayModeValue displayMode = 8;
+}
+
+message Image {
+  ImageFormat format = 1;
+  uint32 width = 2;
+  uint32 height = 3;
+  bytes image = 4;
+  uint32 seq = 5;
+  uint64 timestampUs = 6;
+}
+
+message ImageTransport {
+  enum TransportChannel {
+    TRANSPORT_CHANNEL_UNSPECIFIED = 0;
+    MMAP = 1;
+  }
+
+  TransportChannel channel = 1;
+  string handle = 2;
+}
+
+message FoldedDisplay {
+  uint32 width = 1;
+  uint32 height = 2;
+  uint32 xOffset = 3;
+  uint32 yOffset = 4;
+}
+
+message Rotation {
+  enum SkinRotation {
+    PORTRAIT = 0;
+    LANDSCAPE = 1;
+    REVERSE_PORTRAIT = 2;
+    REVERSE_LANDSCAPE = 3;
+  }
+
+  SkinRotation rotation = 1;
+  double xAxis = 2;
+  double yAxis = 3;
+  double zAxis = 4;
+}
+
+enum DisplayModeValue {
+  UNKNOWN_DISPLAY_MODE = 0;
+  PHONE = 1;
+  FOLDABLE = 2;
+  TABLET = 3;
+  DESKTOP = 4;
+}

--- a/packages/server/src/android.rs
+++ b/packages/server/src/android.rs
@@ -20,6 +20,7 @@ use std::time::{Duration, Instant};
 
 const ANDROID_ID_PREFIX: &str = "android:";
 const DEFAULT_EMULATOR_CONSOLE_PORT_BASE: u16 = 5554;
+const DEFAULT_EMULATOR_GRPC_PORT_BASE: u16 = 8554;
 const ANDROID_EMULATOR_DEFAULT_GPU_MODE: &str = "host";
 const ANDROID_EMULATOR_GPU_ENV: &str = "SIMDECK_ANDROID_GPU";
 const ANDROID_SHARED_VIDEO_HEADER_BYTES: usize = std::mem::size_of::<AndroidSharedVideoHeader>();
@@ -87,6 +88,7 @@ pub struct AndroidDevice {
     pub serial: Option<String>,
     pub is_booted: bool,
     pub console_port: u16,
+    pub grpc_port: u16,
 }
 
 #[derive(Clone, Debug)]
@@ -99,6 +101,7 @@ pub struct AndroidEmulatorSpec {
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct AndroidH264StreamQuality {
     pub max_edge: Option<u32>,
+    pub fps: Option<u32>,
     pub min_bitrate: Option<u32>,
     pub bits_per_pixel: Option<u32>,
 }
@@ -121,6 +124,10 @@ impl Default for AndroidBootOptions {
 #[derive(Debug)]
 pub struct AndroidSharedVideoFrame {
     pub timestamp_us: u64,
+    pub source_sequence: u32,
+    pub source_fps: u32,
+    pub source_width: u32,
+    pub source_height: u32,
     pub width: u32,
     pub height: u32,
     pub bgra: Vec<u8>,
@@ -187,6 +194,7 @@ impl AndroidBridge {
                     serial: running.get(&avd_name).cloned(),
                     is_booted: running.contains_key(&avd_name),
                     console_port,
+                    grpc_port: grpc_port_for_console_port(console_port)?,
                     avd_name,
                 })
             })
@@ -818,6 +826,7 @@ impl AndroidBridge {
                 "avdName": device.avd_name,
                 "serial": device.serial,
                 "consolePort": device.console_port,
+                "grpcPort": device.grpc_port,
             },
             "privateDisplay": private_display,
         })
@@ -931,6 +940,10 @@ impl AndroidBridge {
             .ok_or_else(|| AppError::not_found(format!("Unknown Android AVD `{avd_name}`.")))?;
         *cache.lock().unwrap() = Some((Instant::now(), ports));
         Ok(port)
+    }
+
+    pub fn grpc_port_for_avd(&self, avd_name: &str) -> Result<u16, AppError> {
+        grpc_port_for_console_port(self.console_port_for_avd(avd_name)?)
     }
 
     fn screen_size_for_serial(&self, serial: &str) -> Result<(f64, f64), AppError> {
@@ -1060,6 +1073,7 @@ fn android_emulator_launch_args(
     let adb_port = console_port.checked_add(1).ok_or_else(|| {
         AppError::native("Android emulator console port overflowed while booting.")
     })?;
+    let grpc_port = grpc_port_for_console_port(console_port)?;
     let emulator_ports = format!("{console_port},{adb_port}");
     let gpu_mode = android_emulator_gpu_mode()?;
     let user_args = sanitized_android_emulator_args(&options.emulator_args)?;
@@ -1069,7 +1083,7 @@ fn android_emulator_launch_args(
         .collect::<HashSet<_>>();
 
     let mut args = vec!["-avd".to_owned(), avd_name.to_owned()];
-    let window_mode = if os == "windows" {
+    let window_mode = if os == "windows" || os == "macos" || os == "darwin" {
         "-qt-hide-window"
     } else {
         "-no-window"
@@ -1087,6 +1101,9 @@ fn android_emulator_launch_args(
     }
     if os == "windows" && !user_option_keys.contains("-feature") {
         args.extend(["-feature".to_owned(), "-Vulkan".to_owned()]);
+    }
+    if !user_option_keys.contains("-grpc") {
+        args.extend(["-grpc".to_owned(), grpc_port.to_string()]);
     }
     args.extend(user_args);
     args.extend(["-ports".to_owned(), emulator_ports, "-share-vid".to_owned()]);
@@ -1470,6 +1487,10 @@ unsafe fn android_shared_video_frame_from_memory(
     )?;
     Ok(AndroidSharedVideoFrame {
         timestamp_us: header.timestamp_us,
+        source_sequence: header.sequence,
+        source_fps: header.fps,
+        source_width: header.width,
+        source_height: header.height,
         width,
         height,
         bgra,
@@ -1874,6 +1895,23 @@ fn console_port_for_avd_index(index: usize) -> Result<u16, AppError> {
         .ok_or_else(|| {
             AppError::native("Android emulator console port overflowed while deriving ports.")
         })
+}
+
+fn grpc_port_for_console_port(console_port: u16) -> Result<u16, AppError> {
+    if console_port < DEFAULT_EMULATOR_CONSOLE_PORT_BASE {
+        return Err(AppError::native(
+            "Android emulator console port was below the SimDeck base port.",
+        ));
+    }
+    let offset = console_port - DEFAULT_EMULATOR_CONSOLE_PORT_BASE;
+    if !offset.is_multiple_of(2) {
+        return Err(AppError::native(
+            "Android emulator console port was not an even SimDeck port.",
+        ));
+    }
+    DEFAULT_EMULATOR_GRPC_PORT_BASE
+        .checked_add(offset / 2)
+        .ok_or_else(|| AppError::native("Android emulator gRPC port overflowed."))
 }
 
 fn console_port_from_serial(serial: &str) -> Option<u16> {
@@ -2501,12 +2539,53 @@ mod tests {
                 "-no-audio",
                 "-gpu",
                 "host",
+                "-grpc",
+                "10054",
                 "-no-snapshot",
                 "-ports",
                 "8554,8555",
                 "-share-vid",
             ]
         );
+    }
+
+    #[test]
+    fn android_emulator_launch_args_use_hidden_qt_window_on_macos() {
+        let args = android_emulator_launch_args(
+            "Pixel_8_API_36",
+            8554,
+            &AndroidBootOptions::default(),
+            "macos",
+        )
+        .unwrap();
+
+        assert!(args.contains(&"-qt-hide-window".to_owned()));
+        assert!(!args.contains(&"-no-window".to_owned()));
+    }
+
+    #[test]
+    fn android_emulator_launch_args_lets_user_replace_default_grpc_port() {
+        let args = android_emulator_launch_args(
+            "Pixel_8_API_36",
+            8554,
+            &AndroidBootOptions {
+                emulator_args: vec!["-grpc".to_owned(), "9654".to_owned()],
+                ..Default::default()
+            },
+            "macos",
+        )
+        .unwrap();
+
+        assert_eq!(args.iter().filter(|arg| *arg == "-grpc").count(), 1);
+        assert!(args
+            .windows(2)
+            .any(|pair| pair[0] == "-grpc" && pair[1] == "9654"));
+    }
+
+    #[test]
+    fn android_grpc_ports_use_separate_avd_index_range() {
+        assert_eq!(grpc_port_for_console_port(5554).unwrap(), 8554);
+        assert_eq!(grpc_port_for_console_port(5556).unwrap(), 8555);
     }
 
     #[test]
@@ -2857,6 +2936,7 @@ abcd1234\tdevice
             None,
             AndroidH264StreamQuality {
                 max_edge: Some(16),
+                fps: None,
                 min_bitrate: None,
                 bits_per_pixel: None,
             },
@@ -2908,6 +2988,7 @@ abcd1234\tdevice
             None,
             AndroidH264StreamQuality {
                 max_edge: Some(240),
+                fps: None,
                 min_bitrate: None,
                 bits_per_pixel: None,
             },
@@ -2946,6 +3027,7 @@ abcd1234\tdevice
                 source,
                 AndroidH264StreamQuality {
                     max_edge: Some(240),
+                    fps: None,
                     min_bitrate: None,
                     bits_per_pixel: None,
                 },

--- a/packages/server/src/api/routes.rs
+++ b/packages/server/src/api/routes.rs
@@ -1025,7 +1025,7 @@ fn now_ms() -> u64 {
         .as_millis() as u64
 }
 
-fn normalize_video_codec(codec: &str) -> Option<&'static str> {
+pub(crate) fn normalize_video_codec(codec: &str) -> Option<&'static str> {
     match codec.trim().to_ascii_lowercase().as_str() {
         "auto" => Some("auto"),
         "hardware" => Some("hardware"),
@@ -1053,6 +1053,10 @@ async fn metrics(State(state): State<AppState>) -> Json<Value> {
         object.insert(
             "encoders".to_owned(),
             json_value!(state.registry.encoder_snapshots()),
+        );
+        object.insert(
+            "androidEncoders".to_owned(),
+            json_value!(crate::transport::webrtc::android_encoder_snapshots()),
         );
     }
     json(snapshot)

--- a/packages/server/src/main.rs
+++ b/packages/server/src/main.rs
@@ -19,6 +19,11 @@ mod static_files;
 mod transport;
 #[cfg(target_os = "macos")]
 mod webkit;
+
+pub(crate) mod android_emulation_control {
+    tonic::include_proto!("android.emulation.control");
+}
+
 #[cfg(not(target_os = "macos"))]
 mod webkit {
     use crate::error::AppError;

--- a/packages/server/src/native/ffi.rs
+++ b/packages/server/src/native/ffi.rs
@@ -334,12 +334,22 @@ unsafe extern "C" {
         error_message: *mut *mut c_char,
     ) -> bool;
 
-    pub fn xcw_native_h264_encoder_create(
+    pub fn xcw_native_h264_encoder_create_with_video_codec(
         callback: Option<xcw_native_frame_callback>,
         user_data: *mut c_void,
+        video_codec: *const c_char,
         error_message: *mut *mut c_char,
     ) -> *mut c_void;
     pub fn xcw_native_h264_encoder_destroy(handle: *mut c_void);
+    pub fn xcw_native_h264_encoder_encode_rgba(
+        handle: *mut c_void,
+        rgba: *const u8,
+        length: usize,
+        width: u32,
+        height: u32,
+        timestamp_us: u64,
+        error_message: *mut *mut c_char,
+    ) -> bool;
     pub fn xcw_native_h264_encoder_encode_bgra(
         handle: *mut c_void,
         bgra: *const u8,
@@ -350,6 +360,10 @@ unsafe extern "C" {
         error_message: *mut *mut c_char,
     ) -> bool;
     pub fn xcw_native_h264_encoder_request_keyframe(handle: *mut c_void);
+    pub fn xcw_native_h264_encoder_stats(
+        handle: *mut c_void,
+        error_message: *mut *mut c_char,
+    ) -> *mut c_char;
 
     pub fn xcw_native_free_string(value: *mut c_char);
     pub fn xcw_native_free_bytes(bytes: xcw_native_owned_bytes);

--- a/packages/server/src/transport/webrtc.rs
+++ b/packages/server/src/transport/webrtc.rs
@@ -1,4 +1,7 @@
 use crate::android;
+use crate::android_emulation_control::{
+    emulator_controller_client::EmulatorControllerClient, image_format, ImageFormat,
+};
 use crate::api::routes::{
     apply_stream_client_foreground_from_stats, apply_stream_quality_payload,
     bridge_input_session_for_control, run_bridge_multitouch_control_message, run_control_message,
@@ -11,14 +14,17 @@ use crate::native::ffi;
 use crate::transport::packet::{FramePacket, SharedFrame};
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
 use std::collections::{HashMap, VecDeque};
-use std::ffi::{c_void, CStr};
+use std::ffi::{c_void, CStr, CString};
+use std::net::{SocketAddr, TcpStream};
 use std::ptr;
 use std::slice;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, RwLock, Weak};
 use std::thread;
 use std::time::Duration;
+use tokio::runtime::Builder as TokioRuntimeBuilder;
 use tokio::sync::{broadcast, mpsc};
 use tokio::task;
 use tokio::time::{self, Instant};
@@ -65,9 +71,19 @@ const WEBRTC_RTP_OUTBOUND_MTU: usize = 1200;
 const WEBRTC_PEER_DISCONNECTED_TIMEOUT: Duration = Duration::from_secs(12);
 const ANDROID_WEBRTC_FRAME_BROADCAST_CAPACITY: usize = 1;
 const ANDROID_WEBRTC_DEFAULT_POLL_FPS: u64 = 120;
+const ANDROID_WEBRTC_DEFAULT_MAX_EDGE: u32 = 960;
+const ANDROID_WEBRTC_DEFAULT_FPS: u32 = 60;
+const ANDROID_WEBRTC_DEFAULT_MIN_BITRATE: u32 = 6_000_000;
+const ANDROID_WEBRTC_DEFAULT_BITS_PER_PIXEL: u32 = 5;
+const ANDROID_WEBRTC_DEFAULT_VIDEO_CODEC: &str = "software";
 const ANDROID_SHARED_VIDEO_RETRY_DELAY: Duration = Duration::from_millis(200);
+const ANDROID_GRPC_FALLBACK_RETRY_INTERVAL: Duration = Duration::from_secs(2);
+const ANDROID_GRPC_FALLBACK_PROBE_TIMEOUT: Duration = Duration::from_millis(100);
 static WEBRTC_MEDIA_STREAMS: OnceLock<Mutex<HashMap<String, Vec<WebRtcMediaStreamToken>>>> =
     OnceLock::new();
+static ANDROID_WEBRTC_SOURCES: OnceLock<Mutex<Vec<Weak<AndroidWebRtcSourceInner>>>> =
+    OnceLock::new();
+static NEXT_ANDROID_WEBRTC_SOURCE_ID: AtomicU64 = AtomicU64::new(1);
 const MAX_WEBRTC_MEDIA_STREAMS_PER_UDID: usize = 16;
 
 #[derive(Clone)]
@@ -104,27 +120,69 @@ pub struct WebRtcVideoMetadata {
     pub height: u32,
 }
 
-fn android_h264_quality_from_payload(
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct AndroidH264StreamConfig {
+    quality: android::AndroidH264StreamQuality,
+    video_codec: String,
+}
+
+fn android_h264_config_from_payload(
     payload: Option<&StreamQualityPayload>,
-) -> Result<android::AndroidH264StreamQuality, AppError> {
+) -> Result<AndroidH264StreamConfig, AppError> {
+    let video_codec = android_video_codec_from_payload(payload)?;
     let Some(payload) = payload else {
-        return Ok(android::AndroidH264StreamQuality::default());
+        return Ok(AndroidH264StreamConfig {
+            quality: default_android_h264_quality(),
+            video_codec,
+        });
     };
     let limits = stream_quality_limits_for_payload(payload)?;
-    let unscaled_profile = payload
+    let profile = payload
         .profile
         .as_deref()
         .map(str::trim)
-        .is_some_and(|profile| matches!(profile, "full" | "quality" | "smooth"));
-    Ok(android::AndroidH264StreamQuality {
-        max_edge: if unscaled_profile {
-            None
-        } else {
-            Some(limits.max_edge)
+        .filter(|profile| !profile.is_empty());
+    let max_edge = match profile {
+        Some("full" | "quality") => None,
+        Some("balanced" | "smooth") => Some(ANDROID_WEBRTC_DEFAULT_MAX_EDGE),
+        _ => Some(limits.max_edge),
+    };
+    Ok(AndroidH264StreamConfig {
+        quality: android::AndroidH264StreamQuality {
+            max_edge,
+            fps: Some(limits.fps),
+            min_bitrate: Some(limits.min_bitrate),
+            bits_per_pixel: Some(limits.bits_per_pixel),
         },
-        min_bitrate: Some(limits.min_bitrate),
-        bits_per_pixel: Some(limits.bits_per_pixel),
+        video_codec,
     })
+}
+
+fn android_video_codec_from_payload(
+    payload: Option<&StreamQualityPayload>,
+) -> Result<String, AppError> {
+    if let Some(video_codec) = payload
+        .and_then(|payload| payload.video_codec.as_deref())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        return crate::api::routes::normalize_video_codec(video_codec)
+            .map(ToOwned::to_owned)
+            .ok_or_else(|| AppError::bad_request(format!("Unknown video codec `{video_codec}`.")));
+    }
+    Ok(std::env::var("SIMDECK_ANDROID_VIDEO_CODEC")
+        .ok()
+        .and_then(|value| crate::api::routes::normalize_video_codec(&value).map(ToOwned::to_owned))
+        .unwrap_or_else(|| ANDROID_WEBRTC_DEFAULT_VIDEO_CODEC.to_owned()))
+}
+
+fn default_android_h264_quality() -> android::AndroidH264StreamQuality {
+    android::AndroidH264StreamQuality {
+        max_edge: Some(ANDROID_WEBRTC_DEFAULT_MAX_EDGE),
+        fps: Some(ANDROID_WEBRTC_DEFAULT_FPS),
+        min_bitrate: Some(ANDROID_WEBRTC_DEFAULT_MIN_BITRATE),
+        bits_per_pixel: Some(ANDROID_WEBRTC_DEFAULT_BITS_PER_PIXEL),
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -161,12 +219,13 @@ pub async fn create_answer(
     }
 
     let source = if is_android {
+        let stream_config = android_h264_config_from_payload(payload.stream_config.as_ref())?;
         WebRtcVideoSource::Android(
             AndroidWebRtcSource::start(
                 state.android.clone(),
                 state.metrics.clone(),
                 udid.clone(),
-                android_h264_quality_from_payload(payload.stream_config.as_ref())?,
+                stream_config,
             )
             .await?,
         )
@@ -334,7 +393,7 @@ pub async fn create_answer(
     let first_frame_height = first_frame.height;
     let client_id = payload.client_id.clone();
     let (cancellation_token, cancellation) =
-        register_webrtc_media_stream(&udid, payload.client_id.as_deref(), true);
+        register_webrtc_media_stream(&udid, payload.client_id.as_deref(), true, false);
     tokio::spawn(
         WebRtcMediaStream {
             state,
@@ -678,8 +737,8 @@ fn attach_android_data_channel(
                         let _ = stream_control_tx.send(command);
                     }
                     WebRtcDataChannelMessage::StreamQuality { config } => {
-                        match android_h264_quality_from_payload(Some(&config)) {
-                            Ok(quality) => source.reconfigure_h264(quality),
+                        match android_h264_config_from_payload(Some(&config)) {
+                            Ok(config) => source.reconfigure_h264(config.quality),
                             Err(error) => {
                                 warn!(
                                     "Android WebRTC stream quality update failed for {udid}: {error}"
@@ -1139,6 +1198,7 @@ fn register_webrtc_media_stream(
     udid: &str,
     client_id: Option<&str>,
     evict_anonymous: bool,
+    replace_existing_for_udid: bool,
 ) -> (broadcast::Sender<()>, broadcast::Receiver<()>) {
     let (tx, rx) = broadcast::channel(1);
     let streams = WEBRTC_MEDIA_STREAMS.get_or_init(|| Mutex::new(HashMap::new()));
@@ -1148,7 +1208,11 @@ fn register_webrtc_media_stream(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToOwned::to_owned);
-    if let Some(client_id) = &client_id {
+    if replace_existing_for_udid {
+        for stream in active_streams.drain(..) {
+            let _ = stream.cancellation.send(());
+        }
+    } else if let Some(client_id) = &client_id {
         active_streams.retain(|stream| {
             let is_same_client = stream.client_id.as_ref() == Some(client_id);
             let is_anonymous = evict_anonymous && stream.client_id.is_none();
@@ -1186,7 +1250,7 @@ fn active_webrtc_media_stream_count(udid: &str) -> usize {
 fn register_webrtc_media_stream_for_test(
     udid: &str,
 ) -> (broadcast::Sender<()>, broadcast::Receiver<()>) {
-    register_webrtc_media_stream(udid, None, false)
+    register_webrtc_media_stream(udid, None, false, false)
 }
 
 #[cfg(test)]
@@ -1194,7 +1258,7 @@ fn register_webrtc_media_stream_for_client_test(
     udid: &str,
     client_id: &str,
 ) -> (broadcast::Sender<()>, broadcast::Receiver<()>) {
-    register_webrtc_media_stream(udid, Some(client_id), false)
+    register_webrtc_media_stream(udid, Some(client_id), false, false)
 }
 
 #[cfg(test)]
@@ -1202,7 +1266,15 @@ fn register_webrtc_media_stream_evicting_anonymous_for_test(
     udid: &str,
     client_id: &str,
 ) -> (broadcast::Sender<()>, broadcast::Receiver<()>) {
-    register_webrtc_media_stream(udid, Some(client_id), true)
+    register_webrtc_media_stream(udid, Some(client_id), true, false)
+}
+
+#[cfg(test)]
+fn register_webrtc_media_stream_replacing_udid_for_test(
+    udid: &str,
+    client_id: Option<&str>,
+) -> (broadcast::Sender<()>, broadcast::Receiver<()>) {
+    register_webrtc_media_stream(udid, client_id, true, true)
 }
 
 #[cfg(test)]
@@ -1303,15 +1375,42 @@ pub(crate) struct AndroidWebRtcSource {
 }
 
 struct AndroidWebRtcSourceInner {
+    source_id: u64,
     udid: String,
+    video_codec: String,
     shutdown_tx: broadcast::Sender<()>,
     sender: broadcast::Sender<SharedFrame>,
     latest_keyframe: RwLock<Option<SharedFrame>>,
     frame_sequence: AtomicU64,
     quality: Mutex<android::AndroidH264StreamQuality>,
+    source_kind: RwLock<&'static str>,
     encoder_handle: AtomicUsize,
     callback_user_data: AtomicUsize,
+    shared_frames_read: AtomicU64,
+    encode_submissions: AtomicU64,
+    encode_failures: AtomicU64,
+    latest_shared_frame_copy_us: AtomicU64,
+    latest_encode_submit_us: AtomicU64,
+    latest_source_frame_gap_us: AtomicU64,
+    latest_source_timestamp_us: AtomicU64,
+    source_sequence: AtomicU64,
+    source_fps: AtomicU64,
+    source_width: AtomicU64,
+    source_height: AtomicU64,
+    output_width: AtomicU64,
+    output_height: AtomicU64,
     metrics: Arc<crate::metrics::counters::Metrics>,
+}
+
+struct AndroidSourceFrameRecord {
+    sequence: u64,
+    timestamp_us: u64,
+    source_fps: u64,
+    source_width: u64,
+    source_height: u64,
+    output_width: u64,
+    output_height: u64,
+    copy_duration: Duration,
 }
 
 unsafe impl Send for AndroidWebRtcSourceInner {}
@@ -1322,24 +1421,48 @@ impl AndroidWebRtcSource {
         bridge: android::AndroidBridge,
         metrics: Arc<crate::metrics::counters::Metrics>,
         udid: String,
-        quality: android::AndroidH264StreamQuality,
+        config: AndroidH264StreamConfig,
     ) -> Result<Self, AppError> {
+        let sources = ANDROID_WEBRTC_SOURCES.get_or_init(|| Mutex::new(Vec::new()));
+        let mut sources = sources.lock().unwrap();
+        if let Some(inner) = reusable_android_webrtc_source(&mut sources, &udid, &config) {
+            return Ok(Self { inner });
+        }
+
         let (sender, _) = broadcast::channel(ANDROID_WEBRTC_FRAME_BROADCAST_CAPACITY);
         let (shutdown_tx, _) = broadcast::channel(1);
         let inner = Arc::new(AndroidWebRtcSourceInner {
+            source_id: NEXT_ANDROID_WEBRTC_SOURCE_ID.fetch_add(1, Ordering::Relaxed),
             udid: udid.clone(),
+            video_codec: config.video_codec,
             shutdown_tx,
             sender,
             latest_keyframe: RwLock::new(None),
             frame_sequence: AtomicU64::new(0),
-            quality: Mutex::new(quality),
+            quality: Mutex::new(config.quality),
+            source_kind: RwLock::new("shared-video"),
             encoder_handle: AtomicUsize::new(0),
             callback_user_data: AtomicUsize::new(0),
+            shared_frames_read: AtomicU64::new(0),
+            encode_submissions: AtomicU64::new(0),
+            encode_failures: AtomicU64::new(0),
+            latest_shared_frame_copy_us: AtomicU64::new(0),
+            latest_encode_submit_us: AtomicU64::new(0),
+            latest_source_frame_gap_us: AtomicU64::new(0),
+            latest_source_timestamp_us: AtomicU64::new(0),
+            source_sequence: AtomicU64::new(0),
+            source_fps: AtomicU64::new(0),
+            source_width: AtomicU64::new(0),
+            source_height: AtomicU64::new(0),
+            output_width: AtomicU64::new(0),
+            output_height: AtomicU64::new(0),
             metrics,
         });
 
         let source = Self { inner };
         source.inner.create_native_encoder()?;
+        sources.push(Arc::downgrade(&source.inner));
+        drop(sources);
         spawn_android_shared_video_encoder(bridge, &source.inner);
         Ok(source)
     }
@@ -1393,6 +1516,52 @@ impl AndroidWebRtcSource {
     }
 }
 
+fn reusable_android_webrtc_source(
+    sources: &mut Vec<Weak<AndroidWebRtcSourceInner>>,
+    udid: &str,
+    config: &AndroidH264StreamConfig,
+) -> Option<Arc<AndroidWebRtcSourceInner>> {
+    let mut reusable = None;
+    sources.retain(|source| {
+        let Some(existing) = source.upgrade() else {
+            return false;
+        };
+
+        if existing.udid != udid {
+            return true;
+        }
+
+        if reusable.is_none() && existing.video_codec == config.video_codec {
+            existing.reconfigure_h264(config.quality);
+            reusable = Some(existing);
+            return true;
+        }
+
+        if existing.source_id != reusable.as_ref().map_or(0, |source| source.source_id) {
+            let _ = existing.shutdown_tx.send(());
+        }
+        false
+    });
+    reusable
+}
+
+pub(crate) fn android_encoder_snapshots() -> Vec<Value> {
+    let mut sources = ANDROID_WEBRTC_SOURCES
+        .get_or_init(|| Mutex::new(Vec::new()))
+        .lock()
+        .unwrap();
+    let mut snapshots = Vec::new();
+    sources.retain(|source| {
+        if let Some(inner) = source.upgrade() {
+            snapshots.push(inner.stats_snapshot());
+            true
+        } else {
+            false
+        }
+    });
+    snapshots
+}
+
 fn spawn_android_shared_video_encoder(
     bridge: android::AndroidBridge,
     inner: &Arc<AndroidWebRtcSourceInner>,
@@ -1403,6 +1572,28 @@ fn spawn_android_shared_video_encoder(
     thread::spawn(move || loop {
         if android_shutdown_requested(&mut shutdown_rx) || weak_inner.upgrade().is_none() {
             break;
+        }
+        if let Some(grpc_port) = android_grpc_port_for_udid(&bridge, &udid) {
+            match TokioRuntimeBuilder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|error| {
+                    AppError::native(format!("Unable to start Android gRPC runtime: {error}"))
+                })
+                .and_then(|runtime| {
+                    runtime.block_on(run_android_grpc_screenshot_encoder(
+                        grpc_port,
+                        weak_inner.clone(),
+                        &mut shutdown_rx,
+                    ))
+                }) {
+                Ok(()) => return,
+                Err(error) => {
+                    warn!(
+                        "Android gRPC screenshot stream failed for {udid} on port {grpc_port}: {error}; falling back to shared video"
+                    );
+                }
+            }
         }
         let mut stream = match bridge.shared_video_frame_stream(&udid) {
             Ok(stream) => stream,
@@ -1415,6 +1606,10 @@ fn spawn_android_shared_video_encoder(
         info!("Android shared-video stream attached for {udid}");
         let poll_interval = android_webrtc_poll_interval();
         let mut next_poll_at = Instant::now();
+        let mut next_frame_at = Instant::now();
+        let mut next_grpc_probe_at = Instant::now()
+            .checked_add(ANDROID_GRPC_FALLBACK_RETRY_INTERVAL)
+            .unwrap_or_else(Instant::now);
         loop {
             if android_shutdown_requested(&mut shutdown_rx) {
                 return;
@@ -1422,9 +1617,33 @@ fn spawn_android_shared_video_encoder(
             let Some(inner) = weak_inner.upgrade() else {
                 return;
             };
+            let now = Instant::now();
+            if now >= next_grpc_probe_at {
+                next_grpc_probe_at = now
+                    .checked_add(ANDROID_GRPC_FALLBACK_RETRY_INTERVAL)
+                    .unwrap_or(now);
+                if let Some(grpc_port) = android_grpc_port_for_udid(&bridge, &udid) {
+                    if android_grpc_endpoint_accepts_connections(grpc_port) {
+                        info!(
+                            "Android gRPC endpoint became available for {udid} on port {grpc_port}; leaving shared-video fallback"
+                        );
+                        break;
+                    }
+                }
+            }
             let quality = inner.h264_quality();
+            let source_read_interval = android_source_read_interval(quality);
+            if let Some(interval) = source_read_interval {
+                if Instant::now() < next_frame_at {
+                    sleep_until_next_android_poll(&mut next_poll_at, poll_interval);
+                    continue;
+                }
+                schedule_next_android_frame(&mut next_frame_at, interval);
+            }
+            let read_started = Instant::now();
             match stream.next_frame(quality) {
                 Ok(Some(frame)) => {
+                    inner.record_shared_video_frame(&frame, read_started.elapsed());
                     if let Err(error) = inner.encode_android_shared_video_frame(&frame) {
                         warn!("Android shared-video encode failed for {udid}: {error}");
                         thread::sleep(ANDROID_SHARED_VIDEO_RETRY_DELAY);
@@ -1439,6 +1658,176 @@ fn spawn_android_shared_video_encoder(
             sleep_until_next_android_poll(&mut next_poll_at, poll_interval);
         }
     });
+}
+
+fn android_grpc_port_for_udid(bridge: &android::AndroidBridge, udid: &str) -> Option<u16> {
+    let avd_name = udid.strip_prefix("android:")?;
+    bridge.grpc_port_for_avd(avd_name).ok()
+}
+
+fn android_grpc_endpoint_accepts_connections(grpc_port: u16) -> bool {
+    let address = SocketAddr::from(([127, 0, 0, 1], grpc_port));
+    TcpStream::connect_timeout(&address, ANDROID_GRPC_FALLBACK_PROBE_TIMEOUT).is_ok()
+}
+
+async fn run_android_grpc_screenshot_encoder(
+    grpc_port: u16,
+    weak_inner: Weak<AndroidWebRtcSourceInner>,
+    shutdown_rx: &mut broadcast::Receiver<()>,
+) -> Result<(), AppError> {
+    let Some(inner) = weak_inner.upgrade() else {
+        return Ok(());
+    };
+    inner.set_source_kind("grpc-screenshot");
+    let quality = inner.h264_quality();
+    let requested_edge = quality.max_edge;
+    let request = ImageFormat {
+        format: image_format::ImgFormat::Rgba8888 as i32,
+        width: requested_edge.unwrap_or(0),
+        height: requested_edge.unwrap_or(0),
+        ..Default::default()
+    };
+    let endpoint = format!("http://127.0.0.1:{grpc_port}");
+    let mut client = time::timeout(
+        Duration::from_secs(2),
+        EmulatorControllerClient::connect(endpoint),
+    )
+    .await
+    .map_err(|_| AppError::native("Android emulator gRPC connect timed out."))?
+    .map_err(|error| AppError::native(format!("Android emulator gRPC connect failed: {error}")))?;
+    let mut stream = client
+        .stream_screenshot(request)
+        .await
+        .map_err(|error| AppError::native(format!("Android emulator gRPC stream failed: {error}")))?
+        .into_inner();
+
+    loop {
+        if android_shutdown_requested(shutdown_rx) || weak_inner.strong_count() == 0 {
+            return Ok(());
+        }
+        let Some(image) = stream.message().await.map_err(|error| {
+            AppError::native(format!("Android emulator gRPC frame failed: {error}"))
+        })?
+        else {
+            return Err(AppError::native(
+                "Android emulator gRPC screenshot stream ended.",
+            ));
+        };
+        let Some(inner) = weak_inner.upgrade() else {
+            return Ok(());
+        };
+        if inner.h264_quality().max_edge != requested_edge {
+            return Err(AppError::native(
+                "Android stream quality changed; reconnecting gRPC screenshot stream.",
+            ));
+        }
+        let read_started = Instant::now();
+        let (width, height) = android_grpc_image_dimensions(&image)?;
+        if width == 0 || height == 0 || image.image.is_empty() {
+            continue;
+        }
+        let (rgba, output_width, output_height) =
+            android_grpc_top_down_even_rgba(&image.image, width, height)?;
+        inner.record_android_source_frame(AndroidSourceFrameRecord {
+            sequence: u64::from(image.seq),
+            timestamp_us: image.timestamp_us,
+            source_fps: u64::from(android_h264_target_fps(inner.h264_quality())),
+            source_width: u64::from(width),
+            source_height: u64::from(height),
+            output_width: u64::from(output_width),
+            output_height: u64::from(output_height),
+            copy_duration: read_started.elapsed(),
+        });
+        if let Err(error) =
+            inner.encode_android_rgba_frame(&rgba, output_width, output_height, image.timestamp_us)
+        {
+            warn!(
+                "Android gRPC screenshot encode failed for {}: {error}",
+                inner.udid
+            );
+            time::sleep(ANDROID_SHARED_VIDEO_RETRY_DELAY).await;
+        }
+    }
+}
+
+fn android_grpc_image_dimensions(
+    image: &crate::android_emulation_control::Image,
+) -> Result<(u32, u32), AppError> {
+    let (width, height) = image
+        .format
+        .as_ref()
+        .map(|format| (format.width, format.height))
+        .unwrap_or((image.width, image.height));
+    if width == 0 || height == 0 {
+        return Ok((0, 0));
+    }
+    let pixels = u64::from(width)
+        .checked_mul(u64::from(height))
+        .and_then(|pixels| pixels.checked_mul(4))
+        .ok_or_else(|| AppError::native("Android gRPC screenshot frame size overflowed."))?;
+    if pixels > 256 * 1024 * 1024 {
+        return Err(AppError::native(
+            "Android gRPC screenshot frame size was outside supported bounds.",
+        ));
+    }
+    Ok((width, height))
+}
+
+fn android_grpc_top_down_even_rgba(
+    source_rgba: &[u8],
+    width: u32,
+    height: u32,
+) -> Result<(Vec<u8>, u32, u32), AppError> {
+    let row_bytes = usize::try_from(width)
+        .ok()
+        .and_then(|width| width.checked_mul(4))
+        .ok_or_else(|| AppError::native("Android gRPC screenshot row size overflowed."))?;
+    let expected_len = row_bytes
+        .checked_mul(usize::try_from(height).unwrap_or(usize::MAX))
+        .ok_or_else(|| AppError::native("Android gRPC screenshot frame size overflowed."))?;
+    if source_rgba.len() != expected_len {
+        return Err(AppError::native(format!(
+            "Android gRPC screenshot frame size mismatch: got {}, expected {expected_len}.",
+            source_rgba.len()
+        )));
+    }
+    let output_width = if width.is_multiple_of(2) {
+        width
+    } else {
+        width + 1
+    };
+    let output_height = if height.is_multiple_of(2) {
+        height
+    } else {
+        height + 1
+    };
+    let output_row_bytes = usize::try_from(output_width)
+        .ok()
+        .and_then(|width| width.checked_mul(4))
+        .ok_or_else(|| AppError::native("Android gRPC screenshot output row size overflowed."))?;
+    let output_len = output_row_bytes
+        .checked_mul(usize::try_from(output_height).unwrap_or(usize::MAX))
+        .ok_or_else(|| AppError::native("Android gRPC screenshot output frame size overflowed."))?;
+    let mut top_down = vec![0u8; output_len];
+    let height = usize::try_from(height)
+        .map_err(|_| AppError::native("Android gRPC screenshot height overflowed."))?;
+    for y in 0..height {
+        let source = y * row_bytes;
+        let target = y * output_row_bytes;
+        top_down[target..target + row_bytes]
+            .copy_from_slice(&source_rgba[source..source + row_bytes]);
+        if output_width != width {
+            let last_pixel = target + row_bytes - 4;
+            let padded_pixel = target + row_bytes;
+            top_down.copy_within(last_pixel..last_pixel + 4, padded_pixel);
+        }
+    }
+    if output_height != u32::try_from(height).unwrap_or(u32::MAX) {
+        let last_row = (height - 1) * output_row_bytes;
+        let padded_row = height * output_row_bytes;
+        top_down.copy_within(last_row..last_row + output_row_bytes, padded_row);
+    }
+    Ok((top_down, output_width, output_height))
 }
 
 fn android_shutdown_requested(receiver: &mut broadcast::Receiver<()>) -> bool {
@@ -1470,11 +1859,14 @@ impl AndroidWebRtcSourceInner {
     fn create_native_encoder(self: &Arc<Self>) -> Result<(), AppError> {
         let weak = Arc::downgrade(self);
         let user_data = Weak::into_raw(weak) as *mut c_void;
+        let video_codec = CString::new(self.video_codec.as_str())
+            .map_err(|_| AppError::bad_request("Android video codec contains a NUL byte."))?;
         let mut error = ptr::null_mut();
         let handle = unsafe {
-            ffi::xcw_native_h264_encoder_create(
+            ffi::xcw_native_h264_encoder_create_with_video_codec(
                 Some(android_h264_encoder_frame_callback),
                 user_data,
+                video_codec.as_ptr(),
                 &mut error,
             )
         };
@@ -1495,6 +1887,52 @@ impl AndroidWebRtcSourceInner {
 
     fn h264_quality(&self) -> android::AndroidH264StreamQuality {
         *self.quality.lock().unwrap()
+    }
+
+    fn record_shared_video_frame(
+        &self,
+        frame: &android::AndroidSharedVideoFrame,
+        copy_duration: Duration,
+    ) {
+        self.set_source_kind("shared-video");
+        self.record_android_source_frame(AndroidSourceFrameRecord {
+            sequence: u64::from(frame.source_sequence),
+            timestamp_us: frame.timestamp_us,
+            source_fps: u64::from(frame.source_fps),
+            source_width: u64::from(frame.source_width),
+            source_height: u64::from(frame.source_height),
+            output_width: u64::from(frame.width),
+            output_height: u64::from(frame.height),
+            copy_duration,
+        });
+    }
+
+    fn set_source_kind(&self, source_kind: &'static str) {
+        *self.source_kind.write().unwrap() = source_kind;
+    }
+
+    fn record_android_source_frame(&self, record: AndroidSourceFrameRecord) {
+        self.shared_frames_read.fetch_add(1, Ordering::Relaxed);
+        self.latest_shared_frame_copy_us
+            .store(duration_us(record.copy_duration), Ordering::Relaxed);
+        let previous_timestamp = self
+            .latest_source_timestamp_us
+            .swap(record.timestamp_us, Ordering::Relaxed);
+        if previous_timestamp != 0 && record.timestamp_us > previous_timestamp {
+            self.latest_source_frame_gap_us
+                .store(record.timestamp_us - previous_timestamp, Ordering::Relaxed);
+        }
+        self.source_sequence
+            .store(record.sequence, Ordering::Relaxed);
+        self.source_fps.store(record.source_fps, Ordering::Relaxed);
+        self.source_width
+            .store(record.source_width, Ordering::Relaxed);
+        self.source_height
+            .store(record.source_height, Ordering::Relaxed);
+        self.output_width
+            .store(record.output_width, Ordering::Relaxed);
+        self.output_height
+            .store(record.output_height, Ordering::Relaxed);
     }
 
     fn reconfigure_h264(&self, quality: android::AndroidH264StreamQuality) {
@@ -1519,6 +1957,57 @@ impl AndroidWebRtcSourceInner {
         }
     }
 
+    fn stats_snapshot(&self) -> Value {
+        let quality = self.h264_quality();
+        json!({
+            "sourceId": self.source_id,
+            "udid": self.udid.as_str(),
+            "quality": {
+                "maxEdge": quality.max_edge,
+                "fps": quality.fps,
+                "minBitrate": quality.min_bitrate,
+                "bitsPerPixel": quality.bits_per_pixel,
+                "videoCodec": self.video_codec.as_str(),
+            },
+            "sharedVideo": {
+                "sourceKind": *self.source_kind.read().unwrap(),
+                "framesRead": self.shared_frames_read.load(Ordering::Relaxed),
+                "sourceSequence": self.source_sequence.load(Ordering::Relaxed),
+                "sourceFps": self.source_fps.load(Ordering::Relaxed),
+                "sourceWidth": self.source_width.load(Ordering::Relaxed),
+                "sourceHeight": self.source_height.load(Ordering::Relaxed),
+                "outputWidth": self.output_width.load(Ordering::Relaxed),
+                "outputHeight": self.output_height.load(Ordering::Relaxed),
+                "latestSourceTimestampUs": self.latest_source_timestamp_us.load(Ordering::Relaxed),
+                "latestSourceFrameGapMs": micros_to_millis_value(self.latest_source_frame_gap_us.load(Ordering::Relaxed)),
+                "latestFrameCopyMs": micros_to_millis_value(self.latest_shared_frame_copy_us.load(Ordering::Relaxed)),
+            },
+            "encoder": {
+                "submissions": self.encode_submissions.load(Ordering::Relaxed),
+                "failures": self.encode_failures.load(Ordering::Relaxed),
+                "latestSubmitMs": micros_to_millis_value(self.latest_encode_submit_us.load(Ordering::Relaxed)),
+                "native": self.native_encoder_stats(),
+            },
+        })
+    }
+
+    fn native_encoder_stats(&self) -> Value {
+        let handle = self.encoder_handle.load(Ordering::Acquire);
+        if handle == 0 {
+            return json!({});
+        }
+        unsafe {
+            let mut error = ptr::null_mut();
+            let raw = ffi::xcw_native_h264_encoder_stats(handle as *mut c_void, &mut error);
+            if !error.is_null() {
+                ffi::xcw_native_free_string(error);
+            }
+            take_native_string(raw)
+                .and_then(|json| serde_json::from_str(&json).ok())
+                .unwrap_or_else(|| json!({}))
+        }
+    }
+
     fn encode_android_shared_video_frame(
         &self,
         frame: &android::AndroidSharedVideoFrame,
@@ -1530,6 +2019,8 @@ impl AndroidWebRtcSourceInner {
             ));
         }
         let mut error = ptr::null_mut();
+        let submit_started = Instant::now();
+        self.encode_submissions.fetch_add(1, Ordering::Relaxed);
         let ok = unsafe {
             ffi::xcw_native_h264_encoder_encode_bgra(
                 handle as *mut c_void,
@@ -1541,7 +2032,46 @@ impl AndroidWebRtcSourceInner {
                 &mut error,
             )
         };
+        self.latest_encode_submit_us
+            .store(duration_us(submit_started.elapsed()), Ordering::Relaxed);
         if !ok {
+            self.encode_failures.fetch_add(1, Ordering::Relaxed);
+            return Err(unsafe { take_native_error(error, "Android native H.264 encode failed.") });
+        }
+        Ok(())
+    }
+
+    fn encode_android_rgba_frame(
+        &self,
+        rgba: &[u8],
+        width: u32,
+        height: u32,
+        timestamp_us: u64,
+    ) -> Result<(), AppError> {
+        let handle = self.encoder_handle.load(Ordering::Acquire);
+        if handle == 0 {
+            return Err(AppError::native(
+                "Android native H.264 encoder is not available.",
+            ));
+        }
+        let mut error = ptr::null_mut();
+        let submit_started = Instant::now();
+        self.encode_submissions.fetch_add(1, Ordering::Relaxed);
+        let ok = unsafe {
+            ffi::xcw_native_h264_encoder_encode_rgba(
+                handle as *mut c_void,
+                rgba.as_ptr(),
+                rgba.len(),
+                width,
+                height,
+                timestamp_us,
+                &mut error,
+            )
+        };
+        self.latest_encode_submit_us
+            .store(duration_us(submit_started.elapsed()), Ordering::Relaxed);
+        if !ok {
+            self.encode_failures.fetch_add(1, Ordering::Relaxed);
             return Err(unsafe { take_native_error(error, "Android native H.264 encode failed.") });
         }
         Ok(())
@@ -1610,6 +2140,15 @@ unsafe fn native_c_string(value: *const i8) -> Option<String> {
     CStr::from_ptr(value).to_str().ok().map(ToOwned::to_owned)
 }
 
+unsafe fn take_native_string(value: *mut i8) -> Option<String> {
+    if value.is_null() {
+        return None;
+    }
+    let string = CStr::from_ptr(value).to_str().ok().map(ToOwned::to_owned);
+    ffi::xcw_native_free_string(value);
+    string
+}
+
 unsafe fn take_native_error(error: *mut i8, fallback: &str) -> AppError {
     if error.is_null() {
         return AppError::native(fallback);
@@ -1622,6 +2161,14 @@ unsafe fn take_native_error(error: *mut i8, fallback: &str) -> AppError {
     AppError::native(message)
 }
 
+fn duration_us(duration: Duration) -> u64 {
+    duration.as_micros().min(u128::from(u64::MAX)) as u64
+}
+
+fn micros_to_millis_value(micros: u64) -> Option<f64> {
+    (micros > 0).then_some(micros as f64 / 1000.0)
+}
+
 fn android_webrtc_poll_interval() -> Duration {
     let fps = std::env::var("SIMDECK_ANDROID_SHARED_VIDEO_POLL_FPS")
         .ok()
@@ -1629,6 +2176,34 @@ fn android_webrtc_poll_interval() -> Duration {
         .unwrap_or(ANDROID_WEBRTC_DEFAULT_POLL_FPS)
         .clamp(60, u64::from(WEBRTC_MAX_LOCAL_STREAM_FPS));
     Duration::from_micros(1_000_000 / fps)
+}
+
+fn android_h264_target_fps(quality: android::AndroidH264StreamQuality) -> u32 {
+    quality
+        .fps
+        .unwrap_or(ANDROID_WEBRTC_DEFAULT_FPS)
+        .clamp(10, WEBRTC_MAX_LOCAL_STREAM_FPS)
+}
+
+fn android_source_read_interval(quality: android::AndroidH264StreamQuality) -> Option<Duration> {
+    let fps = android_h264_target_fps(quality);
+    if fps >= ANDROID_WEBRTC_DEFAULT_FPS {
+        return None;
+    }
+    Some(android_h264_frame_interval(quality))
+}
+
+fn android_h264_frame_interval(quality: android::AndroidH264StreamQuality) -> Duration {
+    let fps = android_h264_target_fps(quality);
+    Duration::from_micros(1_000_000 / u64::from(fps))
+}
+
+fn schedule_next_android_frame(next_frame_at: &mut Instant, interval: Duration) {
+    let target = next_frame_at
+        .checked_add(interval)
+        .unwrap_or_else(Instant::now);
+    let now = Instant::now();
+    *next_frame_at = if target > now { target } else { now };
 }
 
 fn sleep_until_next_android_poll(next_poll_at: &mut Instant, interval: Duration) {
@@ -1652,7 +2227,7 @@ enum WebRtcVideoSource {
 
 impl WebRtcVideoSource {
     fn uses_frame_timestamps_for_realtime(&self) -> bool {
-        matches!(self, Self::Android(_))
+        false
     }
 
     fn subscribe(&self) -> WebRtcFrameReceiver {
@@ -2347,18 +2922,17 @@ impl Drop for WebRtcMetricsGuard {
 #[cfg(test)]
 mod tests {
     use super::{
-        android_h264_quality_from_payload, append_avcc_parameter_sets,
-        append_length_prefixed_nalus, h264_annex_b_sample, h264_frame_has_idr,
-        h264_frame_is_decoder_sync, h264_sdp_fmtp_line, is_annex_b, is_h264_codec,
-        rtcp_packet_requests_keyframe, rtp_packet_pacing, WebRtcMetricsGuard, WebRtcSendTiming,
-        ANNEX_B_START_CODE,
+        android_h264_config_from_payload, append_avcc_parameter_sets, append_length_prefixed_nalus,
+        h264_annex_b_sample, h264_frame_has_idr, h264_frame_is_decoder_sync, h264_sdp_fmtp_line,
+        is_annex_b, is_h264_codec, rtcp_packet_requests_keyframe, rtp_packet_pacing,
+        WebRtcMetricsGuard, WebRtcSendTiming, ANNEX_B_START_CODE,
     };
     use crate::api::routes::StreamQualityPayload;
     use crate::metrics::counters::Metrics;
     use crate::transport::packet::FramePacket;
     use bytes::Bytes;
-    use std::sync::atomic::Ordering;
-    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex, RwLock};
     use std::time::Duration;
     use webrtc::rtcp::payload_feedbacks::full_intra_request::FullIntraRequest;
     use webrtc::rtcp::payload_feedbacks::picture_loss_indication::PictureLossIndication;
@@ -2411,7 +2985,7 @@ mod tests {
     #[test]
     fn android_full_size_quality_keeps_native_dimensions() {
         for (profile, min_bitrate, bits_per_pixel) in
-            [("full", 12_000_000, 4), ("smooth", 4_000_000, 5)]
+            [("full", 12_000_000, 4), ("quality", 60_000_000, 10)]
         {
             let payload = StreamQualityPayload {
                 profile: Some(profile.to_owned()),
@@ -2422,16 +2996,52 @@ mod tests {
                 bits_per_pixel: None,
             };
 
-            let quality = android_h264_quality_from_payload(Some(&payload)).unwrap();
+            let config = android_h264_config_from_payload(Some(&payload)).unwrap();
+            let quality = config.quality;
 
             assert_eq!(quality.max_edge, None);
+            assert_eq!(quality.fps, Some(60));
             assert_eq!(quality.min_bitrate, Some(min_bitrate));
             assert_eq!(quality.bits_per_pixel, Some(bits_per_pixel));
+            assert_eq!(config.video_codec, "software");
         }
     }
 
     #[test]
-    fn android_scaled_quality_applies_profile_edge() {
+    fn android_default_config_is_scaled_for_software_local_streaming() {
+        let config = android_h264_config_from_payload(None).unwrap();
+        let quality = config.quality;
+
+        assert_eq!(quality.max_edge, Some(960));
+        assert_eq!(quality.fps, Some(60));
+        assert_eq!(quality.min_bitrate, Some(6_000_000));
+        assert_eq!(quality.bits_per_pixel, Some(5));
+        assert_eq!(config.video_codec, "software");
+    }
+
+    #[test]
+    fn android_smooth_quality_scales_to_android_default_edge() {
+        let payload = StreamQualityPayload {
+            profile: Some("smooth".to_owned()),
+            video_codec: None,
+            max_edge: None,
+            fps: Some(60),
+            min_bitrate: None,
+            bits_per_pixel: None,
+        };
+
+        let config = android_h264_config_from_payload(Some(&payload)).unwrap();
+        let quality = config.quality;
+
+        assert_eq!(quality.max_edge, Some(960));
+        assert_eq!(quality.fps, Some(60));
+        assert_eq!(quality.min_bitrate, Some(4_000_000));
+        assert_eq!(quality.bits_per_pixel, Some(5));
+        assert_eq!(config.video_codec, "software");
+    }
+
+    #[test]
+    fn android_balanced_quality_scales_to_android_default_edge() {
         let payload = StreamQualityPayload {
             profile: Some("balanced".to_owned()),
             video_codec: None,
@@ -2441,9 +3051,152 @@ mod tests {
             bits_per_pixel: None,
         };
 
-        let quality = android_h264_quality_from_payload(Some(&payload)).unwrap();
+        let config = android_h264_config_from_payload(Some(&payload)).unwrap();
+        let quality = config.quality;
 
-        assert_eq!(quality.max_edge, Some(1280));
+        assert_eq!(quality.max_edge, Some(960));
+        assert_eq!(quality.fps, Some(60));
+    }
+
+    #[test]
+    fn android_stream_config_honors_requested_video_codec() {
+        let payload = StreamQualityPayload {
+            profile: Some("balanced".to_owned()),
+            video_codec: Some("hardware".to_owned()),
+            max_edge: None,
+            fps: Some(60),
+            min_bitrate: None,
+            bits_per_pixel: None,
+        };
+
+        let config = android_h264_config_from_payload(Some(&payload)).unwrap();
+
+        assert_eq!(config.video_codec, "hardware");
+        assert_eq!(config.quality.max_edge, Some(960));
+    }
+
+    #[test]
+    fn android_default_source_reads_are_not_pre_throttled() {
+        let quality = crate::android::AndroidH264StreamQuality {
+            fps: Some(60),
+            ..Default::default()
+        };
+
+        assert_eq!(super::android_source_read_interval(quality), None);
+    }
+
+    #[test]
+    fn android_low_fps_source_reads_are_pre_throttled() {
+        let quality = crate::android::AndroidH264StreamQuality {
+            fps: Some(30),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            super::android_source_read_interval(quality),
+            Some(Duration::from_micros(33_333))
+        );
+    }
+
+    #[test]
+    fn android_grpc_rgba_padding_preserves_top_down_rows() {
+        let pixels = [
+            [1, 0, 0, 255],
+            [2, 0, 0, 255],
+            [3, 0, 0, 255],
+            [4, 0, 0, 255],
+            [5, 0, 0, 255],
+            [6, 0, 0, 255],
+        ]
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+
+        let (rgba, width, height) = super::android_grpc_top_down_even_rgba(&pixels, 3, 2).unwrap();
+
+        assert_eq!((width, height), (4, 2));
+        let red_values = rgba
+            .chunks_exact(4)
+            .map(|pixel| pixel[0])
+            .collect::<Vec<_>>();
+        assert_eq!(red_values, vec![1, 2, 3, 3, 4, 5, 6, 6]);
+    }
+
+    fn android_source_inner_for_test(
+        udid: &str,
+        source_id: u64,
+        video_codec: &str,
+    ) -> Arc<super::AndroidWebRtcSourceInner> {
+        let (shutdown_tx, _) = tokio::sync::broadcast::channel(1);
+        let (sender, _) =
+            tokio::sync::broadcast::channel(super::ANDROID_WEBRTC_FRAME_BROADCAST_CAPACITY);
+        Arc::new(super::AndroidWebRtcSourceInner {
+            source_id,
+            udid: udid.to_owned(),
+            video_codec: video_codec.to_owned(),
+            shutdown_tx,
+            sender,
+            latest_keyframe: RwLock::new(None),
+            frame_sequence: AtomicU64::new(0),
+            quality: Mutex::new(crate::android::AndroidH264StreamQuality::default()),
+            source_kind: RwLock::new("shared-video"),
+            encoder_handle: AtomicUsize::new(0),
+            callback_user_data: AtomicUsize::new(0),
+            shared_frames_read: AtomicU64::new(0),
+            encode_submissions: AtomicU64::new(0),
+            encode_failures: AtomicU64::new(0),
+            latest_shared_frame_copy_us: AtomicU64::new(0),
+            latest_encode_submit_us: AtomicU64::new(0),
+            latest_source_frame_gap_us: AtomicU64::new(0),
+            latest_source_timestamp_us: AtomicU64::new(0),
+            source_sequence: AtomicU64::new(0),
+            source_fps: AtomicU64::new(0),
+            source_width: AtomicU64::new(0),
+            source_height: AtomicU64::new(0),
+            output_width: AtomicU64::new(0),
+            output_height: AtomicU64::new(0),
+            metrics: Arc::new(Metrics::default()),
+        })
+    }
+
+    #[test]
+    fn android_source_registry_reuses_same_udid_and_codec() {
+        let udid = format!("test-android-source-{}", std::process::id());
+        let config = super::AndroidH264StreamConfig {
+            quality: crate::android::AndroidH264StreamQuality {
+                fps: Some(30),
+                ..Default::default()
+            },
+            video_codec: "software".to_owned(),
+        };
+        let first = android_source_inner_for_test(&udid, 1, "software");
+        let mut first_shutdown = first.shutdown_tx.subscribe();
+        let mut sources = vec![Arc::downgrade(&first)];
+
+        let reused = super::reusable_android_webrtc_source(&mut sources, &udid, &config).unwrap();
+
+        assert!(Arc::ptr_eq(&first, &reused));
+        assert!(first_shutdown.try_recv().is_err());
+        assert_eq!(sources.len(), 1);
+        assert_eq!(first.h264_quality().fps, Some(30));
+    }
+
+    #[test]
+    fn android_source_registry_replaces_same_udid_when_codec_changes() {
+        let udid = format!("test-android-source-codec-{}", std::process::id());
+        let config = super::AndroidH264StreamConfig {
+            quality: crate::android::AndroidH264StreamQuality::default(),
+            video_codec: "hardware".to_owned(),
+        };
+        let first = android_source_inner_for_test(&udid, 1, "software");
+        let mut first_shutdown = first.shutdown_tx.subscribe();
+        let mut sources = vec![Arc::downgrade(&first)];
+
+        let reused = super::reusable_android_webrtc_source(&mut sources, &udid, &config);
+
+        assert!(reused.is_none());
+        assert!(first_shutdown.try_recv().is_ok());
+        assert!(sources.is_empty());
     }
 
     #[test]
@@ -2535,6 +3288,26 @@ mod tests {
         assert_eq!(super::active_webrtc_media_stream_count(&udid), 1);
 
         super::clear_webrtc_media_stream_for_test(&udid, &identified_token);
+        assert!(!super::has_media_stream(&udid));
+    }
+
+    #[test]
+    fn registering_replacement_stream_cancels_all_existing_udid_streams() {
+        let udid = format!("test-replace-{}", std::process::id());
+        super::reset_webrtc_media_streams_for_test(&udid);
+        let (_anonymous_token, mut anonymous_rx) =
+            super::register_webrtc_media_stream_for_test(&udid);
+        let (_first_client_token, mut first_client_rx) =
+            super::register_webrtc_media_stream_for_client_test(&udid, "page-1");
+        let (replacement_token, mut replacement_rx) =
+            super::register_webrtc_media_stream_replacing_udid_for_test(&udid, Some("page-2"));
+
+        assert!(anonymous_rx.try_recv().is_ok());
+        assert!(first_client_rx.try_recv().is_ok());
+        assert!(replacement_rx.try_recv().is_err());
+        assert_eq!(super::active_webrtc_media_stream_count(&udid), 1);
+
+        super::clear_webrtc_media_stream_for_test(&udid, &replacement_token);
         assert!(!super::has_media_stream(&udid));
     }
 
@@ -2706,7 +3479,7 @@ mod tests {
     }
 
     #[test]
-    fn realtime_android_send_timing_can_use_frame_timestamps() {
+    fn realtime_android_send_timing_ignores_source_timestamp_jitter() {
         let mut timing = WebRtcSendTiming::new();
         let first = FramePacket {
             frame_sequence: 1,
@@ -2720,7 +3493,7 @@ mod tests {
         };
         let second = FramePacket {
             frame_sequence: 2,
-            timestamp_us: 18_333,
+            timestamp_us: 118_333,
             is_keyframe: false,
             width: 100,
             height: 100,
@@ -2730,12 +3503,12 @@ mod tests {
         };
 
         assert_eq!(
-            timing.duration_for(&first, true, true),
+            timing.duration_for(&first, true, false),
             super::realtime_sample_duration()
         );
         assert_eq!(
-            timing.duration_for(&second, true, true),
-            Duration::from_micros(8_333)
+            timing.duration_for(&second, true, false),
+            super::realtime_sample_duration()
         );
     }
 

--- a/skills/simdeck/SKILL.md
+++ b/skills/simdeck/SKILL.md
@@ -99,9 +99,14 @@ Build apps with project tooling.
 
 Android devices use IDs like `android:Pixel_8_API_36`. `simdeck list` discovers
 AVDs from the Android SDK.
-SimDeck-owned Android boots use the emulator shared-video surface plus
-`--android-gpu host` by default. Use `simdeck service restart --android-gpu auto`
-or `--android-gpu swiftshader_indirect` only when host GPU rendering is unstable.
+SimDeck-owned Android boots use emulator gRPC screenshot streaming for live
+video, keep the emulator shared-video surface as fallback, and use
+`--android-gpu host` by default. Android browser streams default to software
+H.264 at 60 fps with a 960px long-edge cap so emulator gRPC frame production
+stays smooth. On macOS, managed boots use `-qt-hide-window` so the Qt render
+loop stays active without showing the native emulator window.
+Use `simdeck service restart --android-gpu auto` or
+`--android-gpu swiftshader_indirect` only when host GPU rendering is unstable.
 Optional user defaults live in `~/.simdeck/config.json`. Supported keys include
 `service.port`, `android.emulatorArgs`, and `android.disableAudio`; explicit
 CLI/API boot arguments still win for one-off runs.


### PR DESCRIPTION
## Summary

- Stream Android emulator video through the emulator gRPC screenshot API when available, with shared-video retained as a fallback.
- Share one Android encoder source per UDID across browser clients so Safari and the in-app browser do not fight/reconnect each other.
- Default Android browser streams to software H.264 at 60 fps with a 960px long-edge cap, add source/encoder metrics, and document the behavior.
- Keep managed Android boots hidden with `-qt-hide-window`, host GPU, deterministic gRPC ports, and vendored proto generation.

## Validation

- `cargo test --manifest-path packages/server/Cargo.toml`
- `npm run --prefix packages/client typecheck`
- `npm run --prefix packages/client test`
- `npm run build`
- `npm run format:check`
- `git diff --check`

## Runtime Check

- Restarted the 4310 LaunchAgent, booted `android:Pixel_9_Pro_API_36`, and verified `/api/metrics` reports `sourceKind: grpc-screenshot`, `androidEncoders.length === 1`, stable `sourceId`, software encoder, and nominal overload.
