### PR TITLE
fix(ios): orientation handling so landscape devices work

### DIFF
--- a/packages/client/src/features/accessibility/AccessibilityOverlay.test.ts
+++ b/packages/client/src/features/accessibility/AccessibilityOverlay.test.ts
@@ -129,4 +129,45 @@ describe("AccessibilityOverlay", () => {
     expect(markup).toContain("accessibility-rect skeleton");
     expect(markup).not.toContain("<span>Continue</span>");
   });
+
+  it("converts display-space frames into natural space for a rotated landscape display", () => {
+    // Landscape display (1210x834). The child is the right half of the display
+    // in display space; after the shell's 270deg rotation it must land in the
+    // bottom half of the natural (portrait) presentation box.
+    const roots = [
+      {
+        frame: { height: 834, width: 1210, x: 0, y: 0 },
+        role: "application",
+        children: [
+          {
+            AXLabel: "RightHalf",
+            frame: { height: 834, width: 605, x: 605, y: 0 },
+            type: "Button",
+          },
+        ],
+      },
+    ];
+
+    const rotated = renderToStaticMarkup(
+      createElement(AccessibilityOverlay, {
+        hoveredId: null,
+        roots,
+        rotationQuarterTurns: 3,
+        selectedId: "",
+      }),
+    );
+    // display right-half -> natural bottom-half.
+    expect(rotated).toContain("height:50%;left:0%;top:50%;width:100%");
+
+    const unrotated = renderToStaticMarkup(
+      createElement(AccessibilityOverlay, {
+        hoveredId: null,
+        roots,
+        rotationQuarterTurns: 0,
+        selectedId: "",
+      }),
+    );
+    // With no rotation the frame keeps its display-space placement (right half).
+    expect(unrotated).toContain("height:100%;left:50%;top:0%;width:50%");
+  });
 });

--- a/packages/client/src/features/accessibility/AccessibilityOverlay.test.ts
+++ b/packages/client/src/features/accessibility/AccessibilityOverlay.test.ts
@@ -6,6 +6,7 @@ import {
   AccessibilityOverlay,
   accessibilityDomTagName,
 } from "./AccessibilityOverlay";
+import type { AccessibilityNode } from "../../api/types";
 
 describe("accessibilityDomTagName", () => {
   it("uses source and component names for annotator-friendly custom tags", () => {
@@ -102,6 +103,33 @@ describe("AccessibilityOverlay", () => {
     expect(markup).not.toContain(">disabled<");
     expect(markup).not.toContain("; disabled");
     expect(markup).not.toContain(" title=");
+  });
+
+  it("tolerates non-string accessibility metadata", () => {
+    const markup = renderToStaticMarkup(
+      createElement(AccessibilityOverlay, {
+        hoveredId: null,
+        roots: [
+          {
+            frame: { height: 844, width: 390, x: 0, y: 0 },
+            role: "application",
+            children: [
+              {
+                AXValue: 42,
+                frame: { height: 48, width: 180, x: 105, y: 720 },
+                placeholder: { text: "Email" },
+                sourceFile: null,
+                type: "TextField",
+              } as unknown as AccessibilityNode,
+            ],
+          },
+        ],
+        selectedId: "",
+      }),
+    );
+
+    expect(markup).toContain('data-simdeck-accessibility-value="42"');
+    expect(markup).toContain('data-simdeck-accessibility-label="42"');
   });
 
   it("draws label-free skeleton frames when requested", () => {

--- a/packages/client/src/features/accessibility/AccessibilityOverlay.tsx
+++ b/packages/client/src/features/accessibility/AccessibilityOverlay.tsx
@@ -1,6 +1,7 @@
 import { createElement, type AriaRole, type CSSProperties } from "react";
 
 import type { AccessibilityNode } from "../../api/types";
+import { mapDisplayedPointToNaturalOrientation } from "../viewport/viewportMath";
 import {
   accessibilityKind,
   accessibilityIdentifier,
@@ -16,6 +17,7 @@ import {
 interface AccessibilityOverlayProps {
   hoveredId: string | null;
   roots: AccessibilityNode[];
+  rotationQuarterTurns?: number;
   selectedId: string;
   skeletonVisible?: boolean;
 }
@@ -23,6 +25,7 @@ interface AccessibilityOverlayProps {
 export function AccessibilityOverlay({
   hoveredId,
   roots,
+  rotationQuarterTurns = 0,
   selectedId,
   skeletonVisible = false,
 }: AccessibilityOverlayProps) {
@@ -61,6 +64,7 @@ export function AccessibilityOverlay({
             key={item.id}
             node={item.node}
             rootFrame={rootFrame}
+            rotationQuarterTurns={rotationQuarterTurns}
           />
         ))}
       </div>
@@ -71,15 +75,26 @@ export function AccessibilityOverlay({
                 key={`skeleton-${item.id}`}
                 node={item.node}
                 rootFrame={rootFrame}
+                rotationQuarterTurns={rotationQuarterTurns}
                 variant="skeleton"
               />
             ))
           : null}
         {hovered ? (
-          <NodeRect node={hovered} rootFrame={rootFrame} variant="hovered" />
+          <NodeRect
+            node={hovered}
+            rootFrame={rootFrame}
+            rotationQuarterTurns={rotationQuarterTurns}
+            variant="hovered"
+          />
         ) : null}
         {selected ? (
-          <NodeRect node={selected} rootFrame={rootFrame} variant="selected" />
+          <NodeRect
+            node={selected}
+            rootFrame={rootFrame}
+            rotationQuarterTurns={rotationQuarterTurns}
+            variant="selected"
+          />
         ) : null}
       </div>
     </div>
@@ -107,20 +122,18 @@ function framedNode(
 function NodeRect({
   node,
   rootFrame,
+  rotationQuarterTurns,
   variant,
 }: {
   node: AccessibilityNode;
   rootFrame: { height: number; width: number; x: number; y: number };
+  rotationQuarterTurns: number;
   variant: "hovered" | "selected" | "skeleton";
 }) {
   if (!validFrame(node.frame)) {
     return null;
   }
 
-  const left = ((node.frame.x - rootFrame.x) / rootFrame.width) * 100;
-  const top = ((node.frame.y - rootFrame.y) / rootFrame.height) * 100;
-  const width = (node.frame.width / rootFrame.width) * 100;
-  const height = (node.frame.height / rootFrame.height) * 100;
   const label =
     variant === "skeleton"
       ? ""
@@ -129,12 +142,7 @@ function NodeRect({
   return (
     <div
       className={`accessibility-rect ${variant}`}
-      style={{
-        height: `${height}%`,
-        left: `${left}%`,
-        top: `${top}%`,
-        width: `${width}%`,
-      }}
+      style={frameStyle(node.frame, rootFrame, rotationQuarterTurns)}
     >
       {label ? <span>{label}</span> : null}
     </div>
@@ -146,11 +154,13 @@ function AccessibilityDomNode({
   id,
   node,
   rootFrame,
+  rotationQuarterTurns,
 }: {
   depth: number;
   id: string;
   node: AccessibilityNode;
   rootFrame: { height: number; width: number; x: number; y: number };
+  rotationQuarterTurns: number;
 }) {
   if (!validFrame(node.frame)) {
     return null;
@@ -200,19 +210,40 @@ function AccessibilityDomNode({
     "data-simdeck-inspector-id": node.inspectorId || undefined,
     "data-simdeck-uikit-id": node.uikitId || undefined,
     role,
-    style: frameStyle(node.frame, rootFrame),
+    style: frameStyle(node.frame, rootFrame, rotationQuarterTurns),
   });
 }
 
+// Native-ax frames arrive in DISPLAY (interface) space. The overlay lives
+// inside the shell container that CSS-rotates by `rotationQuarterTurns`, so the
+// frame is converted back into the device's natural (pre-rotation) space here;
+// the shared shell rotation then carries the overlay and the video to the
+// displayed orientation together. `rotationQuarterTurns === 0` is the identity,
+// so portrait devices keep their existing behavior.
 function frameStyle(
   frame: { height: number; width: number; x: number; y: number },
   rootFrame: { height: number; width: number; x: number; y: number },
+  rotationQuarterTurns: number,
 ): CSSProperties {
+  const start = mapDisplayedPointToNaturalOrientation(
+    {
+      x: (frame.x - rootFrame.x) / rootFrame.width,
+      y: (frame.y - rootFrame.y) / rootFrame.height,
+    },
+    rotationQuarterTurns,
+  );
+  const end = mapDisplayedPointToNaturalOrientation(
+    {
+      x: (frame.x + frame.width - rootFrame.x) / rootFrame.width,
+      y: (frame.y + frame.height - rootFrame.y) / rootFrame.height,
+    },
+    rotationQuarterTurns,
+  );
   return {
-    height: `${(frame.height / rootFrame.height) * 100}%`,
-    left: `${((frame.x - rootFrame.x) / rootFrame.width) * 100}%`,
-    top: `${((frame.y - rootFrame.y) / rootFrame.height) * 100}%`,
-    width: `${(frame.width / rootFrame.width) * 100}%`,
+    height: `${Math.abs(end.y - start.y) * 100}%`,
+    left: `${Math.min(start.x, end.x) * 100}%`,
+    top: `${Math.min(start.y, end.y) * 100}%`,
+    width: `${Math.abs(end.x - start.x) * 100}%`,
   };
 }
 

--- a/packages/client/src/features/accessibility/AccessibilityOverlay.tsx
+++ b/packages/client/src/features/accessibility/AccessibilityOverlay.tsx
@@ -487,8 +487,12 @@ function accessibilityStateSummary(
   return state.join(", ");
 }
 
-function cleanAccessibilityText(
-  value: string | null | undefined,
-): string | null {
-  return value?.trim() || null;
+function cleanAccessibilityText(value: unknown): string | null {
+  if (typeof value === "string") {
+    return value.trim() || null;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return null;
 }

--- a/packages/client/src/features/accessibility/accessibilityTree.ts
+++ b/packages/client/src/features/accessibility/accessibilityTree.ts
@@ -579,9 +579,15 @@ function frameContainsPoint(
   );
 }
 
-function cleanText(value: string | null | undefined): string | null {
-  const trimmed = value?.trim();
-  return trimmed ? trimmed : null;
+function cleanText(value: unknown): string | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed ? trimmed : null;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return null;
 }
 
 function displayAccessibilityKind(

--- a/packages/client/src/features/viewport/DeviceChrome.tsx
+++ b/packages/client/src/features/viewport/DeviceChrome.tsx
@@ -7,7 +7,7 @@ import type {
 } from "../../api/types";
 import { AccessibilityOverlay } from "../accessibility/AccessibilityOverlay";
 import { findAccessibilityItemAtPoint } from "../accessibility/accessibilityTree";
-import { normalizedPointerCoordinatesForOrientation } from "../input/gestureMath";
+import { normalizedPointerCoordinates } from "../input/gestureMath";
 import type { TouchIndicator } from "./types";
 
 interface DeviceChromeProps {
@@ -698,6 +698,7 @@ function ScreenLayer({
       <AccessibilityOverlay
         hoveredId={accessibilityHoveredId}
         roots={accessibilityRoots}
+        rotationQuarterTurns={rotationQuarterTurns}
         selectedId={accessibilitySelectedId}
         skeletonVisible={accessibilitySkeletonVisible}
       />
@@ -719,22 +720,12 @@ function ScreenLayer({
           onPointerMove={(event) => {
             event.preventDefault();
             event.stopPropagation();
-            onPickerHover(
-              hitTestAccessibilityId(
-                event,
-                accessibilityRoots,
-                rotationQuarterTurns,
-              ),
-            );
+            onPickerHover(hitTestAccessibilityId(event, accessibilityRoots));
           }}
           onPointerUp={(event) => {
             event.preventDefault();
             event.stopPropagation();
-            const id = hitTestAccessibilityId(
-              event,
-              accessibilityRoots,
-              rotationQuarterTurns,
-            );
+            const id = hitTestAccessibilityId(event, accessibilityRoots);
             if (id) {
               onPickerSelect(id);
             }
@@ -788,15 +779,16 @@ function TouchInteractionOverlay({
   );
 }
 
+// Native-ax frames are in DISPLAY (interface) space, so the picker compares the
+// pointer directly in displayed coordinates — no display→natural remap. (The
+// overlay does the inverse remap for rendering because it lives inside the
+// CSS-rotated shell; the pointer here is already measured against the displayed,
+// post-rotation bounding box.)
 function hitTestAccessibilityId(
   event: React.PointerEvent<HTMLElement>,
   roots: AccessibilityNode[],
-  rotationQuarterTurns: number,
 ): string | null {
-  const point = normalizedPointerCoordinatesForOrientation(
-    event,
-    rotationQuarterTurns,
-  );
+  const point = normalizedPointerCoordinates(event);
   if (!point) {
     return null;
   }

--- a/packages/server/src/accessibility.rs
+++ b/packages/server/src/accessibility.rs
@@ -1,5 +1,5 @@
 use clap::ValueEnum;
-use serde_json::{Map, Value};
+use serde_json::{json, Map, Value};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
 pub enum AccessibilitySource {
@@ -50,6 +50,146 @@ impl AccessibilitySource {
             Self::AndroidUiautomator => "android-uiautomator",
         }
     }
+}
+
+/// Rotate device-native (portrait) accessibility frames into the current
+/// display (interface) orientation, in place.
+///
+/// The private CoreSimulator accessibility API reports element frames in the
+/// device's *native* coordinate space. For an app that renders rotated (e.g. a
+/// landscape-locked iPad app, or the SpringBoard home screen), descendant
+/// frames come back in portrait axes even though the video/display is
+/// landscape — so `describe` annotations and selector taps land 90° off.
+///
+/// Not every app is affected: apps that lay their views out natively in the
+/// current orientation (e.g. Settings) already report display-space frames.
+/// We therefore rotate a root's subtree only when the subtree itself proves it
+/// is in portrait space — no descendant frame is wider than the portrait width
+/// (which, in landscape, equals the display height). The top-level application
+/// element reports its own frame in display space regardless, so it (and any
+/// oversized outlier) is left untouched.
+///
+/// Only landscape orientations (odd quarter turns) are handled. Portrait (0)
+/// needs no change, and upside-down portrait (2) is left as-is.
+pub fn normalize_native_ax_orientation(snapshot: &mut Value, quarter_turns: i32) {
+    let quarter_turns = quarter_turns.rem_euclid(4);
+    if quarter_turns != 1 && quarter_turns != 3 {
+        return;
+    }
+    let Some(roots) = snapshot.get_mut("roots").and_then(Value::as_array_mut) else {
+        return;
+    };
+    // In landscape the display is wider than it is tall. Derive the display
+    // dimensions (in points) from the largest root frame, which the AX API
+    // reports in display space.
+    let Some((display_width, display_height)) = display_size_from_roots(roots) else {
+        return;
+    };
+    for root in roots.iter_mut() {
+        if subtree_is_display_space(root, display_height) {
+            continue;
+        }
+        rotate_descendant_frames(root, quarter_turns, display_width, display_height);
+    }
+}
+
+fn frame_rect(node: &Value) -> Option<(f64, f64, f64, f64)> {
+    let frame = node.get("frame")?;
+    Some((
+        frame.get("x")?.as_f64()?,
+        frame.get("y")?.as_f64()?,
+        frame.get("width")?.as_f64()?,
+        frame.get("height")?.as_f64()?,
+    ))
+}
+
+/// Landscape display size `(width, height)` with `width >= height`, taken from
+/// the largest root frame (reported by the AX API in display space).
+fn display_size_from_roots(roots: &[Value]) -> Option<(f64, f64)> {
+    let mut best: Option<(f64, f64)> = None;
+    for root in roots {
+        if let Some((_, _, width, height)) = frame_rect(root) {
+            if width > 0.0 && height > 0.0 && best.map_or(true, |(bw, bh)| width * height > bw * bh)
+            {
+                best = Some((width, height));
+            }
+        }
+    }
+    let (width, height) = best?;
+    Some((width.max(height), width.min(height)))
+}
+
+/// True when a root's subtree is already in display space, detected by any
+/// descendant frame being wider than the portrait width (== display height in
+/// landscape). Portrait content can never exceed the portrait width.
+fn subtree_is_display_space(root: &Value, display_height: f64) -> bool {
+    fn any_wider_than(node: &Value, threshold: f64) -> bool {
+        let Some(children) = node.get("children").and_then(Value::as_array) else {
+            return false;
+        };
+        children.iter().any(|child| {
+            frame_rect(child).is_some_and(|(x, _, width, _)| x + width > threshold)
+                || any_wider_than(child, threshold)
+        })
+    }
+    // +1pt slack so an element spanning exactly the portrait width is not a
+    // false positive.
+    any_wider_than(root, display_height + 1.0)
+}
+
+fn rotate_descendant_frames(root: &mut Value, quarter_turns: i32, display_w: f64, display_h: f64) {
+    let Some(children) = root.get_mut("children").and_then(Value::as_array_mut) else {
+        return;
+    };
+    for child in children.iter_mut() {
+        rotate_node_frame(child, quarter_turns, display_w, display_h);
+    }
+}
+
+fn rotate_node_frame(node: &mut Value, quarter_turns: i32, display_w: f64, display_h: f64) {
+    if let Some((x, y, width, height)) = frame_rect(node) {
+        // Only rotate frames that fit the portrait canvas (portrait width ==
+        // display height, portrait height == display width). Anything larger is
+        // an already-display-space outlier and is left untouched.
+        if width <= display_h + 1.0 && height <= display_w + 1.0 {
+            let (nx, ny, nw, nh) =
+                rotate_rect(x, y, width, height, quarter_turns, display_w, display_h);
+            if let Some(frame) = node.get_mut("frame").and_then(Value::as_object_mut) {
+                frame.insert("x".to_owned(), json!(round_tenths(nx)));
+                frame.insert("y".to_owned(), json!(round_tenths(ny)));
+                frame.insert("width".to_owned(), json!(round_tenths(nw)));
+                frame.insert("height".to_owned(), json!(round_tenths(nh)));
+            }
+        }
+    }
+    if let Some(children) = node.get_mut("children").and_then(Value::as_array_mut) {
+        for child in children.iter_mut() {
+            rotate_node_frame(child, quarter_turns, display_w, display_h);
+        }
+    }
+}
+
+/// Map a rect from device-native portrait axes into the landscape display,
+/// swapping width/height. Portrait canvas is `display_h` wide by `display_w`
+/// tall.
+fn rotate_rect(
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+    quarter_turns: i32,
+    display_w: f64,
+    display_h: f64,
+) -> (f64, f64, f64, f64) {
+    match quarter_turns {
+        3 => (y, display_h - x - width, height, width),
+        1 => (display_w - y - height, x, height, width),
+        _ => (x, y, width, height),
+    }
+}
+
+fn round_tenths(value: f64) -> f64 {
+    (value * 10.0).round() / 10.0
 }
 
 pub fn interactive_accessibility_snapshot(snapshot: &Value) -> Value {
@@ -261,4 +401,111 @@ fn number_from_map(object: &Map<String, Value>, field: &str) -> Option<f64> {
 
 fn string_from_map(object: &Map<String, Value>, field: &str) -> Option<String> {
     object.get(field).and_then(Value::as_str).map(str::to_owned)
+}
+
+#[cfg(test)]
+mod orientation_tests {
+    use super::normalize_native_ax_orientation;
+    use serde_json::{json, Value};
+
+    fn frame(node: &Value, path: &[usize]) -> (f64, f64, f64, f64) {
+        let mut current = node;
+        for &index in path {
+            current = &current["children"][index];
+        }
+        let frame = &current["frame"];
+        (
+            frame["x"].as_f64().unwrap(),
+            frame["y"].as_f64().unwrap(),
+            frame["width"].as_f64().unwrap(),
+            frame["height"].as_f64().unwrap(),
+        )
+    }
+
+    // A real SpringBoard capture (iPad Pro 11", rotationQuarterTurns == 3):
+    // the application root reports display-space (1210x834) but the icon
+    // children are in device-native portrait axes.
+    fn springboard_snapshot() -> Value {
+        json!({
+            "source": "native-ax",
+            "roots": [{
+                "role": "Application",
+                "frame": { "x": 0, "y": 0, "width": 1210, "height": 834 },
+                "children": [
+                    { "role": "Button", "AXLabel": "Fitness",
+                      "frame": { "x": 657, "y": 979, "width": 95.5, "height": 72 } },
+                    { "role": "Button", "AXLabel": "Messages",
+                      "frame": { "x": 27.5, "y": 342.5, "width": 68, "height": 68 } }
+                ]
+            }]
+        })
+    }
+
+    // A real Settings capture (same device/orientation): the app lays out in
+    // landscape, so its frames are already in display space (the detail pane
+    // button spans nearly the full 1210 width).
+    fn settings_snapshot() -> Value {
+        json!({
+            "source": "native-ax",
+            "roots": [{
+                "role": "Application",
+                "frame": { "x": 0, "y": 0, "width": 1210, "height": 834 },
+                "children": [
+                    { "role": "Group", "AXLabel": "Sidebar",
+                      "frame": { "x": 10, "y": 32, "width": 320, "height": 792 } },
+                    { "role": "Button", "AXLabel": "About",
+                      "frame": { "x": 346, "y": 326.5, "width": 848, "height": 53 } }
+                ]
+            }]
+        })
+    }
+
+    #[test]
+    fn rotates_portrait_subtree_for_quarter_turns_3() {
+        let mut snapshot = springboard_snapshot();
+        normalize_native_ax_orientation(&mut snapshot, 3);
+        let root = &snapshot["roots"][0];
+        // Root stays in display space (it is not a portrait-canvas frame).
+        assert_eq!(frame(root, &[]), (0.0, 0.0, 1210.0, 834.0));
+        // Fitness: (x,y,w,h) -> (y, Hd - x - w, h, w) with Hd = 834.
+        assert_eq!(frame(root, &[0]), (979.0, 81.5, 72.0, 95.5));
+        // Messages sits at portrait-left (x~27) => landscape bottom (y~738).
+        assert_eq!(frame(root, &[1]), (342.5, 738.5, 68.0, 68.0));
+    }
+
+    #[test]
+    fn rotates_portrait_subtree_for_quarter_turns_1() {
+        let mut snapshot = springboard_snapshot();
+        normalize_native_ax_orientation(&mut snapshot, 1);
+        let root = &snapshot["roots"][0];
+        // (x,y,w,h) -> (Wd - y - h, x, h, w) with Wd = 1210.
+        assert_eq!(
+            frame(root, &[0]),
+            (1210.0 - 979.0 - 72.0, 657.0, 72.0, 95.5)
+        );
+        assert_eq!(frame(root, &[1]), (1210.0 - 342.5 - 68.0, 27.5, 68.0, 68.0));
+    }
+
+    #[test]
+    fn leaves_display_space_subtree_untouched() {
+        let mut snapshot = settings_snapshot();
+        let before = snapshot.clone();
+        normalize_native_ax_orientation(&mut snapshot, 3);
+        // The "About" button (x+width = 1194 > portrait width) proves the whole
+        // subtree is already display-space, so nothing is rotated.
+        assert_eq!(snapshot, before);
+    }
+
+    #[test]
+    fn portrait_and_upside_down_are_noops() {
+        for quarter_turns in [0, 2, 4] {
+            let mut snapshot = springboard_snapshot();
+            let before = snapshot.clone();
+            normalize_native_ax_orientation(&mut snapshot, quarter_turns);
+            assert_eq!(
+                snapshot, before,
+                "quarter_turns {quarter_turns} must be a no-op"
+            );
+        }
+    }
 }

--- a/packages/server/src/accessibility.rs
+++ b/packages/server/src/accessibility.rs
@@ -109,7 +109,7 @@ fn display_size_from_roots(roots: &[Value]) -> Option<(f64, f64)> {
     let mut best: Option<(f64, f64)> = None;
     for root in roots {
         if let Some((_, _, width, height)) = frame_rect(root) {
-            if width > 0.0 && height > 0.0 && best.map_or(true, |(bw, bh)| width * height > bw * bh)
+            if width > 0.0 && height > 0.0 && best.is_none_or(|(bw, bh)| width * height > bw * bh)
             {
                 best = Some((width, height));
             }

--- a/packages/server/src/accessibility.rs
+++ b/packages/server/src/accessibility.rs
@@ -64,10 +64,13 @@ impl AccessibilitySource {
 /// Not every app is affected: apps that lay their views out natively in the
 /// current orientation (e.g. Settings) already report display-space frames.
 /// We therefore rotate a root's subtree only when the subtree itself proves it
-/// is in portrait space — no descendant frame is wider than the portrait width
-/// (which, in landscape, equals the display height). The top-level application
-/// element reports its own frame in display space regardless, so it (and any
-/// oversized outlier) is left untouched.
+/// is in portrait space: a descendant extends below the landscape display
+/// height, which is only valid on the native portrait canvas. Conversely, a
+/// descendant that extends past the portrait width proves the subtree is
+/// already in display space. Ambiguous small left-side subtrees are left alone
+/// rather than guessing. The top-level application element reports its own
+/// frame in display space regardless, so it (and any oversized outlier) is left
+/// untouched.
 ///
 /// Only landscape orientations (odd quarter turns) are handled. Portrait (0)
 /// needs no change, and upside-down portrait (2) is left as-is.
@@ -86,10 +89,12 @@ pub fn normalize_native_ax_orientation(snapshot: &mut Value, quarter_turns: i32)
         return;
     };
     for root in roots.iter_mut() {
-        if subtree_is_display_space(root, display_height) {
-            continue;
+        match subtree_orientation(root, display_height) {
+            SubtreeOrientation::PortraitNative => {
+                rotate_descendant_frames(root, quarter_turns, display_width, display_height);
+            }
+            SubtreeOrientation::DisplaySpace | SubtreeOrientation::Ambiguous => {}
         }
-        rotate_descendant_frames(root, quarter_turns, display_width, display_height);
     }
 }
 
@@ -118,22 +123,48 @@ fn display_size_from_roots(roots: &[Value]) -> Option<(f64, f64)> {
     Some((width.max(height), width.min(height)))
 }
 
-/// True when a root's subtree is already in display space, detected by any
-/// descendant frame being wider than the portrait width (== display height in
-/// landscape). Portrait content can never exceed the portrait width.
-fn subtree_is_display_space(root: &Value, display_height: f64) -> bool {
-    fn any_wider_than(node: &Value, threshold: f64) -> bool {
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SubtreeOrientation {
+    PortraitNative,
+    DisplaySpace,
+    Ambiguous,
+}
+
+/// Classify the coordinate space of a root's descendants.
+///
+/// In landscape, the natural portrait canvas is `display_height` points wide
+/// and `display_width` points tall. A descendant whose right edge exceeds
+/// `display_height` must already be in display space. A descendant whose bottom
+/// edge exceeds `display_height` proves portrait-native coordinates, because
+/// that point would be outside the visible landscape display.
+fn subtree_orientation(root: &Value, display_height: f64) -> SubtreeOrientation {
+    fn visit(node: &Value, threshold: f64) -> SubtreeOrientation {
         let Some(children) = node.get("children").and_then(Value::as_array) else {
-            return false;
+            return SubtreeOrientation::Ambiguous;
         };
-        children.iter().any(|child| {
-            frame_rect(child).is_some_and(|(x, _, width, _)| x + width > threshold)
-                || any_wider_than(child, threshold)
-        })
+        let mut orientation = SubtreeOrientation::Ambiguous;
+        for child in children {
+            if let Some((x, y, width, height)) = frame_rect(child) {
+                if x + width > threshold {
+                    return SubtreeOrientation::DisplaySpace;
+                }
+                if y + height > threshold {
+                    orientation = SubtreeOrientation::PortraitNative;
+                }
+            }
+            match visit(child, threshold) {
+                SubtreeOrientation::DisplaySpace => return SubtreeOrientation::DisplaySpace,
+                SubtreeOrientation::PortraitNative => {
+                    orientation = SubtreeOrientation::PortraitNative;
+                }
+                SubtreeOrientation::Ambiguous => {}
+            }
+        }
+        orientation
     }
     // +1pt slack so an element spanning exactly the portrait width is not a
     // false positive.
-    any_wider_than(root, display_height + 1.0)
+    visit(root, display_height + 1.0)
 }
 
 fn rotate_descendant_frames(root: &mut Value, quarter_turns: i32, display_w: f64, display_h: f64) {
@@ -492,6 +523,24 @@ mod orientation_tests {
         normalize_native_ax_orientation(&mut snapshot, 3);
         // The "About" button (x+width = 1194 > portrait width) proves the whole
         // subtree is already display-space, so nothing is rotated.
+        assert_eq!(snapshot, before);
+    }
+
+    #[test]
+    fn leaves_ambiguous_left_side_subtree_untouched() {
+        let mut snapshot = json!({
+            "source": "native-ax",
+            "roots": [{
+                "role": "Application",
+                "frame": { "x": 0, "y": 0, "width": 1210, "height": 834 },
+                "children": [
+                    { "role": "Button", "AXLabel": "Narrow",
+                      "frame": { "x": 24, "y": 96, "width": 240, "height": 56 } }
+                ]
+            }]
+        });
+        let before = snapshot.clone();
+        normalize_native_ax_orientation(&mut snapshot, 3);
         assert_eq!(snapshot, before);
     }
 

--- a/packages/server/src/accessibility.rs
+++ b/packages/server/src/accessibility.rs
@@ -109,8 +109,7 @@ fn display_size_from_roots(roots: &[Value]) -> Option<(f64, f64)> {
     let mut best: Option<(f64, f64)> = None;
     for root in roots {
         if let Some((_, _, width, height)) = frame_rect(root) {
-            if width > 0.0 && height > 0.0 && best.is_none_or(|(bw, bh)| width * height > bw * bh)
-            {
+            if width > 0.0 && height > 0.0 && best.is_none_or(|(bw, bh)| width * height > bw * bh) {
                 best = Some((width, height));
             }
         }

--- a/packages/server/src/api/routes.rs
+++ b/packages/server/src/api/routes.rs
@@ -5708,6 +5708,7 @@ async fn accessibility_snapshot_with_options(
 ) -> Result<Value, AppError> {
     let bridge = state.registry.bridge().clone();
     let metrics = state.metrics.clone();
+    let rotation_udid = udid.clone();
     let started = Instant::now();
     let task = task::spawn_blocking(move || {
         bridge.accessibility_snapshot_with_options(&udid, point, max_depth, interactive_only)
@@ -5728,7 +5729,19 @@ async fn accessibility_snapshot_with_options(
         result.is_ok(),
         duration_ms >= NATIVE_AX_SNAPSHOT_TIMEOUT.as_millis() as u64,
     );
-    result
+    // The private AX API reports device-native (portrait) frames for rotated
+    // apps; rotate them into display space so annotations and selector taps
+    // match the landscape video. No-op unless the display is landscape.
+    result.map(|mut snapshot| {
+        if let Some(quarter_turns) = state
+            .registry
+            .get(&rotation_udid)
+            .map(|session| session.rotation_quarter_turns())
+        {
+            crate::accessibility::normalize_native_ax_orientation(&mut snapshot, quarter_turns);
+        }
+        snapshot
+    })
 }
 
 #[cfg(test)]

--- a/packages/server/src/simulators/session.rs
+++ b/packages/server/src/simulators/session.rs
@@ -414,6 +414,12 @@ impl SimulatorSession {
         })
     }
 
+    /// Current display rotation in quarter turns (0..=3). Odd values mean the
+    /// interface is landscape relative to the device's native orientation.
+    pub fn rotation_quarter_turns(&self) -> i32 {
+        self.inner.native.rotation_quarter_turns()
+    }
+
     pub fn is_idle_for(&self, idle_timeout: Duration) -> bool {
         if Arc::strong_count(&self.inner) > 1 {
             return false;


### PR DESCRIPTION
Introduces robust handling for accessibility overlay rendering and hit-testing in rotated device orientations, particularly for iOS devices where accessibility frames may be reported in the device's native portrait axes even when the display is rotated. 