### PR TITLE
feat: stream Android emulators on Windows and Linux with OpenH264

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,40 @@ jobs:
       - name: Rust unit tests
         run: cargo test --manifest-path packages/server/Cargo.toml
 
+  rust-non-macos:
+    name: Rust unit tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Cache Rust build outputs
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/git
+            ~/.cargo/registry
+            packages/server/target
+          key: rust-${{ runner.os }}-${{ hashFiles('packages/server/Cargo.lock', 'packages/server/Cargo.toml', 'packages/server/build.rs', 'packages/server/src/**/*.rs', 'packages/server/native_stubs.c') }}
+          restore-keys: |
+            rust-${{ runner.os }}-
+
+      # The macOS job cannot compile the OpenH264 software encoder or the
+      # native stubs, so lint and test them where they are actually built.
+      - name: Clippy
+        run: cargo clippy --manifest-path packages/server/Cargo.toml --all-targets -- -D warnings
+
+      - name: Rust unit tests
+        run: cargo test --manifest-path packages/server/Cargo.toml
+
   client:
     name: Client lint, build, and tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,16 +367,16 @@ jobs:
           npm run build:cli
           npm run build:simdeck-test
 
-      # Build the same x86_64-pc-windows-gnu binary the release ships so the
-      # emulator test also proves it starts from PowerShell without MinGW DLLs.
+      # Build the same x86_64-pc-windows-msvc binary the release ships (static
+      # CRT) so the emulator test also proves it starts from PowerShell without
+      # any toolchain runtime DLLs.
       - name: Build Android integration artifacts (Windows, release target)
         if: runner.os == 'Windows'
         shell: bash
         env:
-          SIMDECK_BUILD_TARGET: x86_64-pc-windows-gnu
+          SIMDECK_BUILD_TARGET: x86_64-pc-windows-msvc
           SIMDECK_DISABLE_X264: "1"
         run: |
-          rustup target add x86_64-pc-windows-gnu
           npm run build:cli
           npm run build:simdeck-test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,9 @@ jobs:
       - name: Test workflow and CLI packaging guards
         run: npm run test:github-actions
 
+      - name: Test Windows runtime import guard
+        run: npm run test:windows-runtime
+
       - name: Typecheck client
         run: npm run --prefix packages/client typecheck
 
@@ -359,7 +362,21 @@ jobs:
         run: npm ci --ignore-scripts --force
 
       - name: Build Android integration artifacts
+        if: runner.os != 'Windows'
         run: |
+          npm run build:cli
+          npm run build:simdeck-test
+
+      # Build the same x86_64-pc-windows-gnu binary the release ships so the
+      # emulator test also proves it starts from PowerShell without MinGW DLLs.
+      - name: Build Android integration artifacts (Windows, release target)
+        if: runner.os == 'Windows'
+        shell: bash
+        env:
+          SIMDECK_BUILD_TARGET: x86_64-pc-windows-gnu
+          SIMDECK_DISABLE_X264: "1"
+        run: |
+          rustup target add x86_64-pc-windows-gnu
           npm run build:cli
           npm run build:simdeck-test
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,9 +77,63 @@ permissions:
   id-token: write # OIDC trusted publishing + npm provenance
 
 jobs:
+  # The release version is resolved once, up front, so the native CLI binaries
+  # are compiled from the same version that gets committed and published. (Doing
+  # the bump only in the release job meant the binaries were built from the
+  # previous Cargo.toml and reported a stale `--version`.)
+  resolve-version:
+    name: Resolve ${{ inputs.package }} version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Resolve release version
+        id: version
+        shell: bash
+        env:
+          INPUT_PACKAGE: ${{ inputs.package }}
+          BUMP: ${{ inputs.bump }}
+          PREID: ${{ inputs.preid }}
+        run: |
+          set -euo pipefail
+          case "$INPUT_PACKAGE" in
+            simdeck) dir="." ;;
+            react-native-simdeck) dir="packages/react-native-inspector" ;;
+            "@nativescript/simdeck-inspector") dir="packages/nativescript-inspector" ;;
+            simdeck-vscode) dir="packages/vscode-extension" ;;
+            *)
+              echo "Unknown package input: $INPUT_PACKAGE" >&2
+              exit 1
+              ;;
+          esac
+          cd "$dir"
+
+          if [[ "$BUMP" == "current" ]]; then
+            version="$(node -p "require('./package.json').version")"
+          elif [[ "$BUMP" == "prerelease" ]]; then
+            new="$(npm version prerelease --preid "$PREID" --no-git-tag-version)"
+            version="${new#v}"
+          else
+            new="$(npm version "$BUMP" --no-git-tag-version)"
+            version="${new#v}"
+          fi
+
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Resolved ${INPUT_PACKAGE} release version: ${version}"
+
   build-native-artifacts:
     if: ${{ inputs.package == 'simdeck' }}
     name: Build ${{ matrix.platform }} native artifact
+    needs: resolve-version
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -87,24 +141,28 @@ jobs:
         include:
           - platform: macos-arm64
             runner: macos-latest
+            binary: build/simdeck-bin-darwin-arm64
             build_cmd: |
               rustup target add aarch64-apple-darwin
               SIMDECK_BUILD_TARGET=aarch64-apple-darwin npm run build:cli
               cp build/simdeck-bin build/simdeck-bin-darwin-arm64
           - platform: macos-x64
             runner: macos-latest
+            binary: build/simdeck-bin-darwin-x64
             build_cmd: |
               rustup target add x86_64-apple-darwin
               SIMDECK_DISABLE_X264=1 SIMDECK_BUILD_TARGET=x86_64-apple-darwin npm run build:cli
               cp build/simdeck-bin build/simdeck-bin-darwin-x64
           - platform: linux-x64
             runner: ubuntu-latest
+            binary: build/simdeck-bin-linux-x64
             build_cmd: |
               rustup target add x86_64-unknown-linux-gnu
               SIMDECK_DISABLE_X264=1 SIMDECK_BUILD_TARGET=x86_64-unknown-linux-gnu npm run build:cli
               cp build/simdeck-bin build/simdeck-bin-linux-x64
           - platform: windows-x64
             runner: windows-latest
+            binary: build/simdeck-bin-win32-x64.exe
             build_cmd: |
               rustup target add x86_64-pc-windows-gnu
               export SIMDECK_DISABLE_X264=1
@@ -150,11 +208,42 @@ jobs:
       - name: Install root dependencies
         run: npm ci
 
+      - name: Sync Rust CLI version
+        shell: bash
+        env:
+          NEW_VERSION: ${{ needs.resolve-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          perl -0pi -e 's/(\[package\]\s+name = "simdeck-server"\s+version = ")[^"]+(")/$1$ENV{NEW_VERSION}$2/s' packages/server/Cargo.toml
+          cargo update --manifest-path packages/server/Cargo.toml -p simdeck-server --precise "$NEW_VERSION"
+          grep -q "^version = \"${NEW_VERSION}\"$" packages/server/Cargo.toml
+          echo "Building simdeck-server ${NEW_VERSION}"
+
       - name: Build native artifact
         shell: bash
         run: |
           set -euo pipefail
           ${{ matrix.build_cmd }}
+
+      - name: Verify native artifact reports the release version
+        shell: bash
+        env:
+          EXPECTED_VERSION: ${{ needs.resolve-version.outputs.version }}
+          BINARY: ${{ matrix.binary }}
+        run: |
+          set -euo pipefail
+          if [[ "$RUNNER_OS" == "macOS" && "$BINARY" == *darwin-x64 && "$(uname -m)" == "arm64" ]] \
+            && ! arch -x86_64 /usr/bin/true >/dev/null 2>&1; then
+            echo "::warning::Rosetta is unavailable on this runner; skipping the runtime version check for ${BINARY}."
+            exit 0
+          fi
+
+          actual="$("$BINARY" --version)"
+          echo "${BINARY} --version -> ${actual}"
+          if [[ "${actual##* }" != "$EXPECTED_VERSION" ]]; then
+            echo "::error::${BINARY} reports '${actual}' but this release is ${EXPECTED_VERSION}. The binary was built from a stale crate version." >&2
+            exit 1
+          fi
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -169,8 +258,8 @@ jobs:
 
   release:
     name: Release ${{ inputs.package }} (${{ inputs.bump }})
-    needs: build-native-artifacts
-    if: ${{ always() && (needs.build-native-artifacts.result == 'success' || inputs.package != 'simdeck') }}
+    needs: [resolve-version, build-native-artifacts]
+    if: ${{ always() && needs.resolve-version.result == 'success' && (needs.build-native-artifacts.result == 'success' || inputs.package != 'simdeck') }}
     runs-on: macos-latest
     environment:
       name: ${{ inputs.dry-run && 'npm-publish-dry-run' || 'npm-publish' }}
@@ -269,21 +358,29 @@ jobs:
         shell: bash
         env:
           BUMP: ${{ inputs.bump }}
-          PREID: ${{ inputs.preid }}
+          RESOLVED_VERSION: ${{ needs.resolve-version.outputs.version }}
           PKG_DIR: ${{ steps.meta.outputs.dir }}
           SLUG: ${{ steps.meta.outputs.slug }}
         run: |
           set -euo pipefail
           cd "$PKG_DIR"
 
+          # The version was resolved by the resolve-version job (and already
+          # compiled into the native binaries); apply the same value here.
+          version="$RESOLVED_VERSION"
+          if [[ -z "$version" ]]; then
+            echo "resolve-version did not produce a version" >&2
+            exit 1
+          fi
+
           if [[ "$BUMP" == "current" ]]; then
-            version="$(node -p "require('./package.json').version")"
-          elif [[ "$BUMP" == "prerelease" ]]; then
-            new="$(npm version prerelease --preid "$PREID" --no-git-tag-version)"
-            version="${new#v}"
+            current="$(node -p "require('./package.json').version")"
+            if [[ "$current" != "$version" ]]; then
+              echo "Resolved version ${version} does not match package.json (${current})" >&2
+              exit 1
+            fi
           else
-            new="$(npm version "$BUMP" --no-git-tag-version)"
-            version="${new#v}"
+            npm version "$version" --no-git-tag-version --allow-same-version >/dev/null
           fi
 
           tag="${SLUG}-v${version}"
@@ -339,7 +436,11 @@ jobs:
 
       - name: Verify CLI artifacts are published for all supported hosts
         if: ${{ steps.meta.outputs.kind == 'npm-cli' }}
+        shell: bash
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.version }}
         run: |
+          set -euo pipefail
           for artifact in \
             build/simdeck-bin \
             build/simdeck-bin-darwin-arm64 \
@@ -348,6 +449,7 @@ jobs:
             build/simdeck-bin-win32-x64.exe
           do
             test -f "$artifact"
+            chmod +x "$artifact"
           done
 
           file build/simdeck-bin
@@ -357,6 +459,17 @@ jobs:
           file build/simdeck-bin-darwin-x64 | grep -q 'x86_64'
           file build/simdeck-bin-linux-x64 | grep -q 'ELF'
           file build/simdeck-bin-win32-x64.exe | grep -Eq 'PE32|PE32\+'
+
+          # The universal binary is what macOS users run; make sure it was
+          # compiled from this release's crate version, not the previous one.
+          for artifact in build/simdeck-bin build/simdeck-bin-darwin-arm64; do
+            actual="$("$artifact" --version)"
+            echo "${artifact} --version -> ${actual}"
+            if [[ "${actual##* }" != "$NEW_VERSION" ]]; then
+              echo "::error::${artifact} reports '${actual}' but this release is ${NEW_VERSION}." >&2
+              exit 1
+            fi
+          done
 
       # ---------- Apple codesign + notarize (root simdeck only) ----------
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,9 +164,8 @@ jobs:
             runner: windows-latest
             binary: build/simdeck-bin-win32-x64.exe
             build_cmd: |
-              rustup target add x86_64-pc-windows-gnu
               export SIMDECK_DISABLE_X264=1
-              export SIMDECK_BUILD_TARGET=x86_64-pc-windows-gnu
+              export SIMDECK_BUILD_TARGET=x86_64-pc-windows-msvc
               npm run build:cli
               cp build/simdeck-bin.exe build/simdeck-bin-win32-x64.exe
 
@@ -191,7 +190,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-apple-darwin,x86_64-apple-darwin,x86_64-unknown-linux-gnu,x86_64-pc-windows-gnu
+          targets: aarch64-apple-darwin,x86_64-apple-darwin,x86_64-unknown-linux-gnu,x86_64-pc-windows-msvc
 
       - name: Install native build dependencies
         shell: bash
@@ -201,8 +200,6 @@ jobs:
           elif [[ "$RUNNER_OS" == "Linux" ]]; then
             sudo apt-get update
             sudo apt-get install -y pkg-config libx264-dev
-          else
-            choco install mingw --no-progress -y
           fi
 
       - name: Install root dependencies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,13 @@ The native side should own anything that depends on macOS frameworks, `xcrun sim
   Defines REST routes for simulator control, health, metrics, and chrome assets.
 - `packages/server/src/transport/webrtc.rs`
   Exposes the H.264 WebRTC offer/answer endpoint for browser live video.
+- `packages/server/src/platform.rs`
+  Single source of truth for host platform capabilities. Live H.264 video
+  (iOS simulator and Android emulator) exists only in the macOS build; the
+  Windows and Linux builds compile `packages/server/native_stubs.c` in place
+  of the native bridge. Health, stream-quality, the WebRTC offer error, the
+  CLI banner, and the browser client all read this module's `liveVideo`
+  capability instead of hard-coding platform checks.
 - `packages/server/src/webkit.rs`
   Discovers simulator WebKit Remote Inspector targets and bridges WebInspectorUI
   WebSocket traffic to the simulator `webinspectord` binary-plist socket.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,12 +21,18 @@ The native side should own anything that depends on macOS frameworks, `xcrun sim
 - `packages/server/src/transport/webrtc.rs`
   Exposes the H.264 WebRTC offer/answer endpoint for browser live video.
 - `packages/server/src/platform.rs`
-  Single source of truth for host platform capabilities. Live H.264 video
-  (iOS simulator and Android emulator) exists only in the macOS build; the
-  Windows and Linux builds compile `packages/server/native_stubs.c` in place
-  of the native bridge. Health, stream-quality, the WebRTC offer error, the
-  CLI banner, and the browser client all read this module's `liveVideo`
-  capability instead of hard-coding platform checks.
+  Single source of truth for host platform capabilities. iOS simulators exist
+  only in the macOS build; the Windows and Linux builds compile
+  `packages/server/native_stubs.c` in place of the native bridge. Health,
+  stream-quality, the WebRTC offer error, the CLI banner, and the browser
+  client all read this module's `liveVideo` capability instead of hard-coding
+  platform checks.
+- `packages/server/src/transport/software_h264.rs`
+  OpenH264 software encoder (the `openh264` crate, compiled from source) used
+  for Android emulator WebRTC streams on non-macOS builds. It emits Annex B
+  baseline H.264 so `transport/webrtc.rs` packetizes it exactly like the macOS
+  native encoder output. macOS keeps encoding Android frames through
+  `XCWH264Encoder` behind the C ABI.
 - `packages/server/src/webkit.rs`
   Discovers simulator WebKit Remote Inspector targets and bridges WebInspectorUI
   WebSocket traffic to the simulator `webinspectord` binary-plist socket.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,10 +180,14 @@ manually from the Actions tab and pick the package, bump type, and dist-tag.
 
 The workflow:
 
+- Resolves the new version up front so every job builds from the same number
+- Builds the per-platform native binaries for the root `simdeck` package with
+  `packages/server/Cargo.toml` synced to that version, and fails if any binary's
+  `--version` output disagrees with it
 - Bumps the chosen package's version, commits, and tags as `<slug>-v<version>`
-- Builds a universal native binary for the root `simdeck` package, codesigns
-  with the team's Developer ID Application certificate, and notarizes with
-  Apple's notary service
+- Merges the macOS binaries into a universal binary, codesigns it with the
+  team's Developer ID Application certificate, and notarizes with Apple's
+  notary service
 - Publishes npm packages over OIDC trusted publishing (no NPM_TOKEN required)
 - Publishes the VS Code extension via `vsce` using a stored PAT
 - Creates a GitHub Release with the signed binary attached

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ view inside the editor.
 
 ## Features
 
-- Supports native H.264 streaming for both iOS simulators and Android emulators (live video requires the macOS build; the Windows and Linux CLIs manage Android emulators without a browser stream)
+- Supports native H.264 streaming for both iOS simulators and Android emulators (iOS simulators need the macOS build; Windows and Linux stream Android emulators with a built-in OpenH264 software encoder)
 - Full simulator control & inspection using private iOS accessibility APIs and Android UIAutomator - available using `simdeck` CLI
 - Real-time screen `describe` command using accessibility view tree - available in token-efficient format for agents
 - Profiling built-in: CPU, memory, disk writes, network throughput, hang signals, and stack sampling

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ view inside the editor.
 
 ## Features
 
-- Supports native H.264 streaming for both iOS simulators and Android emulators
+- Supports native H.264 streaming for both iOS simulators and Android emulators (live video requires the macOS build; the Windows and Linux CLIs manage Android emulators without a browser stream)
 - Full simulator control & inspection using private iOS accessibility APIs and Android UIAutomator - available using `simdeck` CLI
 - Real-time screen `describe` command using accessibility view tree - available in token-efficient format for agents
 - Profiling built-in: CPU, memory, disk writes, network throughput, hang signals, and stack sampling

--- a/docs/api/health.md
+++ b/docs/api/health.md
@@ -22,7 +22,12 @@ Example:
   "timestamp": 1714094761.234,
   "videoCodec": "auto",
   "hostOs": "macos",
-  "liveVideo": { "supported": true, "requires": "macos" },
+  "liveVideo": {
+    "supported": true,
+    "encoder": "native",
+    "iosSimulator": true,
+    "androidEmulator": true
+  },
   "androidGpu": "host",
   "lowLatency": false,
   "realtimeStream": true,
@@ -50,16 +55,19 @@ Important fields:
 | `serverKind`    | `launchAgent` or `standalone`                           |
 | `videoCodec`    | Requested codec mode: `auto`, `hardware`, or `software` |
 | `hostOs`        | Server build target: `macos`, `windows`, or `linux`     |
-| `liveVideo`     | Whether this build can encode the live H.264 stream     |
+| `liveVideo`     | Live stream encoder and per-platform device support     |
 | `androidGpu`    | Android emulator renderer mode for SimDeck-owned boots  |
 | `streamQuality` | Active stream profile and limits                        |
 | `webRtc`        | ICE settings the browser should use                     |
 
-`liveVideo` is `{ "supported": true, "requires": "macos" }` on macOS. Windows
-and Linux builds return `supported: false` plus a `reason` string, because live
-H.264 encoding for both iOS simulators and Android emulators lives in the macOS
-native bridge. Clients should show that reason instead of opening a WebRTC
-offer; the offer endpoint answers `501 Not Implemented` with the same message.
+`liveVideo.encoder` is `native` on macOS (VideoToolbox or x264 through the
+simulator bridge) and `openh264` on Windows and Linux, where Android emulator
+frames are encoded in software. `androidEmulator` is `true` everywhere.
+`iosSimulator` is `true` only on macOS; other builds add an
+`iosSimulatorReason` string, and the WebRTC offer endpoint answers iOS
+simulator offers there with `501 Not Implemented` and the same message.
+`supported` is `true` for every shipped build; a client should treat
+`supported: false` plus `reason` as "do not open a WebRTC offer".
 `GET /api/stream-quality` includes the same `liveVideo` block.
 
 When auth is required, the `401` JSON body still includes `serverId`, `advertiseHost`, `hostId`, `hostName`, `httpPort`, and `serverKind` so native clients can group endpoints before pairing.

--- a/docs/api/health.md
+++ b/docs/api/health.md
@@ -21,6 +21,8 @@ Example:
   "serverKind": "launchAgent",
   "timestamp": 1714094761.234,
   "videoCodec": "auto",
+  "hostOs": "macos",
+  "liveVideo": { "supported": true, "requires": "macos" },
   "androidGpu": "host",
   "lowLatency": false,
   "realtimeStream": true,
@@ -47,9 +49,18 @@ Important fields:
 | `httpPort`      | Port serving UI and API                                 |
 | `serverKind`    | `launchAgent` or `standalone`                           |
 | `videoCodec`    | Requested codec mode: `auto`, `hardware`, or `software` |
+| `hostOs`        | Server build target: `macos`, `windows`, or `linux`     |
+| `liveVideo`     | Whether this build can encode the live H.264 stream     |
 | `androidGpu`    | Android emulator renderer mode for SimDeck-owned boots  |
 | `streamQuality` | Active stream profile and limits                        |
 | `webRtc`        | ICE settings the browser should use                     |
+
+`liveVideo` is `{ "supported": true, "requires": "macos" }` on macOS. Windows
+and Linux builds return `supported: false` plus a `reason` string, because live
+H.264 encoding for both iOS simulators and Android emulators lives in the macOS
+native bridge. Clients should show that reason instead of opening a WebRTC
+offer; the offer endpoint answers `501 Not Implemented` with the same message.
+`GET /api/stream-quality` includes the same `liveVideo` block.
 
 When auth is required, the `401` JSON body still includes `serverId`, `advertiseHost`, `hostId`, `hostName`, `httpPort`, and `serverKind` so native clients can group endpoints before pairing.
 

--- a/docs/api/rest.md
+++ b/docs/api/rest.md
@@ -53,9 +53,10 @@ curl -X POST \
 | `POST` | `/api/stream-quality`      | Update stream quality settings                             |
 
 See [Health and metrics](/api/health) for details. Both `/api/health` and
-`/api/stream-quality` include a `liveVideo` block; check `liveVideo.supported`
-before opening a WebRTC offer, because Windows and Linux builds cannot encode
-the live stream and answer offers with `501` and the `liveVideo.reason` text.
+`/api/stream-quality` include a `liveVideo` block. Android emulators stream on
+every platform (`encoder` is `native` on macOS and `openh264` elsewhere); check
+`liveVideo.iosSimulator` before opening an iOS simulator WebRTC offer, because
+Windows and Linux builds answer those with `501` and `iosSimulatorReason`.
 
 ## Devices
 

--- a/docs/api/rest.md
+++ b/docs/api/rest.md
@@ -52,7 +52,10 @@ curl -X POST \
 | `GET`  | `/api/stream-quality`      | Current stream quality settings                            |
 | `POST` | `/api/stream-quality`      | Update stream quality settings                             |
 
-See [Health and metrics](/api/health) for details.
+See [Health and metrics](/api/health) for details. Both `/api/health` and
+`/api/stream-quality` include a `liveVideo` block; check `liveVideo.supported`
+before opening a WebRTC offer, because Windows and Linux builds cannot encode
+the live stream and answer offers with `501` and the `liveVideo.reason` text.
 
 ## Devices
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -8,21 +8,22 @@
 
 ## Platform support
 
-The npm package installs a native CLI for macOS, Windows, and Linux, but only
-the macOS build includes the native simulator bridge and H.264 encoder.
+The npm package installs a native CLI for macOS, Windows, and Linux. Only the
+macOS build includes the private simulator bridge, so iOS simulators need a
+Mac. Android emulators work everywhere, including the live browser stream.
 
-| Capability                                         | macOS | Windows / Linux         |
-| -------------------------------------------------- | ----- | ----------------------- |
-| iOS simulator control, inspection, and streaming   | Yes   | No                      |
-| Android emulator control and inspection            | Yes   | Yes                     |
-| Live H.264 browser stream (iOS and Android)        | Yes   | No                      |
-| `--video-codec`, stream quality, and encoder menus | Yes   | Reported as unavailable |
+| Capability                                       | macOS                | Windows / Linux        |
+| ------------------------------------------------ | -------------------- | ---------------------- |
+| iOS simulator control, inspection, and streaming | Yes                  | No                     |
+| Android emulator control and inspection          | Yes                  | Yes                    |
+| Android emulator live H.264 browser stream       | VideoToolbox or x264 | OpenH264 software      |
+| `--video-codec hardware`                         | VideoToolbox         | Falls back to software |
 
 On Windows and Linux the CLI prints a `Live video:` note after the service
-URLs, `GET /api/health` and `GET /api/stream-quality` report
-`liveVideo.supported: false` with the reason, the browser shows that reason in
-place of the device screen, and the WebRTC offer endpoint answers `501` with
-the same message. See [Video and streaming](./video.md) for the encoder details.
+URLs, and `GET /api/health` reports `liveVideo.encoder: "openh264"` with
+`liveVideo.iosSimulator: false`. Selecting an iOS simulator through the API
+there returns `501` with the same explanation. See
+[Video and streaming](./video.md) for the encoder details.
 
 Check Xcode selection if you have multiple installs:
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -2,9 +2,27 @@
 
 ## Requirements
 
-- macOS on Apple Silicon.
+- macOS on Apple Silicon for the full experience.
 - Xcode with the simulator runtimes you want to use.
 - Node.js 18 or newer.
+
+## Platform support
+
+The npm package installs a native CLI for macOS, Windows, and Linux, but only
+the macOS build includes the native simulator bridge and H.264 encoder.
+
+| Capability                                         | macOS | Windows / Linux         |
+| -------------------------------------------------- | ----- | ----------------------- |
+| iOS simulator control, inspection, and streaming   | Yes   | No                      |
+| Android emulator control and inspection            | Yes   | Yes                     |
+| Live H.264 browser stream (iOS and Android)        | Yes   | No                      |
+| `--video-codec`, stream quality, and encoder menus | Yes   | Reported as unavailable |
+
+On Windows and Linux the CLI prints a `Live video:` note after the service
+URLs, `GET /api/health` and `GET /api/stream-quality` report
+`liveVideo.supported: false` with the reason, the browser shows that reason in
+place of the device screen, and the WebRTC offer endpoint answers `501` with
+the same message. See [Video and streaming](./video.md) for the encoder details.
 
 Check Xcode selection if you have multiple installs:
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -107,6 +107,20 @@ Android IDs in SimDeck use `android:<avd-name>`.
 
 ## Stream is black or stuck
 
+### Live video requires macOS
+
+```text
+Live H.264 video streaming requires macOS. This SimDeck build for Windows can manage devices but does not include the native H.264 encoder...
+```
+
+This is expected on the Windows and Linux builds, for both iOS simulators and
+Android emulators. Those builds link a stub instead of the macOS native bridge
+that owns VideoToolbox and x264 encoding, so the browser stream, the encoder
+menu, and `--video-codec` cannot work there. Device control, `describe`,
+screenshots, and the inspectors still run. Use a Mac to see the live screen, or
+pair a Windows or Linux browser with a SimDeck service running on a Mac. Check
+`liveVideo.supported` in `GET /api/health` when scripting against the service.
+
 ### Timed out waiting for the first frame
 
 Try software encoding:

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -107,19 +107,32 @@ Android IDs in SimDeck use `android:<avd-name>`.
 
 ## Stream is black or stuck
 
-### Live video requires macOS
+### iOS simulators require macOS
 
 ```text
-Live H.264 video streaming requires macOS. This SimDeck build for Windows can manage devices but does not include the native H.264 encoder...
+iOS simulators require macOS. This SimDeck build for Windows can boot, control, and stream Android emulators, but the iOS simulator bridge is only available on macOS.
 ```
 
-This is expected on the Windows and Linux builds, for both iOS simulators and
-Android emulators. Those builds link a stub instead of the macOS native bridge
-that owns VideoToolbox and x264 encoding, so the browser stream, the encoder
-menu, and `--video-codec` cannot work there. Device control, `describe`,
-screenshots, and the inspectors still run. Use a Mac to see the live screen, or
-pair a Windows or Linux browser with a SimDeck service running on a Mac. Check
-`liveVideo.supported` in `GET /api/health` when scripting against the service.
+This is expected on the Windows and Linux builds. They link a stub instead of
+the macOS native bridge that owns iOS simulator control and the VideoToolbox
+and x264 encoders. Android emulators still boot, stream, and accept input on
+those hosts through the built-in OpenH264 software encoder. Use a Mac for iOS
+simulators, or pair a Windows or Linux browser with a SimDeck service running on
+a Mac. Check `liveVideo.iosSimulator` in `GET /api/health` when scripting
+against the service.
+
+### Android stream is slow on Windows or Linux
+
+Those builds encode with OpenH264 in software. Lower the encoded size first,
+then the frame rate:
+
+```sh
+simdeck service restart --stream-quality low
+```
+
+`GET /api/metrics` lists `androidEncoders[].encoder.native` with
+`latestEncodeLatencyUs` and `skippedFrames`; if encode latency stays above the
+frame interval, the host CPU cannot keep up with the selected profile.
 
 ### Timed out waiting for the first frame
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -44,6 +44,30 @@ If it is an old service:
 simdeck service stop
 ```
 
+### `simdeck` prints nothing for minutes on Windows
+
+Earlier Windows builds let child processes inherit the service's listening
+socket. If the service exited while the adb server or an emulator it
+started was still running, port 4310 stayed open with nothing answering, and
+the next `simdeck` run waited on it before starting a fresh service on another
+port. Stop the orphaned holder and run `simdeck` again:
+
+```powershell
+adb kill-server
+```
+
+Newer builds keep the listener private to the service and give up on a silent
+port after a few seconds.
+
+### Windows reports a missing `libstdc++-6.dll`
+
+The Windows binary is built with the MinGW toolchain and must not depend on its
+runtime DLLs. A build that does starts only inside Git Bash and fails from
+PowerShell or cmd with exit code `0xC0000135`. Released builds link the runtime
+statically; a source build needs `SIMDECK_BUILD_TARGET=x86_64-pc-windows-gnu`,
+which `npm run build:cli` handles by adding `+crt-static` and refusing to
+package a binary that still imports those DLLs.
+
 ### Native binary is missing
 
 Reinstall from npm:

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -59,14 +59,15 @@ adb kill-server
 Newer builds keep the listener private to the service and give up on a silent
 port after a few seconds.
 
-### Windows reports a missing `libstdc++-6.dll`
+### Windows reports a missing `libstdc++-6.dll` or `vcruntime140.dll`
 
-The Windows binary is built with the MinGW toolchain and must not depend on its
-runtime DLLs. A build that does starts only inside Git Bash and fails from
-PowerShell or cmd with exit code `0xC0000135`. Released builds link the runtime
-statically; a source build needs `SIMDECK_BUILD_TARGET=x86_64-pc-windows-gnu`,
-which `npm run build:cli` handles by adding `+crt-static` and refusing to
-package a binary that still imports those DLLs.
+The Windows binary must not depend on toolchain runtime DLLs. A build that does
+fails from PowerShell or cmd with exit code `0xC0000135` (and only starts inside
+Git Bash when the MinGW DLLs happen to be on PATH). Released builds target
+`x86_64-pc-windows-msvc` with a static CRT; a source build should set
+`SIMDECK_BUILD_TARGET=x86_64-pc-windows-msvc`, which `npm run build:cli` handles
+by adding `+crt-static` and refusing to package a binary that still imports
+those DLLs.
 
 ### Native binary is missing
 

--- a/docs/guide/video.md
+++ b/docs/guide/video.md
@@ -5,17 +5,26 @@ SimDeck streams live device video to the browser. Local iOS sessions default to 
 iOS simulator H.264 uses VideoToolbox for hardware encoding and x264 for software encoding.
 Android emulator H.264 uses the emulator gRPC `streamScreenshot` API when SimDeck owns the boot. SimDeck receives raw RGBA frames, pads odd dimensions for H.264, and encodes them on the Mac. If the gRPC endpoint is unavailable, SimDeck falls back to the emulator `-share-vid` display surface and reads BGRA frames from the `videmulator<console-port>` shared memory region.
 
-## Platform requirement
+## Encoders per platform
 
-Live video needs the macOS build. Both encoders above live in the macOS native
-bridge, so the Windows and Linux CLIs link a stub instead and cannot stream iOS
-simulators or Android emulators to the browser. Those builds still manage
-Android emulators, but `--video-codec`, stream quality, and the encoder menu
-have no effect there. The service reports this through `liveVideo` in
-`GET /api/health` and `GET /api/stream-quality`, prints a `Live video:` note
-when it starts, and answers WebRTC offers with `501 Not Implemented` and the
-same explanation. The browser client hides the retry loop and shows that
-message in place of the device screen.
+| Host            | iOS simulator stream          | Android emulator stream                  |
+| --------------- | ----------------------------- | ---------------------------------------- |
+| macOS           | VideoToolbox hardware or x264 | VideoToolbox hardware or x264            |
+| Windows / Linux | Not available                 | OpenH264 software, built into the binary |
+
+Both macOS encoders live in the macOS native bridge, which also owns iOS
+simulator control. The Windows and Linux CLIs link a stub in its place, so they
+cannot drive iOS simulators at all. Android emulator frames on those hosts are
+encoded in Rust with Cisco's OpenH264 (baseline profile, Annex B) and go
+through the same WebRTC path as on macOS. Stream quality profiles and the
+frame-rate and resolution controls apply there too; `--video-codec hardware`
+has no hardware encoder to select and behaves like `software`.
+
+The service reports this through `liveVideo` in `GET /api/health` and
+`GET /api/stream-quality` (`encoder` is `native` or `openh264`, `iosSimulator`
+is `false` off macOS), prints a `Live video:` note when it starts on Windows or
+Linux, and answers iOS simulator WebRTC offers there with `501 Not Implemented`
+and the same explanation.
 
 ## When encoding runs
 

--- a/docs/guide/video.md
+++ b/docs/guide/video.md
@@ -5,6 +5,18 @@ SimDeck streams live device video to the browser. Local iOS sessions default to 
 iOS simulator H.264 uses VideoToolbox for hardware encoding and x264 for software encoding.
 Android emulator H.264 uses the emulator gRPC `streamScreenshot` API when SimDeck owns the boot. SimDeck receives raw RGBA frames, pads odd dimensions for H.264, and encodes them on the Mac. If the gRPC endpoint is unavailable, SimDeck falls back to the emulator `-share-vid` display surface and reads BGRA frames from the `videmulator<console-port>` shared memory region.
 
+## Platform requirement
+
+Live video needs the macOS build. Both encoders above live in the macOS native
+bridge, so the Windows and Linux CLIs link a stub instead and cannot stream iOS
+simulators or Android emulators to the browser. Those builds still manage
+Android emulators, but `--video-codec`, stream quality, and the encoder menu
+have no effect there. The service reports this through `liveVideo` in
+`GET /api/health` and `GET /api/stream-quality`, prints a `Live video:` note
+when it starts, and answers WebRTC offers with `501 Not Implemented` and the
+same explanation. The browser client hides the retry loop and shows that
+message in place of the device screen.
+
 ## When encoding runs
 
 SimDeck starts encoding when a browser stream needs H.264 frames. For iOS, the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simdeck",
-  "version": "0.1.34",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simdeck",
-      "version": "0.1.34",
+      "version": "0.2.0",
       "cpu": [
         "arm64"
       ],

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "test:e2e:webrtc:stress": "node scripts/e2e-webrtc-stress.mjs",
     "test:studio-provider": "node --test scripts/studio-provider-bridge.test.mjs scripts/studio-host-provider.test.mjs",
     "test:github-actions": "node --test scripts/github-actions.test.mjs",
+    "test:windows-runtime": "node --test scripts/windows-runtime.test.mjs",
     "test:stress": "node scripts/stress/simdeck.mjs",
     "test:stress:service": "node scripts/stress/service-cleanup.mjs",
     "bench:agent-control": "node scripts/bench/agent-control-benchmark.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simdeck",
-  "version": "0.1.34",
+  "version": "0.2.0",
   "description": "Native macOS simulator control plane with a browser client",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/cli/bin/simdeck.mjs
+++ b/packages/cli/bin/simdeck.mjs
@@ -42,7 +42,9 @@ function findPackageRoot(startDir) {
   while (true) {
     if (
       existsSync(path.join(current, "package.json")) ||
-      buildMarkers.some((marker) => existsSync(path.join(current, "build", marker)))
+      buildMarkers.some((marker) =>
+        existsSync(path.join(current, "build", marker)),
+      )
     ) {
       return current;
     }

--- a/packages/client/src/api/types.ts
+++ b/packages/client/src/api/types.ts
@@ -187,12 +187,25 @@ export interface ChromeDevToolsTargetDiscovery {
   warnings: string[];
 }
 
+/**
+ * Whether the server build can encode the live H.264 browser stream. Only the
+ * macOS build links the native encoder; Windows and Linux builds report
+ * `supported: false` with a user-facing `reason`.
+ */
+export interface LiveVideoCapability {
+  supported: boolean;
+  requires?: string;
+  reason?: string | null;
+}
+
 export interface HealthResponse {
   ok: boolean;
   serverId?: string;
   advertiseHost?: string;
   hostId?: string;
   hostName?: string;
+  hostOs?: string;
+  liveVideo?: LiveVideoCapability;
   httpPort?: number;
   serverKind?:
     | "launchAgent"

--- a/packages/client/src/api/types.ts
+++ b/packages/client/src/api/types.ts
@@ -188,12 +188,18 @@ export interface ChromeDevToolsTargetDiscovery {
 }
 
 /**
- * Whether the server build can encode the live H.264 browser stream. Only the
- * macOS build links the native encoder; Windows and Linux builds report
- * `supported: false` with a user-facing `reason`.
+ * What the server build can stream. Every shipped build encodes the live H.264
+ * browser stream (`native` VideoToolbox/x264 on macOS, `openh264` elsewhere),
+ * but only macOS can drive iOS simulators; Windows and Linux builds report
+ * `iosSimulator: false` with a user-facing `iosSimulatorReason`. A server that
+ * cannot stream at all would report `supported: false` with a `reason`.
  */
 export interface LiveVideoCapability {
   supported: boolean;
+  encoder?: string;
+  iosSimulator?: boolean;
+  androidEmulator?: boolean;
+  iosSimulatorReason?: string | null;
   requires?: string;
   reason?: string | null;
 }

--- a/packages/client/src/app/AppShell.tsx
+++ b/packages/client/src/app/AppShell.tsx
@@ -628,9 +628,9 @@ export function AppShell({
   );
   const [streamConfigApplyKey, setStreamConfigApplyKey] = useState(0);
   const [streamConfigReady, setStreamConfigReady] = useState(false);
-  // Non-empty when the connected server build cannot encode live video (for
-  // example the Windows or Linux CLI). The stream stays paused and the reason
-  // is shown instead of retrying WebRTC offers that can never succeed.
+  // Non-empty when the connected server reports that it cannot encode live
+  // video at all. The stream stays paused and the reason is shown instead of
+  // retrying WebRTC offers that can never succeed.
   const [liveVideoUnavailable, setLiveVideoUnavailable] = useState("");
   const [touchIndicators, setTouchIndicators] = useState<TouchIndicator[]>([]);
   const [selectedSimulatorState, setSelectedSimulatorState] =

--- a/packages/client/src/app/AppShell.tsx
+++ b/packages/client/src/app/AppShell.tsx
@@ -38,6 +38,7 @@ import type {
   AccessibilitySourcePreference,
   AccessibilityTreeResponse,
   ChromeProfile,
+  LiveVideoCapability,
   SimulatorMetadata,
   SimulatorStateResponse,
   TouchPhase,
@@ -55,6 +56,7 @@ import {
   simulatorUsesInsetChromeButtons,
 } from "../features/simulators/simulatorDisplay";
 import { useSimulatorList } from "../features/simulators/useSimulatorList";
+import { liveVideoUnavailableReason } from "../features/stream/liveVideoCapability";
 import { sendWebRtcControlMessage } from "../features/stream/streamWorkerClient";
 import type {
   StreamConfig,
@@ -174,6 +176,7 @@ clearLegacyVolatileUiState();
 
 interface StreamQualityResponse {
   ok?: boolean;
+  liveVideo?: LiveVideoCapability;
   quality?: {
     fps?: number;
     maxEdge?: number;
@@ -413,9 +416,9 @@ function simulatorDisplayReady(simulator: SimulatorMetadata): boolean {
   const display = simulator.privateDisplay;
   return Boolean(
     simulator.isBooted &&
-    display?.displayReady &&
-    display.displayWidth > 0 &&
-    display.displayHeight > 0,
+      display?.displayReady &&
+      display.displayWidth > 0 &&
+      display.displayHeight > 0,
   );
 }
 
@@ -625,6 +628,10 @@ export function AppShell({
   );
   const [streamConfigApplyKey, setStreamConfigApplyKey] = useState(0);
   const [streamConfigReady, setStreamConfigReady] = useState(false);
+  // Non-empty when the connected server build cannot encode live video (for
+  // example the Windows or Linux CLI). The stream stays paused and the reason
+  // is shown instead of retrying WebRTC offers that can never succeed.
+  const [liveVideoUnavailable, setLiveVideoUnavailable] = useState("");
   const [touchIndicators, setTouchIndicators] = useState<TouchIndicator[]>([]);
   const [selectedSimulatorState, setSelectedSimulatorState] =
     useState<SimulatorStateResponse | null>(null);
@@ -847,6 +854,7 @@ export function AppShell({
         if (requestId !== streamConfigRequestIdRef.current) {
           return;
         }
+        setLiveVideoUnavailable(liveVideoUnavailableReason(response.liveVideo));
         if (
           !options?.ignoreUserGrace &&
           Date.now() - streamConfigUserChangeAtRef.current <
@@ -930,7 +938,7 @@ export function AppShell({
     streamCanvasKey,
   } = useLiveStream({
     canvasElement: streamCanvasElement,
-    paused: !streamConfigReady,
+    paused: !streamConfigReady || Boolean(liveVideoUnavailable),
     remote: remoteStream,
     simulator: selectedSimulator,
     streamConfig: effectiveStreamConfig,
@@ -1035,8 +1043,8 @@ export function AppShell({
     selectedSimulator != null && shouldRenderNativeChrome(selectedSimulator);
   const deviceChromeToggleActive = Boolean(
     selectedSupportsChrome &&
-    deviceChromeVisible &&
-    !selectedChromeAssetsFailed,
+      deviceChromeVisible &&
+      !selectedChromeAssetsFailed,
   );
   const shouldRenderChrome = deviceChromeToggleActive;
   const viewportChromeProfile = shouldRenderChrome ? chromeProfile : null;
@@ -1127,8 +1135,8 @@ export function AppShell({
     : recordingOverlayLabel || captureStatus?.label || "";
   const captureOverlayBusy = Boolean(
     isInstallingApp ||
-    captureStatus?.busy ||
-    screenRecording?.phase === "stopping",
+      captureStatus?.busy ||
+      screenRecording?.phase === "stopping",
   );
   const autoViewportOffsetY =
     viewMode === "manual" ? 0 : -zoomDockReservedHeight / 2;
@@ -2153,13 +2161,15 @@ export function AppShell({
   const viewportStatusOverlayLabel =
     (providerDisconnected ? NOT_CONNECTED_MESSAGE : "") ||
     simulatorStatusOverlayLabel ||
+    liveVideoUnavailable ||
     streamStatusMessage ||
     (selectedSimulator ? visibleListError : "");
   const viewportHasStreamError = Boolean(
     providerDisconnected ||
-    streamStatus.state === "error" ||
-    visibleStreamError ||
-    (selectedSimulator && visibleListError),
+      liveVideoUnavailable ||
+      streamStatus.state === "error" ||
+      visibleStreamError ||
+      (selectedSimulator && visibleListError),
   );
   const deviceTransform = `translate(${pan.x}px, ${pan.y + autoViewportOffsetY}px) scale(${effectiveZoom})`;
   const chromeScreenRect = computeChromeScreenRect(
@@ -3812,6 +3822,7 @@ export function AppShell({
         recordingActive={screenRecording?.phase === "recording"}
         recordingStopping={screenRecording?.phase === "stopping"}
         remoteStream={remoteStream}
+        liveVideoUnavailableReason={liveVideoUnavailable}
         search={search}
         selectedSimulator={selectedSimulator}
         selectedSimulatorIdentifier={selectedSimulatorDetail}
@@ -3821,8 +3832,8 @@ export function AppShell({
         }}
         showBootButton={Boolean(
           selectedSimulator &&
-          !selectedSimulator.isBooted &&
-          !selectedSimulatorTransitionKind,
+            !selectedSimulator.isBooted &&
+            !selectedSimulatorTransitionKind,
         )}
         streamConfig={effectiveStreamConfig}
         streamTransport={streamTransport}
@@ -4325,8 +4336,8 @@ function normalizeMaxEdge(
 function isAndroidSimulator(simulator: SimulatorMetadata | null): boolean {
   return Boolean(
     simulator?.platform === "android-emulator" ||
-    simulator?.deviceTypeIdentifier === "android-emulator" ||
-    simulator?.udid.startsWith("android:"),
+      simulator?.deviceTypeIdentifier === "android-emulator" ||
+      simulator?.udid.startsWith("android:"),
   );
 }
 

--- a/packages/client/src/app/AppShell.tsx
+++ b/packages/client/src/app/AppShell.tsx
@@ -416,9 +416,9 @@ function simulatorDisplayReady(simulator: SimulatorMetadata): boolean {
   const display = simulator.privateDisplay;
   return Boolean(
     simulator.isBooted &&
-      display?.displayReady &&
-      display.displayWidth > 0 &&
-      display.displayHeight > 0,
+    display?.displayReady &&
+    display.displayWidth > 0 &&
+    display.displayHeight > 0,
   );
 }
 
@@ -1043,8 +1043,8 @@ export function AppShell({
     selectedSimulator != null && shouldRenderNativeChrome(selectedSimulator);
   const deviceChromeToggleActive = Boolean(
     selectedSupportsChrome &&
-      deviceChromeVisible &&
-      !selectedChromeAssetsFailed,
+    deviceChromeVisible &&
+    !selectedChromeAssetsFailed,
   );
   const shouldRenderChrome = deviceChromeToggleActive;
   const viewportChromeProfile = shouldRenderChrome ? chromeProfile : null;
@@ -1135,8 +1135,8 @@ export function AppShell({
     : recordingOverlayLabel || captureStatus?.label || "";
   const captureOverlayBusy = Boolean(
     isInstallingApp ||
-      captureStatus?.busy ||
-      screenRecording?.phase === "stopping",
+    captureStatus?.busy ||
+    screenRecording?.phase === "stopping",
   );
   const autoViewportOffsetY =
     viewMode === "manual" ? 0 : -zoomDockReservedHeight / 2;
@@ -2166,10 +2166,10 @@ export function AppShell({
     (selectedSimulator ? visibleListError : "");
   const viewportHasStreamError = Boolean(
     providerDisconnected ||
-      liveVideoUnavailable ||
-      streamStatus.state === "error" ||
-      visibleStreamError ||
-      (selectedSimulator && visibleListError),
+    liveVideoUnavailable ||
+    streamStatus.state === "error" ||
+    visibleStreamError ||
+    (selectedSimulator && visibleListError),
   );
   const deviceTransform = `translate(${pan.x}px, ${pan.y + autoViewportOffsetY}px) scale(${effectiveZoom})`;
   const chromeScreenRect = computeChromeScreenRect(
@@ -3832,8 +3832,8 @@ export function AppShell({
         }}
         showBootButton={Boolean(
           selectedSimulator &&
-            !selectedSimulator.isBooted &&
-            !selectedSimulatorTransitionKind,
+          !selectedSimulator.isBooted &&
+          !selectedSimulatorTransitionKind,
         )}
         streamConfig={effectiveStreamConfig}
         streamTransport={streamTransport}
@@ -4336,8 +4336,8 @@ function normalizeMaxEdge(
 function isAndroidSimulator(simulator: SimulatorMetadata | null): boolean {
   return Boolean(
     simulator?.platform === "android-emulator" ||
-      simulator?.deviceTypeIdentifier === "android-emulator" ||
-      simulator?.udid.startsWith("android:"),
+    simulator?.deviceTypeIdentifier === "android-emulator" ||
+    simulator?.udid.startsWith("android:"),
   );
 }
 

--- a/packages/client/src/features/simulators/SimulatorMenu.tsx
+++ b/packages/client/src/features/simulators/SimulatorMenu.tsx
@@ -49,6 +49,8 @@ interface SimulatorMenuProps {
   recordingActive: boolean;
   recordingStopping: boolean;
   remoteStream?: boolean;
+  /** Set when the server build cannot stream video; disables stream controls. */
+  liveVideoUnavailableReason?: string;
   selectedSimulator: SimulatorMetadata | null;
   showBootButton: boolean;
   showStopButton: boolean;
@@ -94,6 +96,7 @@ export function SimulatorMenu({
   recordingActive,
   recordingStopping,
   remoteStream = false,
+  liveVideoUnavailableReason = "",
   selectedSimulator,
   showBootButton,
   showStopButton,
@@ -123,6 +126,7 @@ export function SimulatorMenu({
   const canRotateSelectedSimulator =
     selectedSimulator != null &&
     !simulatorHasFixedOrientation(selectedSimulator);
+  const streamControlsDisabled = liveVideoUnavailableReason !== "";
   return (
     <div className="menu-wrap" ref={menuRef}>
       <button
@@ -146,13 +150,24 @@ export function SimulatorMenu({
                 <div className="menu-section-heading">
                   <span className="menu-section-title">Stream</span>
                   <span className="menu-section-meta">
-                    {formatStreamConfigSummary(streamConfig, streamTransport)}
+                    {streamControlsDisabled
+                      ? "Requires macOS"
+                      : formatStreamConfigSummary(
+                          streamConfig,
+                          streamTransport,
+                        )}
                   </span>
                 </div>
+                {streamControlsDisabled ? (
+                  <p className="menu-note" title={liveVideoUnavailableReason}>
+                    {LIVE_VIDEO_UNAVAILABLE_NOTE}
+                  </p>
+                ) : null}
                 <label className="menu-field">
                   <span className="menu-field-label">Transport</span>
                   <select
                     className="menu-select"
+                    disabled={streamControlsDisabled}
                     onChange={(event) =>
                       onStreamTransportChange(
                         event.currentTarget.value as StreamTransport,
@@ -171,8 +186,14 @@ export function SimulatorMenu({
                   {STREAM_ENCODERS.map((option) => (
                     <button
                       className={`menu-option ${streamConfig.encoder === option.value ? "active" : ""}`}
+                      disabled={streamControlsDisabled}
                       key={option.value}
                       onClick={() => onStreamEncoderChange(option.value)}
+                      title={
+                        streamControlsDisabled
+                          ? liveVideoUnavailableReason
+                          : undefined
+                      }
                       type="button"
                     >
                       {option.label}
@@ -183,6 +204,7 @@ export function SimulatorMenu({
                   {[...activeFpsOption, ...fpsOptions].map((option) => (
                     <button
                       className={`menu-option ${streamConfig.fps === option.value ? "active" : ""}`}
+                      disabled={streamControlsDisabled}
                       key={option.value}
                       onClick={() => onStreamFpsChange(option.value)}
                       type="button"
@@ -195,6 +217,7 @@ export function SimulatorMenu({
                   <span className="menu-field-label">Resolution</span>
                   <select
                     className="menu-select"
+                    disabled={streamControlsDisabled}
                     onChange={(event) =>
                       onStreamQualityChange(
                         event.currentTarget.value as StreamQualityPreset,
@@ -396,6 +419,9 @@ export function SimulatorMenu({
     </div>
   );
 }
+
+const LIVE_VIDEO_UNAVAILABLE_NOTE =
+  "Live H.264 streaming requires macOS. Device control still works from this host.";
 
 const STREAM_ENCODERS: Array<{ label: string; value: StreamEncoder }> = [
   { label: "Auto", value: "auto" },

--- a/packages/client/src/features/stream/liveVideoCapability.test.ts
+++ b/packages/client/src/features/stream/liveVideoCapability.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  LIVE_VIDEO_UNAVAILABLE_MESSAGE,
+  liveVideoUnavailableReason,
+} from "./liveVideoCapability";
+
+describe("liveVideoUnavailableReason", () => {
+  it("treats a missing capability block as supported", () => {
+    expect(liveVideoUnavailableReason(undefined)).toBe("");
+    expect(liveVideoUnavailableReason(null)).toBe("");
+  });
+
+  it("returns nothing when the server supports live video", () => {
+    expect(
+      liveVideoUnavailableReason({ supported: true, requires: "macos" }),
+    ).toBe("");
+  });
+
+  it("prefers the server-provided reason", () => {
+    expect(
+      liveVideoUnavailableReason({
+        supported: false,
+        requires: "macos",
+        reason: "  Live H.264 video streaming requires macOS.  ",
+      }),
+    ).toBe("Live H.264 video streaming requires macOS.");
+  });
+
+  it("falls back to the client message when the reason is blank", () => {
+    expect(
+      liveVideoUnavailableReason({ supported: false, reason: "   " }),
+    ).toBe(LIVE_VIDEO_UNAVAILABLE_MESSAGE);
+    expect(liveVideoUnavailableReason({ supported: false })).toBe(
+      LIVE_VIDEO_UNAVAILABLE_MESSAGE,
+    );
+  });
+});

--- a/packages/client/src/features/stream/liveVideoCapability.ts
+++ b/packages/client/src/features/stream/liveVideoCapability.ts
@@ -1,14 +1,16 @@
 import type { LiveVideoCapability } from "../../api/types";
 
 export const LIVE_VIDEO_UNAVAILABLE_MESSAGE =
-  "Live H.264 video streaming requires macOS. This SimDeck build can manage devices but cannot stream video to the browser.";
+  "This SimDeck server cannot stream live video to the browser.";
 
 /**
  * Returns the user-facing reason live video is unavailable on the connected
  * server, or an empty string when the server can stream (or did not say).
  *
- * Servers older than the capability field omit `liveVideo`; treat that as
- * supported so the client keeps attempting WebRTC against macOS hosts.
+ * Every shipped build streams (macOS through the native bridge, Windows and
+ * Linux through OpenH264), so this only trips for a server that explicitly
+ * reports `supported: false`. Servers older than the capability field omit
+ * `liveVideo`; treat that as supported so the client keeps attempting WebRTC.
  */
 export function liveVideoUnavailableReason(
   capability: LiveVideoCapability | null | undefined,

--- a/packages/client/src/features/stream/liveVideoCapability.ts
+++ b/packages/client/src/features/stream/liveVideoCapability.ts
@@ -1,0 +1,21 @@
+import type { LiveVideoCapability } from "../../api/types";
+
+export const LIVE_VIDEO_UNAVAILABLE_MESSAGE =
+  "Live H.264 video streaming requires macOS. This SimDeck build can manage devices but cannot stream video to the browser.";
+
+/**
+ * Returns the user-facing reason live video is unavailable on the connected
+ * server, or an empty string when the server can stream (or did not say).
+ *
+ * Servers older than the capability field omit `liveVideo`; treat that as
+ * supported so the client keeps attempting WebRTC against macOS hosts.
+ */
+export function liveVideoUnavailableReason(
+  capability: LiveVideoCapability | null | undefined,
+): string {
+  if (!capability || capability.supported !== false) {
+    return "";
+  }
+  const reason = capability.reason?.trim();
+  return reason || LIVE_VIDEO_UNAVAILABLE_MESSAGE;
+}

--- a/packages/client/src/features/stream/streamWorkerClient.test.ts
+++ b/packages/client/src/features/stream/streamWorkerClient.test.ts
@@ -4,7 +4,62 @@ import {
   buildStreamTarget,
   initialStreamBackend,
   preferredStreamBackend,
+  responseErrorMessage,
 } from "./streamWorkerClient";
+
+function fakeResponse(
+  status: number,
+  body: string,
+  contentType?: string,
+): Pick<Response, "headers" | "status" | "text"> {
+  return {
+    headers: new Headers(contentType ? { "content-type": contentType } : {}),
+    status,
+    text: () => Promise.resolve(body),
+  };
+}
+
+describe("responseErrorMessage", () => {
+  it("unwraps the server error field from JSON bodies", async () => {
+    const message = await responseErrorMessage(
+      fakeResponse(
+        501,
+        '{"error":"Live H.264 video streaming requires macOS."}',
+        "application/json",
+      ),
+    );
+
+    expect(message).toBe("Live H.264 video streaming requires macOS.");
+  });
+
+  it("unwraps JSON error bodies even without a content type", async () => {
+    const message = await responseErrorMessage(
+      fakeResponse(500, '{"error":"encoder failed"}'),
+    );
+
+    expect(message).toBe("encoder failed");
+  });
+
+  it("returns plain text bodies unchanged", async () => {
+    expect(await responseErrorMessage(fakeResponse(502, "Bad gateway"))).toBe(
+      "Bad gateway",
+    );
+  });
+
+  it("falls back to the status when the body is empty or malformed", async () => {
+    expect(await responseErrorMessage(fakeResponse(503, ""))).toBe(
+      "Request failed with status 503",
+    );
+    expect(await responseErrorMessage(fakeResponse(500, "{not json"))).toBe(
+      "{not json",
+    );
+    expect(
+      await responseErrorMessage(
+        fakeResponse(500, '{"error":""}', "application/json"),
+      ),
+    ).toBe('{"error":""}');
+  });
+});
 
 describe("streamWorkerClient", () => {
   it("ignores removed legacy stream transport preferences", () => {

--- a/packages/client/src/features/stream/streamWorkerClient.ts
+++ b/packages/client/src/features/stream/streamWorkerClient.ts
@@ -1303,6 +1303,33 @@ function streamErrorIsServerUnreachable(message: string): boolean {
   );
 }
 
+/**
+ * Extracts a human-readable message from a failed SimDeck API response. The
+ * server answers errors with `{"error": "..."}`; surfacing that field instead
+ * of the raw JSON keeps overlays like the stream status readable.
+ */
+export async function responseErrorMessage(
+  response: Pick<Response, "headers" | "status" | "text">,
+): Promise<string> {
+  const fallback = `Request failed with status ${response.status}`;
+  const text = (await response.text().catch(() => "")).trim();
+  if (!text) {
+    return fallback;
+  }
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json") || text.startsWith("{")) {
+    try {
+      const body = JSON.parse(text) as { error?: unknown };
+      if (typeof body.error === "string" && body.error.trim()) {
+        return body.error.trim();
+      }
+    } catch {
+      // Fall through and show the raw body.
+    }
+  }
+  return text;
+}
+
 async function postWebRtcOfferWithAuthRetry(
   target: StreamConnectTarget,
   localDescription: RTCSessionDescription,
@@ -1310,17 +1337,17 @@ async function postWebRtcOfferWithAuthRetry(
   const response = await postWebRtcOffer(target, localDescription);
   if (response.status !== 401) {
     if (!response.ok) {
-      throw new Error(await response.text());
+      throw new Error(await responseErrorMessage(response));
     }
     return response;
   }
   if (target.remote) {
-    throw new Error(await response.text());
+    throw new Error(await responseErrorMessage(response));
   }
   await fetchHealth();
   const retry = await postWebRtcOffer(target, localDescription);
   if (!retry.ok) {
-    throw new Error(await retry.text());
+    throw new Error(await responseErrorMessage(retry));
   }
   return retry;
 }
@@ -1335,17 +1362,17 @@ async function postStreamConfigWithAuthRetry(
   const response = await postStreamConfig(config);
   if (response.status !== 401) {
     if (!response.ok) {
-      throw new Error(await response.text());
+      throw new Error(await responseErrorMessage(response));
     }
     return;
   }
   if (options.remote) {
-    throw new Error(await response.text());
+    throw new Error(await responseErrorMessage(response));
   }
   await fetchHealth();
   const retry = await postStreamConfig(config);
   if (!retry.ok) {
-    throw new Error(await retry.text());
+    throw new Error(await responseErrorMessage(retry));
   }
 }
 

--- a/packages/client/src/features/toolbar/Toolbar.tsx
+++ b/packages/client/src/features/toolbar/Toolbar.tsx
@@ -70,6 +70,7 @@ interface ToolbarProps {
   recordingActive: boolean;
   recordingStopping: boolean;
   remoteStream?: boolean;
+  liveVideoUnavailableReason?: string;
   search: string;
   selectedSimulator: SimulatorMetadata | null;
   selectedSimulatorIdentifier: string;
@@ -137,6 +138,7 @@ export function Toolbar({
   recordingActive,
   recordingStopping,
   remoteStream = false,
+  liveVideoUnavailableReason = "",
   search,
   selectedSimulator,
   selectedSimulatorIdentifier,
@@ -216,6 +218,7 @@ export function Toolbar({
           recordingActive={recordingActive}
           recordingStopping={recordingStopping}
           remoteStream={remoteStream}
+          liveVideoUnavailableReason={liveVideoUnavailableReason}
           selectedSimulator={selectedSimulator}
           showBootButton={showBootButton}
           showStopButton={showStopButton}

--- a/packages/client/src/styles/components.css
+++ b/packages/client/src/styles/components.css
@@ -464,6 +464,13 @@
   opacity: 0.55;
 }
 
+.menu-note {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
 .menu-toggle {
   display: flex;
   align-items: center;

--- a/packages/server/Cargo.lock
+++ b/packages/server/Cargo.lock
@@ -400,6 +400,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -1273,6 +1275,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.2",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1425,6 +1437,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "nasm-rs"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "706bf8a5e8c8ddb99128c3291d31bd21f4bcde17f0f4c20ec678d85c74faa149"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1516,6 +1537,27 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openh264"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc9071a0b5f9c501ddd01066c2600d922cc799dc450a52975222bcda7755a08"
+dependencies = [
+ "openh264-sys2",
+ "wide",
+]
+
+[[package]]
+name = "openh264-sys2"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ada29a4cadc13d4d326737af87c13e224210d7d99fe47594e9f3f9b0102fd70"
+dependencies = [
+ "cc",
+ "nasm-rs",
+ "walkdir",
+]
 
 [[package]]
 name = "p256"
@@ -2130,6 +2172,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "safe_arch"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42c6efa15875e6ecb39ca61fb0b0c1a40b84fac5a5ffe71eef7d1000c8eb3f5f"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2305,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "simdeck-server"
-version = "0.1.34"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -2317,6 +2377,7 @@ dependencies = [
  "hex",
  "http",
  "libc",
+ "openh264",
  "plist",
  "prost",
  "protoc-bin-vendored",
@@ -2956,6 +3017,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3277,6 +3348,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wide"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf05ca94c9fba0c51316899caa1d1e74a064fc310a5efa7375e614343d415be"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3291,6 +3372,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/packages/server/Cargo.toml
+++ b/packages/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simdeck-server"
-version = "0.1.34"
+version = "0.2.0"
 edition = "2021"
 build = "build.rs"
 

--- a/packages/server/Cargo.toml
+++ b/packages/server/Cargo.toml
@@ -32,6 +32,12 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 webrtc = "0.12"
 
+# macOS encodes through the native bridge (VideoToolbox/x264). Other targets
+# encode Android emulator frames with OpenH264 compiled from source, see
+# src/transport/software_h264.rs.
+[target.'cfg(not(target_os = "macos"))'.dependencies]
+openh264 = { version = "0.9", default-features = false, features = ["source"] }
+
 [build-dependencies]
 cc = "1.2"
 protoc-bin-vendored = "3"

--- a/packages/server/native_stubs.c
+++ b/packages/server/native_stubs.c
@@ -51,13 +51,14 @@ static void xcw_set_error(char **error_message, const char *message) {
   }
 }
 
-/* Shared by every H.264 encoder stub. Keep the wording aligned with
- * packages/server/src/platform.rs, which reports the same limitation through
- * the CLI banner and the HTTP API. */
+/* Shared by every H.264 encoder stub. Android emulator streams never reach
+ * these on non-macOS builds: packages/server/src/transport/software_h264.rs
+ * encodes them with OpenH264 instead. Keep the wording aligned with
+ * packages/server/src/platform.rs. */
 static const char XCW_LIVE_VIDEO_UNSUPPORTED_MESSAGE[] =
-    "Live H.264 video streaming requires macOS. This SimDeck build does not "
-    "include the native H.264 encoder used for iOS simulator and Android "
-    "emulator streams.";
+    "The native H.264 encoder is only available in the macOS simulator "
+    "bridge. iOS simulators require macOS; Android emulators on this build "
+    "use the built-in OpenH264 encoder.";
 
 static bool xcw_unsupported(char **error_message) {
   xcw_set_error(error_message,

--- a/packages/server/native_stubs.c
+++ b/packages/server/native_stubs.c
@@ -51,6 +51,14 @@ static void xcw_set_error(char **error_message, const char *message) {
   }
 }
 
+/* Shared by every H.264 encoder stub. Keep the wording aligned with
+ * packages/server/src/platform.rs, which reports the same limitation through
+ * the CLI banner and the HTTP API. */
+static const char XCW_LIVE_VIDEO_UNSUPPORTED_MESSAGE[] =
+    "Live H.264 video streaming requires macOS. This SimDeck build does not "
+    "include the native H.264 encoder used for iOS simulator and Android "
+    "emulator streams.";
+
 static bool xcw_unsupported(char **error_message) {
   xcw_set_error(error_message,
                 "iOS simulator native bridge is only available on macOS.");
@@ -573,8 +581,7 @@ void *xcw_native_h264_encoder_create_with_video_codec(
   (void)callback;
   (void)user_data;
   (void)video_codec;
-  xcw_set_error(error_message,
-                "H.264 encoding is only available in the macOS native bridge.");
+  xcw_set_error(error_message, XCW_LIVE_VIDEO_UNSUPPORTED_MESSAGE);
   return NULL;
 }
 
@@ -597,8 +604,7 @@ bool xcw_native_h264_encoder_encode_rgba(void *handle, const uint8_t *rgba,
   (void)width;
   (void)height;
   (void)timestamp_us;
-  xcw_set_error(error_message,
-                "H.264 encoding is only available in the macOS native bridge.");
+  xcw_set_error(error_message, XCW_LIVE_VIDEO_UNSUPPORTED_MESSAGE);
   return false;
 }
 
@@ -613,8 +619,7 @@ bool xcw_native_h264_encoder_encode_bgra(void *handle, const uint8_t *bgra,
   (void)width;
   (void)height;
   (void)timestamp_us;
-  xcw_set_error(error_message,
-                "H.264 encoding is only available in the macOS native bridge.");
+  xcw_set_error(error_message, XCW_LIVE_VIDEO_UNSUPPORTED_MESSAGE);
   return false;
 }
 
@@ -622,8 +627,7 @@ void xcw_native_h264_encoder_request_keyframe(void *handle) { (void)handle; }
 
 char *xcw_native_h264_encoder_stats(void *handle, char **error_message) {
   (void)handle;
-  xcw_set_error(error_message,
-                "H.264 encoding is only available in the macOS native bridge.");
+  xcw_set_error(error_message, XCW_LIVE_VIDEO_UNSUPPORTED_MESSAGE);
   return NULL;
 }
 

--- a/packages/server/src/android.rs
+++ b/packages/server/src/android.rs
@@ -1981,20 +1981,7 @@ fn java_home() -> Option<OsString> {
 }
 
 fn home_dir() -> PathBuf {
-    env::var_os("HOME")
-        .or_else(|| env::var_os("USERPROFILE"))
-        .or_else(
-            || match (env::var_os("HOMEDRIVE"), env::var_os("HOMEPATH")) {
-                (Some(drive), Some(path)) => {
-                    let mut combined = PathBuf::from(drive);
-                    combined.push(path);
-                    Some(combined.into_os_string())
-                }
-                _ => None,
-            },
-        )
-        .map(PathBuf::from)
-        .unwrap_or_else(|| Path::new("/").to_path_buf())
+    crate::platform::user_home_dir().unwrap_or_else(|| Path::new("/").to_path_buf())
 }
 
 fn extract_xml(output: &str) -> &str {

--- a/packages/server/src/android.rs
+++ b/packages/server/src/android.rs
@@ -135,6 +135,7 @@ pub struct AndroidSharedVideoFrame {
 
 pub struct AndroidSharedVideoFrameStream {
     handle: String,
+    #[cfg_attr(not(unix), allow(dead_code))]
     fd: RawFd,
     ptr: *mut u8,
     length: usize,
@@ -1249,6 +1250,9 @@ fn round_android_h264_dimension(value: u32) -> u32 {
     }
 }
 
+// On non-unix hosts the early `return` is the whole body, which clippy reads
+// as needless; keeping one function body for both platforms is clearer.
+#[allow(clippy::needless_return)]
 fn open_android_shared_video_memory(handle: &str) -> Result<(RawFd, *mut u8, usize), AppError> {
     #[cfg(not(unix))]
     {

--- a/packages/server/src/api/routes.rs
+++ b/packages/server/src/api/routes.rs
@@ -992,6 +992,8 @@ async fn health(State(state): State<AppState>) -> Json<Value> {
         "serverKind": state.config.server_kind.as_str(),
         "timestamp": SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or(Duration::ZERO).as_secs_f64(),
         "videoCodec": video_codec,
+        "hostOs": crate::platform::host_os(),
+        "liveVideo": crate::platform::live_video_capability_value(),
         "androidGpu": active_android_gpu(),
         "lowLatency": state.config.low_latency,
         "realtimeStream": crate::transport::webrtc::realtime_stream_enabled(),
@@ -1480,6 +1482,7 @@ fn stream_quality_response(config: &Config) -> Value {
         "ok": true,
         "quality": stream_quality_state_value(&quality),
         "videoCodec": video_codec,
+        "liveVideo": crate::platform::live_video_capability_value(),
         "profiles": STREAM_QUALITY_PROFILES
             .iter()
             .filter(|profile| VISIBLE_STREAM_QUALITY_PROFILE_IDS.contains(&profile.id))
@@ -5873,6 +5876,24 @@ mod tests {
             logical_screen_size_from_display_pixels(1668.0, 2388.0),
             Some((834.0, 1194.0))
         );
+    }
+
+    #[test]
+    fn video_codec_modes_normalize_on_every_platform() {
+        assert_eq!(normalize_video_codec("auto"), Some("auto"));
+        assert_eq!(normalize_video_codec(" Hardware "), Some("hardware"));
+        assert_eq!(normalize_video_codec("software"), Some("software"));
+        assert_eq!(normalize_video_codec("h265"), None);
+    }
+
+    #[test]
+    fn stream_quality_state_reports_live_video_capability() {
+        let value = crate::platform::live_video_capability_value();
+        assert_eq!(
+            value["supported"].as_bool(),
+            Some(crate::platform::live_video_supported())
+        );
+        assert_eq!(value["requires"].as_str(), Some("macos"));
     }
 
     #[test]

--- a/packages/server/src/api/routes.rs
+++ b/packages/server/src/api/routes.rs
@@ -5880,10 +5880,10 @@ mod tests {
 
     #[test]
     fn video_codec_modes_normalize_on_every_platform() {
-        assert_eq!(normalize_video_codec("auto"), Some("auto"));
-        assert_eq!(normalize_video_codec(" Hardware "), Some("hardware"));
-        assert_eq!(normalize_video_codec("software"), Some("software"));
-        assert_eq!(normalize_video_codec("h265"), None);
+        assert_eq!(super::normalize_video_codec("auto"), Some("auto"));
+        assert_eq!(super::normalize_video_codec(" Hardware "), Some("hardware"));
+        assert_eq!(super::normalize_video_codec("software"), Some("software"));
+        assert_eq!(super::normalize_video_codec("h265"), None);
     }
 
     #[test]

--- a/packages/server/src/api/routes.rs
+++ b/packages/server/src/api/routes.rs
@@ -5889,11 +5889,16 @@ mod tests {
     #[test]
     fn stream_quality_state_reports_live_video_capability() {
         let value = crate::platform::live_video_capability_value();
+        assert_eq!(value["supported"].as_bool(), Some(true));
+        assert_eq!(value["androidEmulator"].as_bool(), Some(true));
         assert_eq!(
-            value["supported"].as_bool(),
-            Some(crate::platform::live_video_supported())
+            value["iosSimulator"].as_bool(),
+            Some(crate::platform::ios_simulator_supported())
         );
-        assert_eq!(value["requires"].as_str(), Some("macos"));
+        assert_eq!(
+            value["encoder"].as_str(),
+            Some(crate::platform::live_video_encoder())
+        );
     }
 
     #[test]

--- a/packages/server/src/config.rs
+++ b/packages/server/src/config.rs
@@ -83,9 +83,7 @@ pub fn user_config_path() -> PathBuf {
 }
 
 pub fn simdeck_user_state_dir() -> PathBuf {
-    std::env::var_os("HOME")
-        .filter(|value| !value.is_empty())
-        .map(PathBuf::from)
+    crate::platform::user_home_dir()
         .map(|home| home.join(".simdeck"))
         .unwrap_or_else(|| std::env::temp_dir().join("simdeck"))
 }

--- a/packages/server/src/config.rs
+++ b/packages/server/src/config.rs
@@ -226,6 +226,7 @@ fn io_platform_uuid() -> Option<String> {
     parse_io_platform_uuid(&String::from_utf8_lossy(&output.stdout))
 }
 
+#[cfg(any(target_os = "macos", test))]
 fn parse_io_platform_uuid(output: &str) -> Option<String> {
     output.lines().find_map(|line| {
         let (_, value) = line.split_once("\"IOPlatformUUID\"")?;

--- a/packages/server/src/error.rs
+++ b/packages/server/src/error.rs
@@ -14,6 +14,10 @@ pub enum AppError {
     Native(String),
     #[error("{0}")]
     Internal(String),
+    /// The feature exists in SimDeck but this build cannot provide it on the
+    /// current host platform.
+    #[error("{0}")]
+    Unsupported(String),
 }
 
 #[derive(Serialize)]
@@ -37,6 +41,10 @@ impl AppError {
     pub fn internal(message: impl Into<String>) -> Self {
         Self::Internal(message.into())
     }
+
+    pub fn unsupported(message: impl Into<String>) -> Self {
+        Self::Unsupported(message.into())
+    }
 }
 
 impl IntoResponse for AppError {
@@ -45,6 +53,7 @@ impl IntoResponse for AppError {
             Self::BadRequest(_) => StatusCode::BAD_REQUEST,
             Self::NotFound(_) => StatusCode::NOT_FOUND,
             Self::Native(_) | Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::Unsupported(_) => StatusCode::NOT_IMPLEMENTED,
         };
         let message = self.to_string();
         (status, Json(ErrorBody { error: &message })).into_response()

--- a/packages/server/src/inspector.rs
+++ b/packages/server/src/inspector.rs
@@ -540,8 +540,7 @@ impl Drop for RegistryFileLock {
 fn inspector_registry_path() -> PathBuf {
     env::var_os("SIMDECK_INSPECTOR_REGISTRY_PATH")
         .map(PathBuf::from)
-        .or_else(|| env::var_os("HOME").map(|home| PathBuf::from(home).join(".simdeck")))
-        .unwrap_or_else(|| env::temp_dir().join("simdeck"))
+        .unwrap_or_else(crate::config::simdeck_user_state_dir)
         .join("inspectors.json")
 }
 

--- a/packages/server/src/logs.rs
+++ b/packages/server/src/logs.rs
@@ -79,7 +79,7 @@ impl LogRegistry {
         }
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, unix))]
     fn new_for_tests(spawn_log_stream: LogStreamSpawner) -> Self {
         Self {
             streams: Arc::new(Mutex::new(HashMap::new())),
@@ -240,8 +240,9 @@ fn non_empty_string_field(payload: &Value, key: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{run_start_if_idle, LogRegistry, LogStreamPhase, LogStreamSpawner, LogStreamState};
+    use super::{run_start_if_idle, LogStreamPhase, LogStreamState};
     use crate::error::AppError;
+    #[cfg(unix)]
     use crate::native::bridge::LogFilters;
     #[cfg(unix)]
     use std::process::Stdio;
@@ -250,7 +251,7 @@ mod tests {
     #[cfg(unix)]
     use tokio::process::Command;
     use tokio::sync::Barrier;
-    use tokio::time::{sleep, Duration, Instant};
+    use tokio::time::{sleep, Duration};
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn concurrent_start_only_runs_one_spawn_action() {
@@ -316,7 +317,7 @@ mod tests {
     async fn ensure_started_only_spawns_one_process_and_streams_logs() {
         let calls = Arc::new(AtomicUsize::new(0));
         let barrier = Arc::new(Barrier::new(17));
-        let spawner: LogStreamSpawner = Arc::new({
+        let spawner: super::LogStreamSpawner = Arc::new({
             let calls = calls.clone();
             move |_| {
                 calls.fetch_add(1, Ordering::SeqCst);
@@ -335,7 +336,7 @@ mod tests {
                     })
             }
         });
-        let registry = LogRegistry::new_for_tests(spawner);
+        let registry = super::LogRegistry::new_for_tests(spawner);
 
         let mut handles = Vec::new();
         for _ in 0..16 {
@@ -356,7 +357,7 @@ mod tests {
         assert_eq!(calls.load(Ordering::SeqCst), 1);
 
         let filters = LogFilters::new(Vec::new(), Vec::new(), String::new());
-        let deadline = Instant::now() + Duration::from_secs(1);
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(1);
         loop {
             let entries = registry.snapshot("booted-sim", &filters, 10).await;
             if let Some(entry) = entries.last() {
@@ -367,7 +368,7 @@ mod tests {
             }
 
             assert!(
-                Instant::now() < deadline,
+                tokio::time::Instant::now() < deadline,
                 "timed out waiting for streamed log entry"
             );
             sleep(Duration::from_millis(10)).await;
@@ -378,7 +379,7 @@ mod tests {
     #[tokio::test]
     async fn ensure_started_can_retry_after_spawn_failure() {
         let calls = Arc::new(AtomicUsize::new(0));
-        let spawner: LogStreamSpawner = Arc::new({
+        let spawner: super::LogStreamSpawner = Arc::new({
             let calls = calls.clone();
             move |_| {
                 let call = calls.fetch_add(1, Ordering::SeqCst);
@@ -396,7 +397,7 @@ mod tests {
                     })
             }
         });
-        let registry = LogRegistry::new_for_tests(spawner);
+        let registry = super::LogRegistry::new_for_tests(spawner);
 
         let error = registry.ensure_started("booted-sim").await.unwrap_err();
         assert_eq!(error.to_string(), "failed to spawn");

--- a/packages/server/src/logs.rs
+++ b/packages/server/src/logs.rs
@@ -243,9 +243,11 @@ mod tests {
     use super::{run_start_if_idle, LogRegistry, LogStreamPhase, LogStreamSpawner, LogStreamState};
     use crate::error::AppError;
     use crate::native::bridge::LogFilters;
+    #[cfg(unix)]
     use std::process::Stdio;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
+    #[cfg(unix)]
     use tokio::process::Command;
     use tokio::sync::Barrier;
     use tokio::time::{sleep, Duration, Instant};
@@ -309,6 +311,7 @@ mod tests {
         assert_eq!(state.status.lock().await.phase, LogStreamPhase::Running);
     }
 
+    #[cfg(unix)]
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn ensure_started_only_spawns_one_process_and_streams_logs() {
         let calls = Arc::new(AtomicUsize::new(0));
@@ -371,6 +374,7 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn ensure_started_can_retry_after_spawn_failure() {
         let calls = Arc::new(AtomicUsize::new(0));

--- a/packages/server/src/main.rs
+++ b/packages/server/src/main.rs
@@ -6516,15 +6516,14 @@ mod tests {
         project_service_credentials_from_metadata, read_project_service_credentials_from_path,
         removed_service_process_name, render_agent_accessibility_tree, render_qr_code,
         run_maestro_command, server_health_watchdog_should_restart, service_addresses,
-        service_matches_launch_options, service_post_error_is_retryable,
-        service_url_is_healthy, simdeck_open_link,
-        simdeck_pair_url, studio_service_restart_args, workspace_service_process_is_current,
-        write_project_service_credentials_to_path, AndroidGpuMode, Cli, Command, ElementSelector,
-        NoCommandAction, PairingAddress, ProjectServiceCredentials, ServiceCommand,
-        ServiceLaunchOptions, ServiceMetadata, StreamQualityProfileArg, StudioExposeOptions,
-        TapCommandTarget, VideoCodecMode, WorkspaceServiceProcess, YamlValue,
-        DEFAULT_LOCAL_STREAM_QUALITY_PROFILE, SERVER_HEALTH_WATCHDOG_FAILURE_THRESHOLD,
-        SERVER_HEALTH_WATCHDOG_HTTP_FAILURE_THRESHOLD,
+        service_matches_launch_options, service_post_error_is_retryable, service_url_is_healthy,
+        simdeck_open_link, simdeck_pair_url, studio_service_restart_args,
+        workspace_service_process_is_current, write_project_service_credentials_to_path,
+        AndroidGpuMode, Cli, Command, ElementSelector, NoCommandAction, PairingAddress,
+        ProjectServiceCredentials, ServiceCommand, ServiceLaunchOptions, ServiceMetadata,
+        StreamQualityProfileArg, StudioExposeOptions, TapCommandTarget, VideoCodecMode,
+        WorkspaceServiceProcess, YamlValue, DEFAULT_LOCAL_STREAM_QUALITY_PROFILE,
+        SERVER_HEALTH_WATCHDOG_FAILURE_THRESHOLD, SERVER_HEALTH_WATCHDOG_HTTP_FAILURE_THRESHOLD,
     };
     use clap::Parser;
     use std::collections::HashMap;

--- a/packages/server/src/main.rs
+++ b/packages/server/src/main.rs
@@ -2048,7 +2048,7 @@ fn print_service_metadata_result(
     if let Some(pairing_code) = metadata.pairing_code.as_deref() {
         println!("{:>12}   {}", "Pair:", format_pairing_code(pairing_code));
     }
-    if !platform::live_video_supported() {
+    if !platform::ios_simulator_supported() {
         println!(
             "{:>12}   {}",
             "Live video:",

--- a/packages/server/src/main.rs
+++ b/packages/server/src/main.rs
@@ -22,6 +22,8 @@ mod transport;
 mod webkit;
 
 pub(crate) mod android_emulation_control {
+    // Generated tonic client returns `tonic::Status` errors by value.
+    #![allow(clippy::result_large_err)]
     tonic::include_proto!("android.emulation.control");
 }
 

--- a/packages/server/src/main.rs
+++ b/packages/server/src/main.rs
@@ -5554,8 +5554,13 @@ mod windows_handle {
 
     #[link(name = "kernel32")]
     extern "system" {
-        fn GetHandleInformation(handle: usize, flags: *mut u32) -> i32;
         fn SetHandleInformation(handle: usize, mask: u32, flags: u32) -> i32;
+    }
+
+    #[cfg(test)]
+    #[link(name = "kernel32")]
+    extern "system" {
+        fn GetHandleInformation(handle: usize, flags: *mut u32) -> i32;
     }
 
     pub(crate) fn clear_inherit_flag(handle: usize) -> io::Result<()> {
@@ -7818,7 +7823,10 @@ swipe:
         let port = listener.local_addr().unwrap().port();
         let timeout = std::time::Duration::from_millis(300);
         let started = std::time::Instant::now();
-        assert!(!service_url_is_healthy(&format!("http://127.0.0.1:{port}"), timeout));
+        assert!(!service_url_is_healthy(
+            &format!("http://127.0.0.1:{port}"),
+            timeout
+        ));
         assert!(started.elapsed() < std::time::Duration::from_secs(5));
         drop(listener);
     }
@@ -7829,7 +7837,10 @@ swipe:
         let port = listener.local_addr().unwrap().port();
         drop(listener);
         let timeout = std::time::Duration::from_millis(300);
-        assert!(!service_url_is_healthy(&format!("http://127.0.0.1:{port}"), timeout));
+        assert!(!service_url_is_healthy(
+            &format!("http://127.0.0.1:{port}"),
+            timeout
+        ));
         assert!(!service_url_is_healthy("https://127.0.0.1:4310", timeout));
         assert!(!service_url_is_healthy("nonsense", timeout));
     }

--- a/packages/server/src/main.rs
+++ b/packages/server/src/main.rs
@@ -13,6 +13,7 @@ mod logs;
 mod metrics;
 mod native;
 mod performance;
+mod platform;
 mod service;
 mod simulators;
 mod static_files;
@@ -2046,6 +2047,13 @@ fn print_service_metadata_result(
     }
     if let Some(pairing_code) = metadata.pairing_code.as_deref() {
         println!("{:>12}   {}", "Pair:", format_pairing_code(pairing_code));
+    }
+    if !platform::live_video_supported() {
+        println!(
+            "{:>12}   {}",
+            "Live video:",
+            platform::live_video_cli_note()
+        );
     }
     Ok(())
 }

--- a/packages/server/src/main.rs
+++ b/packages/server/src/main.rs
@@ -110,7 +110,7 @@ use std::env;
 use std::fs;
 use std::hash::{Hash, Hasher};
 use std::io::{self, IsTerminal, Read, Write};
-use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener, UdpSocket};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener, ToSocketAddrs, UdpSocket};
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
@@ -131,6 +131,13 @@ const SERVER_HEALTH_WATCHDOG_PROBE_TIMEOUT: Duration = Duration::from_secs(3);
 const SERVER_HEALTH_WATCHDOG_STALE_HEARTBEAT: Duration = Duration::from_secs(60);
 const SERVER_HEALTH_WATCHDOG_FAILURE_THRESHOLD: usize = 12;
 const SERVER_HEALTH_WATCHDOG_HTTP_FAILURE_THRESHOLD: usize = 3;
+/// Upper bound for one CLI probe of an existing service's `/api/health`.
+///
+/// A port can stay open without anyone answering it: on Windows a child
+/// process such as the adb server inherits the listening socket and keeps it
+/// alive after the service exits. The CLI must not wait the full HTTP client
+/// read timeout for such a port before starting a fresh service.
+const SERVICE_HEALTH_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 const SIMULATOR_SESSION_IDLE_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 const SIMULATOR_SESSION_IDLE_REAPER_INITIAL_DELAY: Duration = Duration::from_secs(60);
 const SIMULATOR_SESSION_IDLE_REAPER_INTERVAL: Duration = Duration::from_secs(30);
@@ -1781,6 +1788,10 @@ struct WorkspaceServiceProcess {
 }
 
 fn service_run_processes() -> anyhow::Result<Vec<ServiceRunProcess>> {
+    if cfg!(windows) {
+        // No `ps`; Windows services are tracked through their metadata files.
+        return Ok(Vec::new());
+    }
     let output = ProcessCommand::new("ps")
         .args(["-axo", "pgid=,command="])
         .output()
@@ -1917,6 +1928,7 @@ fn terminate_process_group(pid: u32, timeout: Duration) {
     terminate_process_group_with_kill_timeout(pid, timeout, Duration::from_secs(2));
 }
 
+#[cfg(not(windows))]
 fn terminate_process_group_with_kill_timeout(pid: u32, timeout: Duration, kill_timeout: Duration) {
     signal_process_group(pid, "TERM");
     signal_process(pid, "TERM");
@@ -1928,6 +1940,20 @@ fn terminate_process_group_with_kill_timeout(pid: u32, timeout: Duration, kill_t
     let _ = wait_for_process_exit(pid, kill_timeout);
 }
 
+/// Windows has no process groups or signals; `taskkill /T` ends the service
+/// together with the emulator and adb children it started, matching the
+/// process-group kill on Unix.
+#[cfg(windows)]
+fn terminate_process_group_with_kill_timeout(pid: u32, timeout: Duration, kill_timeout: Duration) {
+    let _ = ProcessCommand::new("taskkill")
+        .args(["/PID", &pid.to_string(), "/T", "/F"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+    let _ = wait_for_process_exit(pid, timeout + kill_timeout);
+}
+
+#[cfg(not(windows))]
 fn signal_process(pid: u32, signal: &str) {
     let _ = ProcessCommand::new("kill")
         .args([format!("-{signal}"), pid.to_string()])
@@ -1936,6 +1962,7 @@ fn signal_process(pid: u32, signal: &str) {
         .status();
 }
 
+#[cfg(not(windows))]
 fn signal_process_group(pgid: u32, signal: &str) {
     let _ = ProcessCommand::new("kill")
         .arg(format!("-{signal}"))
@@ -1957,6 +1984,7 @@ fn wait_for_process_exit(pid: u32, timeout: Duration) -> bool {
     !process_exists(pid)
 }
 
+#[cfg(not(windows))]
 fn process_exists(pid: u32) -> bool {
     ProcessCommand::new("kill")
         .arg("-0")
@@ -1965,6 +1993,44 @@ fn process_exists(pid: u32) -> bool {
         .stderr(Stdio::null())
         .status()
         .is_ok_and(|status| status.success())
+}
+
+#[cfg(windows)]
+fn process_exists(pid: u32) -> bool {
+    windows_process::exists(pid)
+}
+
+#[cfg(windows)]
+mod windows_process {
+    use std::io;
+
+    const PROCESS_QUERY_LIMITED_INFORMATION: u32 = 0x1000;
+    const STILL_ACTIVE: u32 = 259;
+    const ERROR_ACCESS_DENIED: i32 = 5;
+
+    #[link(name = "kernel32")]
+    extern "system" {
+        fn OpenProcess(desired_access: u32, inherit_handle: i32, process_id: u32) -> usize;
+        fn GetExitCodeProcess(process: usize, exit_code: *mut u32) -> i32;
+        fn CloseHandle(handle: usize) -> i32;
+    }
+
+    /// Whether a process with this id is still running, the equivalent of
+    /// `kill -0` on Unix. A process owned by another user cannot be opened,
+    /// but the access error still proves it exists.
+    pub(crate) fn exists(pid: u32) -> bool {
+        // SAFETY: plain Win32 calls; the handle is closed before returning.
+        unsafe {
+            let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+            if handle == 0 {
+                return io::Error::last_os_error().raw_os_error() == Some(ERROR_ACCESS_DENIED);
+            }
+            let mut exit_code = 0u32;
+            let queried = GetExitCodeProcess(handle, &mut exit_code);
+            CloseHandle(handle);
+            queried != 0 && exit_code == STILL_ACTIVE
+        }
+    }
 }
 
 fn service_status() -> anyhow::Result<()> {
@@ -2394,7 +2460,22 @@ fn wait_for_pairing_target(target: &PairingTarget, timeout: Duration) -> anyhow:
 }
 
 fn service_is_healthy(metadata: &ServiceMetadata) -> bool {
-    http_get_json(&metadata.http_url, "/api/health").is_ok()
+    service_url_is_healthy(&metadata.http_url, SERVICE_HEALTH_PROBE_TIMEOUT)
+}
+
+/// Probes `/api/health` on a local service URL with a bounded timeout for the
+/// connect, the request, and the response, unlike `http_get_json`, which waits
+/// up to the full read timeout for a listener that accepts but never answers.
+fn service_url_is_healthy(http_url: &str, timeout: Duration) -> bool {
+    let Ok(endpoint) = HttpEndpoint::parse(http_url) else {
+        return false;
+    };
+    let Ok(addresses) = (endpoint.host.as_str(), endpoint.port).to_socket_addrs() else {
+        return false;
+    };
+    addresses
+        .into_iter()
+        .any(|address| http_health_probe(address, timeout))
 }
 
 fn service_binary_matches_current(metadata: &ServiceMetadata) -> anyhow::Result<bool> {
@@ -2522,11 +2603,7 @@ fn project_device_selection_path_for_root(root: &Path) -> anyhow::Result<PathBuf
 }
 
 fn simdeck_user_state_dir() -> PathBuf {
-    env::var_os("HOME")
-        .filter(|value| !value.is_empty())
-        .map(PathBuf::from)
-        .map(|home| home.join(".simdeck"))
-        .unwrap_or_else(|| env::temp_dir().join("simdeck"))
+    config::simdeck_user_state_dir()
 }
 
 fn service_metadata_paths() -> anyhow::Result<Vec<PathBuf>> {
@@ -5451,6 +5528,57 @@ fn http_health_probe(address: SocketAddr, timeout: Duration) -> bool {
     read > 12 && response[..read].starts_with(b"HTTP/1.1 200")
 }
 
+/// Keeps the HTTP listener out of child processes on Windows.
+///
+/// Tokio creates Windows sockets with `socket()`, which yields inheritable
+/// handles, and `std::process::Command` lets children inherit every
+/// inheritable handle. A spawned adb server or emulator would otherwise keep
+/// the service port bound after the service exits, so the next `simdeck` run
+/// probes a port that accepts connections but never answers.
+#[cfg(windows)]
+fn mark_listener_non_inheritable(listener: &tokio::net::TcpListener) -> io::Result<()> {
+    use std::os::windows::io::AsRawSocket;
+    windows_handle::clear_inherit_flag(listener.as_raw_socket() as usize)
+}
+
+#[cfg(not(windows))]
+fn mark_listener_non_inheritable(_listener: &tokio::net::TcpListener) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(windows)]
+mod windows_handle {
+    use std::io;
+
+    const HANDLE_FLAG_INHERIT: u32 = 0x0000_0001;
+
+    #[link(name = "kernel32")]
+    extern "system" {
+        fn GetHandleInformation(handle: usize, flags: *mut u32) -> i32;
+        fn SetHandleInformation(handle: usize, mask: u32, flags: u32) -> i32;
+    }
+
+    pub(crate) fn clear_inherit_flag(handle: usize) -> io::Result<()> {
+        // SAFETY: `handle` is an open socket handle owned by the caller and
+        // the call only updates its inherit flag.
+        if unsafe { SetHandleInformation(handle, HANDLE_FLAG_INHERIT, 0) } == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_inheritable(handle: usize) -> io::Result<bool> {
+        let mut flags = 0u32;
+        // SAFETY: `handle` is an open socket handle and `flags` outlives the
+        // call.
+        if unsafe { GetHandleInformation(handle, &mut flags) } == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(flags & HANDLE_FLAG_INHERIT != 0)
+    }
+}
+
 fn start_simulator_session_idle_reaper(registry: SessionRegistry) {
     tokio::spawn(async move {
         tokio::time::sleep(SIMULATOR_SESSION_IDLE_REAPER_INITIAL_DELAY).await;
@@ -6128,6 +6256,8 @@ async fn serve(
     let http_listener = tokio::net::TcpListener::bind(config.http_addr())
         .await
         .with_context(|| format!("bind HTTP listener on {}", config.http_addr()))?;
+    mark_listener_non_inheritable(&http_listener)
+        .with_context(|| format!("protect HTTP listener on {}", config.http_addr()))?;
     let health_heartbeat = Arc::new(AtomicU64::new(now_secs()));
     start_server_health_watchdog(config.http_addr(), health_heartbeat.clone());
     let _bonjour_advertisement = BonjourAdvertisement::start(&config);
@@ -6381,7 +6511,8 @@ mod tests {
         project_service_credentials_from_metadata, read_project_service_credentials_from_path,
         removed_service_process_name, render_agent_accessibility_tree, render_qr_code,
         run_maestro_command, server_health_watchdog_should_restart, service_addresses,
-        service_matches_launch_options, service_post_error_is_retryable, simdeck_open_link,
+        service_matches_launch_options, service_post_error_is_retryable,
+        service_url_is_healthy, simdeck_open_link,
         simdeck_pair_url, studio_service_restart_args, workspace_service_process_is_current,
         write_project_service_credentials_to_path, AndroidGpuMode, Cli, Command, ElementSelector,
         NoCommandAction, PairingAddress, ProjectServiceCredentials, ServiceCommand,
@@ -7677,5 +7808,90 @@ swipe:
             normalize_accessibility_point_for_display(240.0, 226.0, 480.0, 320.0, 800.0, 1200.0),
             (0.70625, 0.5)
         );
+    }
+
+    #[test]
+    fn service_health_probe_gives_up_on_a_port_that_never_answers() {
+        // A bound listener that never accepts stands in for a port kept alive
+        // by an orphaned child process: connections succeed, nothing answers.
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let timeout = std::time::Duration::from_millis(300);
+        let started = std::time::Instant::now();
+        assert!(!service_url_is_healthy(&format!("http://127.0.0.1:{port}"), timeout));
+        assert!(started.elapsed() < std::time::Duration::from_secs(5));
+        drop(listener);
+    }
+
+    #[test]
+    fn service_health_probe_rejects_closed_ports_and_bad_urls() {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        let timeout = std::time::Duration::from_millis(300);
+        assert!(!service_url_is_healthy(&format!("http://127.0.0.1:{port}"), timeout));
+        assert!(!service_url_is_healthy("https://127.0.0.1:4310", timeout));
+        assert!(!service_url_is_healthy("nonsense", timeout));
+    }
+
+    fn spawn_idle_child() -> std::process::Child {
+        let mut command = if cfg!(windows) {
+            let mut command = std::process::Command::new("ping");
+            command.args(["-n", "60", "127.0.0.1"]);
+            command
+        } else {
+            let mut command = std::process::Command::new("sleep");
+            command.arg("60");
+            command
+        };
+        command
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn idle child")
+    }
+
+    #[test]
+    fn process_exists_tracks_live_and_exited_processes() {
+        assert!(super::process_exists(std::process::id()));
+        let mut child = spawn_idle_child();
+        let pid = child.id();
+        assert!(super::process_exists(pid));
+        child.kill().unwrap();
+        child.wait().unwrap();
+        assert!(!super::process_exists(pid));
+    }
+
+    #[test]
+    fn terminate_process_group_ends_a_running_process() {
+        let mut child = spawn_idle_child();
+        let pid = child.id();
+        // Reap concurrently: on Unix a terminated but unreaped child still
+        // answers `kill -0`, which would stall the termination wait.
+        let reaper = std::thread::spawn(move || child.wait().unwrap());
+        super::terminate_process_group(pid, std::time::Duration::from_secs(5));
+        let status = reaper.join().unwrap();
+        assert!(!status.success());
+        assert!(!super::process_exists(pid));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn http_listener_is_not_inheritable_on_windows() {
+        use std::os::windows::io::AsRawSocket;
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+                .await
+                .unwrap();
+            let handle = listener.as_raw_socket() as usize;
+            super::mark_listener_non_inheritable(&listener).unwrap();
+            assert!(!super::windows_handle::is_inheritable(handle).unwrap());
+        });
     }
 }

--- a/packages/server/src/native/ffi.rs
+++ b/packages/server/src/native/ffi.rs
@@ -334,13 +334,18 @@ unsafe extern "C" {
         error_message: *mut *mut c_char,
     ) -> bool;
 
+    // The H.264 encoder ABI is only called on macOS; other targets encode
+    // Android frames in Rust (see transport/software_h264.rs).
+    #[cfg(target_os = "macos")]
     pub fn xcw_native_h264_encoder_create_with_video_codec(
         callback: Option<xcw_native_frame_callback>,
         user_data: *mut c_void,
         video_codec: *const c_char,
         error_message: *mut *mut c_char,
     ) -> *mut c_void;
+    #[cfg(target_os = "macos")]
     pub fn xcw_native_h264_encoder_destroy(handle: *mut c_void);
+    #[cfg(target_os = "macos")]
     pub fn xcw_native_h264_encoder_encode_rgba(
         handle: *mut c_void,
         rgba: *const u8,
@@ -350,6 +355,7 @@ unsafe extern "C" {
         timestamp_us: u64,
         error_message: *mut *mut c_char,
     ) -> bool;
+    #[cfg(target_os = "macos")]
     pub fn xcw_native_h264_encoder_encode_bgra(
         handle: *mut c_void,
         bgra: *const u8,
@@ -359,7 +365,9 @@ unsafe extern "C" {
         timestamp_us: u64,
         error_message: *mut *mut c_char,
     ) -> bool;
+    #[cfg(target_os = "macos")]
     pub fn xcw_native_h264_encoder_request_keyframe(handle: *mut c_void);
+    #[cfg(target_os = "macos")]
     pub fn xcw_native_h264_encoder_stats(
         handle: *mut c_void,
         error_message: *mut *mut c_char,

--- a/packages/server/src/performance.rs
+++ b/packages/server/src/performance.rs
@@ -1,6 +1,7 @@
 use crate::error::AppError;
 use serde::Serialize;
 use std::collections::{HashMap, VecDeque};
+#[cfg(target_os = "macos")]
 use std::ffi::c_void;
 use std::path::Path;
 use std::sync::{Arc, Mutex};

--- a/packages/server/src/platform.rs
+++ b/packages/server/src/platform.rs
@@ -10,9 +10,6 @@
 
 use serde_json::{json, Value};
 
-/// Operating system that provides the iOS simulator bridge.
-pub const IOS_SIMULATOR_REQUIRED_OS: &str = "macos";
-
 /// Rust target OS name for the running binary (`macos`, `windows`, `linux`).
 pub fn host_os() -> &'static str {
     std::env::consts::OS
@@ -127,10 +124,7 @@ mod tests {
     #[test]
     fn ios_support_matches_the_compiled_target() {
         assert_eq!(ios_simulator_supported(), cfg!(target_os = "macos"));
-        assert_eq!(
-            host_os() == IOS_SIMULATOR_REQUIRED_OS,
-            ios_simulator_supported()
-        );
+        assert_eq!(host_os() == "macos", ios_simulator_supported());
         assert_eq!(live_video_encoder() == "native", ios_simulator_supported());
     }
 

--- a/packages/server/src/platform.rs
+++ b/packages/server/src/platform.rs
@@ -1,0 +1,109 @@
+//! Host platform capability reporting.
+//!
+//! SimDeck ships one CLI for macOS, Windows, and Linux, but live H.264 video
+//! streaming depends on the macOS native simulator bridge and its
+//! VideoToolbox/x264 encoders. Non-macOS builds compile `native_stubs.c`
+//! instead of that bridge, so this module is the single place that describes
+//! the gap for the CLI banner, the HTTP API, and the browser client.
+
+use serde_json::{json, Value};
+
+/// Operating system that provides the native H.264 encoder.
+pub const LIVE_VIDEO_REQUIRED_OS: &str = "macos";
+
+/// Rust target OS name for the running binary (`macos`, `windows`, `linux`).
+pub fn host_os() -> &'static str {
+    std::env::consts::OS
+}
+
+/// Whether this build includes the native H.264 encoder used by the browser
+/// WebRTC stream for both iOS simulators and Android emulators.
+pub fn live_video_supported() -> bool {
+    cfg!(target_os = "macos")
+}
+
+/// Full user-facing explanation returned by the API when live video is
+/// requested on a build that cannot encode it.
+pub fn live_video_unsupported_message() -> String {
+    live_video_unsupported_message_for(host_os())
+}
+
+/// Short note printed by the CLI after the service URLs.
+pub fn live_video_cli_note() -> String {
+    format!(
+        "Unavailable on {}. Live H.264 streaming requires macOS.",
+        os_display_name(host_os())
+    )
+}
+
+/// JSON capability block shared by `/api/health` and `/api/stream-quality`.
+pub fn live_video_capability_value() -> Value {
+    live_video_capability_value_for(host_os(), live_video_supported())
+}
+
+pub(crate) fn live_video_unsupported_message_for(os: &str) -> String {
+    format!(
+        "Live H.264 video streaming requires macOS. This SimDeck build for {} can manage devices but does not include the native H.264 encoder, so the browser stream and the `--video-codec` setting are unavailable here.",
+        os_display_name(os)
+    )
+}
+
+pub(crate) fn live_video_capability_value_for(os: &str, supported: bool) -> Value {
+    let mut value = json!({
+        "supported": supported,
+        "requires": LIVE_VIDEO_REQUIRED_OS,
+    });
+    if !supported {
+        value["reason"] = Value::String(live_video_unsupported_message_for(os));
+    }
+    value
+}
+
+pub(crate) fn os_display_name(os: &str) -> String {
+    match os {
+        "macos" => "macOS".to_owned(),
+        "windows" => "Windows".to_owned(),
+        "linux" => "Linux".to_owned(),
+        other => other.to_owned(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unsupported_message_names_the_host_and_the_requirement() {
+        let message = live_video_unsupported_message_for("windows");
+        assert!(message.contains("requires macOS"));
+        assert!(message.contains("build for Windows"));
+        assert!(message.contains("--video-codec"));
+    }
+
+    #[test]
+    fn unsupported_message_falls_back_to_raw_os_name() {
+        let message = live_video_unsupported_message_for("freebsd");
+        assert!(message.contains("build for freebsd"));
+    }
+
+    #[test]
+    fn capability_value_only_carries_a_reason_when_unsupported() {
+        let unsupported = live_video_capability_value_for("linux", false);
+        assert_eq!(unsupported["supported"], Value::Bool(false));
+        assert_eq!(unsupported["requires"], Value::String("macos".to_owned()));
+        assert!(unsupported["reason"]
+            .as_str()
+            .is_some_and(|reason| reason.contains("Linux")));
+
+        let supported = live_video_capability_value_for("macos", true);
+        assert_eq!(supported["supported"], Value::Bool(true));
+        assert_eq!(supported["requires"], Value::String("macos".to_owned()));
+        assert!(supported.get("reason").is_none());
+    }
+
+    #[test]
+    fn live_video_support_matches_the_compiled_target() {
+        assert_eq!(live_video_supported(), cfg!(target_os = "macos"));
+        assert_eq!(host_os() == LIVE_VIDEO_REQUIRED_OS, live_video_supported());
+    }
+}

--- a/packages/server/src/platform.rs
+++ b/packages/server/src/platform.rs
@@ -9,10 +9,34 @@
 //! those differences for the CLI banner, the HTTP API, and the browser client.
 
 use serde_json::{json, Value};
+use std::path::PathBuf;
 
 /// Rust target OS name for the running binary (`macos`, `windows`, `linux`).
 pub fn host_os() -> &'static str {
     std::env::consts::OS
+}
+
+/// The current user's home directory, or `None` when no environment variable
+/// describes one.
+///
+/// Unix shells always export `HOME`. On Windows only Git Bash and similar
+/// environments do; PowerShell and cmd expose `USERPROFILE` (and the older
+/// `HOMEDRIVE`/`HOMEPATH` pair) instead. Every SimDeck path under the home
+/// directory must resolve the same way in all of them, otherwise a service
+/// started from one shell is invisible to the CLI in another.
+pub fn user_home_dir() -> Option<PathBuf> {
+    let from_env = |key: &str| {
+        std::env::var_os(key)
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from)
+    };
+    from_env("HOME")
+        .or_else(|| from_env("USERPROFILE"))
+        .or_else(|| {
+            let drive = from_env("HOMEDRIVE")?;
+            let path = from_env("HOMEPATH")?;
+            Some(drive.join(path))
+        })
 }
 
 /// Whether this build includes the native simulator bridge needed to boot,

--- a/packages/server/src/platform.rs
+++ b/packages/server/src/platform.rs
@@ -1,60 +1,80 @@
 //! Host platform capability reporting.
 //!
-//! SimDeck ships one CLI for macOS, Windows, and Linux, but live H.264 video
-//! streaming depends on the macOS native simulator bridge and its
-//! VideoToolbox/x264 encoders. Non-macOS builds compile `native_stubs.c`
-//! instead of that bridge, so this module is the single place that describes
-//! the gap for the CLI banner, the HTTP API, and the browser client.
+//! SimDeck ships one CLI for macOS, Windows, and Linux. The macOS build links
+//! the private simulator bridge, which owns iOS simulator control and the
+//! VideoToolbox/x264 encoders. Windows and Linux builds compile
+//! `native_stubs.c` in its place, so they cannot drive iOS simulators, but they
+//! still stream Android emulators through the Rust OpenH264 encoder in
+//! `transport::software_h264`. This module is the single place that describes
+//! those differences for the CLI banner, the HTTP API, and the browser client.
 
 use serde_json::{json, Value};
 
-/// Operating system that provides the native H.264 encoder.
-pub const LIVE_VIDEO_REQUIRED_OS: &str = "macos";
+/// Operating system that provides the iOS simulator bridge.
+pub const IOS_SIMULATOR_REQUIRED_OS: &str = "macos";
 
 /// Rust target OS name for the running binary (`macos`, `windows`, `linux`).
 pub fn host_os() -> &'static str {
     std::env::consts::OS
 }
 
-/// Whether this build includes the native H.264 encoder used by the browser
-/// WebRTC stream for both iOS simulators and Android emulators.
-pub fn live_video_supported() -> bool {
+/// Whether this build includes the native simulator bridge needed to boot,
+/// control, and stream iOS simulators.
+pub fn ios_simulator_supported() -> bool {
     cfg!(target_os = "macos")
 }
 
-/// Full user-facing explanation returned by the API when live video is
-/// requested on a build that cannot encode it.
-pub fn live_video_unsupported_message() -> String {
-    live_video_unsupported_message_for(host_os())
+/// Name of the H.264 encoder that produces the live browser stream.
+#[cfg(target_os = "macos")]
+pub fn live_video_encoder() -> &'static str {
+    "native"
 }
 
-/// Short note printed by the CLI after the service URLs.
+/// Name of the H.264 encoder that produces the live browser stream.
+#[cfg(not(target_os = "macos"))]
+pub fn live_video_encoder() -> &'static str {
+    crate::transport::software_h264::SOFTWARE_H264_ENCODER_NAME
+}
+
+/// Full user-facing explanation returned by the API when an iOS simulator
+/// stream is requested on a build without the native bridge.
+pub fn ios_simulator_unsupported_message() -> String {
+    ios_simulator_unsupported_message_for(host_os())
+}
+
+/// Short note printed by the CLI after the service URLs on non-macOS hosts.
 pub fn live_video_cli_note() -> String {
     format!(
-        "Unavailable on {}. Live H.264 streaming requires macOS.",
-        os_display_name(host_os())
+        "Android emulators stream with software H.264 ({}). iOS simulators require macOS.",
+        live_video_encoder()
     )
 }
 
 /// JSON capability block shared by `/api/health` and `/api/stream-quality`.
 pub fn live_video_capability_value() -> Value {
-    live_video_capability_value_for(host_os(), live_video_supported())
+    live_video_capability_value_for(host_os(), live_video_encoder(), ios_simulator_supported())
 }
 
-pub(crate) fn live_video_unsupported_message_for(os: &str) -> String {
+pub(crate) fn ios_simulator_unsupported_message_for(os: &str) -> String {
     format!(
-        "Live H.264 video streaming requires macOS. This SimDeck build for {} can manage devices but does not include the native H.264 encoder, so the browser stream and the `--video-codec` setting are unavailable here.",
+        "iOS simulators require macOS. This SimDeck build for {} can boot, control, and stream Android emulators, but the iOS simulator bridge is only available on macOS.",
         os_display_name(os)
     )
 }
 
-pub(crate) fn live_video_capability_value_for(os: &str, supported: bool) -> Value {
+pub(crate) fn live_video_capability_value_for(
+    os: &str,
+    encoder: &str,
+    ios_simulator: bool,
+) -> Value {
     let mut value = json!({
-        "supported": supported,
-        "requires": LIVE_VIDEO_REQUIRED_OS,
+        "supported": true,
+        "encoder": encoder,
+        "iosSimulator": ios_simulator,
+        "androidEmulator": true,
     });
-    if !supported {
-        value["reason"] = Value::String(live_video_unsupported_message_for(os));
+    if !ios_simulator {
+        value["iosSimulatorReason"] = Value::String(ios_simulator_unsupported_message_for(os));
     }
     value
 }
@@ -73,37 +93,51 @@ mod tests {
     use super::*;
 
     #[test]
-    fn unsupported_message_names_the_host_and_the_requirement() {
-        let message = live_video_unsupported_message_for("windows");
-        assert!(message.contains("requires macOS"));
+    fn ios_message_names_the_host_and_the_requirement() {
+        let message = ios_simulator_unsupported_message_for("windows");
+        assert!(message.starts_with("iOS simulators require macOS."));
         assert!(message.contains("build for Windows"));
-        assert!(message.contains("--video-codec"));
+        assert!(message.contains("Android emulators"));
     }
 
     #[test]
-    fn unsupported_message_falls_back_to_raw_os_name() {
-        let message = live_video_unsupported_message_for("freebsd");
+    fn ios_message_falls_back_to_raw_os_name() {
+        let message = ios_simulator_unsupported_message_for("freebsd");
         assert!(message.contains("build for freebsd"));
     }
 
     #[test]
-    fn capability_value_only_carries_a_reason_when_unsupported() {
-        let unsupported = live_video_capability_value_for("linux", false);
-        assert_eq!(unsupported["supported"], Value::Bool(false));
-        assert_eq!(unsupported["requires"], Value::String("macos".to_owned()));
-        assert!(unsupported["reason"]
+    fn capability_value_reports_android_everywhere_and_ios_only_on_macos() {
+        let windows = live_video_capability_value_for("windows", "openh264", false);
+        assert_eq!(windows["supported"], Value::Bool(true));
+        assert_eq!(windows["encoder"], Value::String("openh264".to_owned()));
+        assert_eq!(windows["androidEmulator"], Value::Bool(true));
+        assert_eq!(windows["iosSimulator"], Value::Bool(false));
+        assert!(windows["iosSimulatorReason"]
             .as_str()
-            .is_some_and(|reason| reason.contains("Linux")));
+            .is_some_and(|reason| reason.contains("Windows")));
 
-        let supported = live_video_capability_value_for("macos", true);
-        assert_eq!(supported["supported"], Value::Bool(true));
-        assert_eq!(supported["requires"], Value::String("macos".to_owned()));
-        assert!(supported.get("reason").is_none());
+        let macos = live_video_capability_value_for("macos", "native", true);
+        assert_eq!(macos["supported"], Value::Bool(true));
+        assert_eq!(macos["encoder"], Value::String("native".to_owned()));
+        assert_eq!(macos["iosSimulator"], Value::Bool(true));
+        assert!(macos.get("iosSimulatorReason").is_none());
     }
 
     #[test]
-    fn live_video_support_matches_the_compiled_target() {
-        assert_eq!(live_video_supported(), cfg!(target_os = "macos"));
-        assert_eq!(host_os() == LIVE_VIDEO_REQUIRED_OS, live_video_supported());
+    fn ios_support_matches_the_compiled_target() {
+        assert_eq!(ios_simulator_supported(), cfg!(target_os = "macos"));
+        assert_eq!(
+            host_os() == IOS_SIMULATOR_REQUIRED_OS,
+            ios_simulator_supported()
+        );
+        assert_eq!(live_video_encoder() == "native", ios_simulator_supported());
+    }
+
+    #[test]
+    fn cli_note_names_the_encoder() {
+        let note = live_video_cli_note();
+        assert!(note.contains(live_video_encoder()));
+        assert!(note.contains("iOS simulators require macOS"));
     }
 }

--- a/packages/server/src/service.rs
+++ b/packages/server/src/service.rs
@@ -470,9 +470,7 @@ fn flag_matches(arguments: &[String], name: &str, expected: bool) -> bool {
 }
 
 fn home_dir() -> anyhow::Result<PathBuf> {
-    std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .ok_or_else(|| anyhow!("HOME is not set"))
+    crate::platform::user_home_dir().ok_or_else(|| anyhow!("HOME is not set"))
 }
 
 fn launchctl_domain() -> anyhow::Result<String> {

--- a/packages/server/src/transport/mod.rs
+++ b/packages/server/src/transport/mod.rs
@@ -1,2 +1,4 @@
 pub mod packet;
+#[cfg(not(target_os = "macos"))]
+pub mod software_h264;
 pub mod webrtc;

--- a/packages/server/src/transport/software_h264.rs
+++ b/packages/server/src/transport/software_h264.rs
@@ -395,11 +395,13 @@ mod tests {
             "keyframe carries an IDR slice: {types:?}"
         );
 
+        // A full-frame color change can trigger a scene-change IDR, so only
+        // require that a second frame keeps flowing as Annex B.
         let second = encoder
             .encode_rgba(&solid_rgba(64, 64, [30, 200, 30]), 64, 64)
             .expect("second encode");
         if let Some(second) = second {
-            assert!(!second.is_keyframe);
+            assert!(second.data.starts_with(&[0, 0, 0, 1]) || second.data.starts_with(&[0, 0, 1]));
         }
 
         encoder.request_keyframe();

--- a/packages/server/src/transport/software_h264.rs
+++ b/packages/server/src/transport/software_h264.rs
@@ -168,10 +168,11 @@ impl SoftwareH264Encoder {
         if matches!(&self.encoder, Some((current, _)) if *current == settings) {
             return Ok(());
         }
-        let encoder = Encoder::with_api_config(OpenH264API::from_source(), encoder_config(settings))
-            .map_err(|error| {
-                AppError::native(format!("OpenH264 encoder creation failed: {error}"))
-            })?;
+        let encoder =
+            Encoder::with_api_config(OpenH264API::from_source(), encoder_config(settings))
+                .map_err(|error| {
+                    AppError::native(format!("OpenH264 encoder creation failed: {error}"))
+                })?;
         if self.encoder.is_some() {
             self.reinitializations += 1;
         }
@@ -190,8 +191,7 @@ impl SoftwareH264Encoder {
         let force_keyframe = std::mem::take(&mut self.keyframe_pending);
         let started = Instant::now();
         let encoded = {
-            let (Some((_, encoder)), Some(yuv)) = (self.encoder.as_mut(), self.yuv.as_ref())
-            else {
+            let (Some((_, encoder)), Some(yuv)) = (self.encoder.as_mut(), self.yuv.as_ref()) else {
                 return Err(AppError::native(
                     "OpenH264 encoder state is missing a frame buffer.",
                 ));
@@ -252,7 +252,10 @@ pub(crate) fn software_h264_settings(
     height: u32,
 ) -> SoftwareH264Settings {
     let fps = fps.max(1);
-    let bits_per_pixel = quality.bits_per_pixel.unwrap_or(DEFAULT_BITS_PER_PIXEL).max(1);
+    let bits_per_pixel = quality
+        .bits_per_pixel
+        .unwrap_or(DEFAULT_BITS_PER_PIXEL)
+        .max(1);
     let min_bitrate = quality.min_bitrate.unwrap_or(DEFAULT_MIN_BITRATE_BPS);
     let computed = u64::from(width) * u64::from(height) * u64::from(bits_per_pixel);
     let bitrate_bps = computed
@@ -293,7 +296,7 @@ fn encoder_threads() -> u16 {
 }
 
 fn validate_frame(length: usize, width: u32, height: u32) -> Result<(), AppError> {
-    if width < 2 || height < 2 || width % 2 != 0 || height % 2 != 0 {
+    if width < 2 || height < 2 || !width.is_multiple_of(2) || !height.is_multiple_of(2) {
         return Err(AppError::native(format!(
             "OpenH264 needs even frame dimensions; got {width}x{height}."
         )));
@@ -383,13 +386,14 @@ mod tests {
             .expect("first encode")
             .expect("first frame is emitted");
         assert!(first.is_keyframe);
-        assert!(
-            first.data.starts_with(&[0, 0, 0, 1]) || first.data.starts_with(&[0, 0, 1])
-        );
+        assert!(first.data.starts_with(&[0, 0, 0, 1]) || first.data.starts_with(&[0, 0, 1]));
         let types = nal_unit_types(&first.data);
         assert!(types.contains(&7), "keyframe carries SPS: {types:?}");
         assert!(types.contains(&8), "keyframe carries PPS: {types:?}");
-        assert!(types.contains(&5), "keyframe carries an IDR slice: {types:?}");
+        assert!(
+            types.contains(&5),
+            "keyframe carries an IDR slice: {types:?}"
+        );
 
         let second = encoder
             .encode_rgba(&solid_rgba(64, 64, [30, 200, 30]), 64, 64)

--- a/packages/server/src/transport/software_h264.rs
+++ b/packages/server/src/transport/software_h264.rs
@@ -1,0 +1,438 @@
+//! Software H.264 encoding for builds without the macOS native bridge.
+//!
+//! macOS encodes Android emulator frames through `XCWH264Encoder` (VideoToolbox
+//! or x264) behind the native bridge C ABI. Windows and Linux link
+//! `native_stubs.c` instead, so this module does the same job in Rust with
+//! Cisco's OpenH264, compiled from source through the `openh264` crate. It
+//! produces Annex B baseline H.264, which is what the WebRTC packetizer in
+//! `transport::webrtc` and every browser H.264 decoder expect.
+//!
+//! The encoder is created lazily from the first frame because the output size
+//! is only known once the emulator delivers a frame, and it is recreated
+//! whenever the size or the quality-derived bitrate changes.
+
+use crate::android::AndroidH264StreamQuality;
+use crate::error::AppError;
+use bytes::Bytes;
+use openh264::encoder::{
+    BitRate, Complexity, Encoder, EncoderConfig, FrameRate, FrameType, IntraFramePeriod, Profile,
+    RateControlMode, SpsPpsStrategy, UsageType,
+};
+use openh264::formats::{BgraSliceU8, RgbaSliceU8, YUVBuffer};
+use openh264::OpenH264API;
+use serde_json::{json, Value};
+use std::time::{Duration, Instant};
+
+/// Name reported through `/api/health` and encoder stats.
+pub(crate) const SOFTWARE_H264_ENCODER_NAME: &str = "openh264";
+/// Matches the macOS realtime keyframe interval; viewers request keyframes on
+/// demand through RTCP, so periodic IDR frames only bound recovery time.
+const KEYFRAME_INTERVAL_SECONDS: u32 = 60;
+const MIN_BITRATE_BPS: u32 = 200_000;
+const MAX_BITRATE_BPS: u32 = 60_000_000;
+const DEFAULT_MIN_BITRATE_BPS: u32 = 3_000_000;
+const DEFAULT_BITS_PER_PIXEL: u32 = 5;
+const MAX_ENCODER_THREADS: usize = 4;
+const BYTES_PER_PIXEL: usize = 4;
+
+/// Encoder parameters derived from the stream quality and the frame size.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct SoftwareH264Settings {
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+    pub(crate) fps: u32,
+    pub(crate) bitrate_bps: u32,
+    pub(crate) keyframe_interval_frames: u32,
+    pub(crate) threads: u16,
+}
+
+/// One encoded access unit in Annex B form.
+pub(crate) struct EncodedH264Frame {
+    pub(crate) is_keyframe: bool,
+    pub(crate) data: Bytes,
+}
+
+pub(crate) struct SoftwareH264Encoder {
+    quality: AndroidH264StreamQuality,
+    fps: u32,
+    threads: u16,
+    encoder: Option<(SoftwareH264Settings, Encoder)>,
+    yuv: Option<YUVBuffer>,
+    yuv_dimensions: (u32, u32),
+    keyframe_pending: bool,
+    reinitializations: u64,
+    output_frames: u64,
+    keyframe_outputs: u64,
+    skipped_frames: u64,
+    encode_failures: u64,
+    latest_encode_us: u64,
+    average_encode_us: f64,
+    peak_encode_us: u64,
+}
+
+impl SoftwareH264Encoder {
+    pub(crate) fn new(quality: AndroidH264StreamQuality, fps: u32) -> Self {
+        Self {
+            quality,
+            fps: fps.max(1),
+            threads: encoder_threads(),
+            encoder: None,
+            yuv: None,
+            yuv_dimensions: (0, 0),
+            keyframe_pending: true,
+            reinitializations: 0,
+            output_frames: 0,
+            keyframe_outputs: 0,
+            skipped_frames: 0,
+            encode_failures: 0,
+            latest_encode_us: 0,
+            average_encode_us: 0.0,
+            peak_encode_us: 0,
+        }
+    }
+
+    /// Applies a new quality target. The encoder is rebuilt on the next frame
+    /// when the derived bitrate or frame rate changes, and always emits a
+    /// keyframe so viewers resynchronize.
+    pub(crate) fn reconfigure(&mut self, quality: AndroidH264StreamQuality, fps: u32) {
+        self.quality = quality;
+        self.fps = fps.max(1);
+        self.keyframe_pending = true;
+    }
+
+    pub(crate) fn request_keyframe(&mut self) {
+        self.keyframe_pending = true;
+    }
+
+    pub(crate) fn encode_rgba(
+        &mut self,
+        rgba: &[u8],
+        width: u32,
+        height: u32,
+    ) -> Result<Option<EncodedH264Frame>, AppError> {
+        validate_frame(rgba.len(), width, height)?;
+        self.prepare_yuv(width, height);
+        if let Some(yuv) = self.yuv.as_mut() {
+            yuv.read_rgba8(RgbaSliceU8::new(rgba, (width as usize, height as usize)));
+        }
+        self.encode_prepared(width, height)
+    }
+
+    pub(crate) fn encode_bgra(
+        &mut self,
+        bgra: &[u8],
+        width: u32,
+        height: u32,
+    ) -> Result<Option<EncodedH264Frame>, AppError> {
+        validate_frame(bgra.len(), width, height)?;
+        self.prepare_yuv(width, height);
+        if let Some(yuv) = self.yuv.as_mut() {
+            yuv.read_bgra8(BgraSliceU8::new(bgra, (width as usize, height as usize)));
+        }
+        self.encode_prepared(width, height)
+    }
+
+    pub(crate) fn stats(&self) -> Value {
+        let settings = self.encoder.as_ref().map(|(settings, _)| *settings);
+        json!({
+            "encoder": SOFTWARE_H264_ENCODER_NAME,
+            "hardware": false,
+            "transportCodec": "h264",
+            "profile": "baseline",
+            "width": settings.map(|settings| settings.width),
+            "height": settings.map(|settings| settings.height),
+            "fps": settings.map(|settings| settings.fps),
+            "bitrateBps": settings.map(|settings| settings.bitrate_bps),
+            "keyFrameIntervalFrames": settings.map(|settings| settings.keyframe_interval_frames),
+            "threads": self.threads,
+            "reinitializations": self.reinitializations,
+            "outputFrames": self.output_frames,
+            "keyFrameOutputs": self.keyframe_outputs,
+            "skippedFrames": self.skipped_frames,
+            "encodeFailures": self.encode_failures,
+            "keyFramePending": self.keyframe_pending,
+            "latestEncodeLatencyUs": self.latest_encode_us,
+            "averageEncodeLatencyUs": self.average_encode_us.round() as u64,
+            "peakEncodeLatencyUs": self.peak_encode_us,
+        })
+    }
+
+    fn prepare_yuv(&mut self, width: u32, height: u32) {
+        if self.yuv.is_none() || self.yuv_dimensions != (width, height) {
+            self.yuv = Some(YUVBuffer::new(width as usize, height as usize));
+            self.yuv_dimensions = (width, height);
+        }
+    }
+
+    fn ensure_encoder(&mut self, settings: SoftwareH264Settings) -> Result<(), AppError> {
+        if matches!(&self.encoder, Some((current, _)) if *current == settings) {
+            return Ok(());
+        }
+        let encoder = Encoder::with_api_config(OpenH264API::from_source(), encoder_config(settings))
+            .map_err(|error| {
+                AppError::native(format!("OpenH264 encoder creation failed: {error}"))
+            })?;
+        if self.encoder.is_some() {
+            self.reinitializations += 1;
+        }
+        self.encoder = Some((settings, encoder));
+        self.keyframe_pending = true;
+        Ok(())
+    }
+
+    fn encode_prepared(
+        &mut self,
+        width: u32,
+        height: u32,
+    ) -> Result<Option<EncodedH264Frame>, AppError> {
+        let settings = software_h264_settings(self.quality, self.fps, self.threads, width, height);
+        self.ensure_encoder(settings)?;
+        let force_keyframe = std::mem::take(&mut self.keyframe_pending);
+        let started = Instant::now();
+        let encoded = {
+            let (Some((_, encoder)), Some(yuv)) = (self.encoder.as_mut(), self.yuv.as_ref())
+            else {
+                return Err(AppError::native(
+                    "OpenH264 encoder state is missing a frame buffer.",
+                ));
+            };
+            if force_keyframe {
+                encoder.force_intra_frame();
+            }
+            encoder
+                .encode(yuv)
+                .map(|bitstream| (bitstream.frame_type(), bitstream.to_vec()))
+        };
+        let (frame_type, data) = match encoded {
+            Ok(encoded) => encoded,
+            Err(error) => {
+                self.encode_failures += 1;
+                self.keyframe_pending = true;
+                return Err(AppError::native(format!("OpenH264 encode error: {error}")));
+            }
+        };
+        self.record_encode_duration(started.elapsed());
+        if data.is_empty() || matches!(frame_type, FrameType::Skip | FrameType::Invalid) {
+            self.skipped_frames += 1;
+            if force_keyframe {
+                self.keyframe_pending = true;
+            }
+            return Ok(None);
+        }
+        let is_keyframe = matches!(frame_type, FrameType::IDR);
+        self.output_frames += 1;
+        if is_keyframe {
+            self.keyframe_outputs += 1;
+        }
+        Ok(Some(EncodedH264Frame {
+            is_keyframe,
+            data: Bytes::from(data),
+        }))
+    }
+
+    fn record_encode_duration(&mut self, duration: Duration) {
+        let micros = duration.as_micros().min(u128::from(u64::MAX)) as u64;
+        self.latest_encode_us = micros;
+        self.peak_encode_us = self.peak_encode_us.max(micros);
+        self.average_encode_us = if self.output_frames == 0 && self.skipped_frames == 0 {
+            micros as f64
+        } else {
+            self.average_encode_us * 0.9 + micros as f64 * 0.1
+        };
+    }
+}
+
+/// Mirrors `XCWAverageBitRateForDimensions` in the macOS encoder: budget a
+/// number of bits per pixel per second, never below the configured minimum.
+pub(crate) fn software_h264_settings(
+    quality: AndroidH264StreamQuality,
+    fps: u32,
+    threads: u16,
+    width: u32,
+    height: u32,
+) -> SoftwareH264Settings {
+    let fps = fps.max(1);
+    let bits_per_pixel = quality.bits_per_pixel.unwrap_or(DEFAULT_BITS_PER_PIXEL).max(1);
+    let min_bitrate = quality.min_bitrate.unwrap_or(DEFAULT_MIN_BITRATE_BPS);
+    let computed = u64::from(width) * u64::from(height) * u64::from(bits_per_pixel);
+    let bitrate_bps = computed
+        .max(u64::from(min_bitrate))
+        .clamp(u64::from(MIN_BITRATE_BPS), u64::from(MAX_BITRATE_BPS)) as u32;
+    SoftwareH264Settings {
+        width,
+        height,
+        fps,
+        bitrate_bps,
+        keyframe_interval_frames: fps.saturating_mul(KEYFRAME_INTERVAL_SECONDS).max(1),
+        threads,
+    }
+}
+
+fn encoder_config(settings: SoftwareH264Settings) -> EncoderConfig {
+    EncoderConfig::new()
+        .usage_type(UsageType::ScreenContentRealTime)
+        .profile(Profile::Baseline)
+        .rate_control_mode(RateControlMode::Bitrate)
+        .bitrate(BitRate::from_bps(settings.bitrate_bps))
+        .max_frame_rate(FrameRate::from_hz(settings.fps as f32))
+        .intra_frame_period(IntraFramePeriod::from_num_frames(
+            settings.keyframe_interval_frames,
+        ))
+        .skip_frames(false)
+        .complexity(Complexity::Low)
+        .sps_pps_strategy(SpsPpsStrategy::ConstantId)
+        .num_threads(settings.threads)
+}
+
+fn encoder_threads() -> u16 {
+    std::thread::available_parallelism()
+        .map(|count| count.get())
+        .unwrap_or(1)
+        .div_ceil(2)
+        .clamp(1, MAX_ENCODER_THREADS) as u16
+}
+
+fn validate_frame(length: usize, width: u32, height: u32) -> Result<(), AppError> {
+    if width < 2 || height < 2 || width % 2 != 0 || height % 2 != 0 {
+        return Err(AppError::native(format!(
+            "OpenH264 needs even frame dimensions; got {width}x{height}."
+        )));
+    }
+    let expected = width as usize * height as usize * BYTES_PER_PIXEL;
+    if length != expected {
+        return Err(AppError::native(format!(
+            "Android frame buffer holds {length} bytes but {width}x{height} needs {expected}."
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn quality(min_bitrate: u32, bits_per_pixel: u32) -> AndroidH264StreamQuality {
+        AndroidH264StreamQuality {
+            max_edge: Some(960),
+            fps: Some(30),
+            min_bitrate: Some(min_bitrate),
+            bits_per_pixel: Some(bits_per_pixel),
+        }
+    }
+
+    fn solid_rgba(width: u32, height: u32, rgb: [u8; 3]) -> Vec<u8> {
+        let mut frame = Vec::with_capacity(width as usize * height as usize * 4);
+        for _ in 0..(width * height) {
+            frame.extend_from_slice(&[rgb[0], rgb[1], rgb[2], 255]);
+        }
+        frame
+    }
+
+    fn nal_unit_types(annex_b: &[u8]) -> Vec<u8> {
+        let mut types = Vec::new();
+        let mut index = 0;
+        while index + 3 < annex_b.len() {
+            let four = annex_b[index..index + 4] == [0, 0, 0, 1];
+            let three = annex_b[index..index + 3] == [0, 0, 1];
+            if four || three {
+                let header = index + if four { 4 } else { 3 };
+                if header < annex_b.len() {
+                    types.push(annex_b[header] & 0x1f);
+                }
+                index = header;
+            } else {
+                index += 1;
+            }
+        }
+        types
+    }
+
+    #[test]
+    fn settings_budget_bits_per_pixel_above_the_minimum() {
+        let settings = software_h264_settings(quality(1_000_000, 5), 30, 2, 432, 960);
+        assert_eq!(settings.bitrate_bps, 432 * 960 * 5);
+        assert_eq!(settings.fps, 30);
+        assert_eq!(settings.keyframe_interval_frames, 30 * 60);
+        assert_eq!(settings.threads, 2);
+    }
+
+    #[test]
+    fn settings_respect_the_minimum_and_the_ceiling() {
+        let floor = software_h264_settings(quality(6_000_000, 1), 60, 1, 64, 64);
+        assert_eq!(floor.bitrate_bps, 6_000_000);
+        let ceiling = software_h264_settings(quality(1_000_000, 10), 60, 1, 4096, 4096);
+        assert_eq!(ceiling.bitrate_bps, MAX_BITRATE_BPS);
+        let defaults = software_h264_settings(Default::default(), 0, 1, 64, 64);
+        assert_eq!(defaults.fps, 1);
+        assert_eq!(defaults.bitrate_bps, DEFAULT_MIN_BITRATE_BPS);
+    }
+
+    #[test]
+    fn frames_must_be_even_and_fully_populated() {
+        assert!(validate_frame(64 * 64 * 4, 64, 64).is_ok());
+        assert!(validate_frame(63 * 64 * 4, 63, 64).is_err());
+        assert!(validate_frame(64 * 64 * 4 - 1, 64, 64).is_err());
+        assert!(validate_frame(0, 0, 0).is_err());
+    }
+
+    #[test]
+    fn encodes_annex_b_keyframes_and_honors_keyframe_requests() {
+        let mut encoder = SoftwareH264Encoder::new(quality(500_000, 2), 30);
+        let first = encoder
+            .encode_rgba(&solid_rgba(64, 64, [200, 30, 30]), 64, 64)
+            .expect("first encode")
+            .expect("first frame is emitted");
+        assert!(first.is_keyframe);
+        assert!(
+            first.data.starts_with(&[0, 0, 0, 1]) || first.data.starts_with(&[0, 0, 1])
+        );
+        let types = nal_unit_types(&first.data);
+        assert!(types.contains(&7), "keyframe carries SPS: {types:?}");
+        assert!(types.contains(&8), "keyframe carries PPS: {types:?}");
+        assert!(types.contains(&5), "keyframe carries an IDR slice: {types:?}");
+
+        let second = encoder
+            .encode_rgba(&solid_rgba(64, 64, [30, 200, 30]), 64, 64)
+            .expect("second encode");
+        if let Some(second) = second {
+            assert!(!second.is_keyframe);
+        }
+
+        encoder.request_keyframe();
+        let third = encoder
+            .encode_bgra(&solid_rgba(64, 64, [30, 30, 200]), 64, 64)
+            .expect("third encode")
+            .expect("forced keyframe is emitted");
+        assert!(third.is_keyframe);
+        assert!(nal_unit_types(&third.data).contains(&5));
+
+        let stats = encoder.stats();
+        assert_eq!(stats["encoder"], Value::String("openh264".to_owned()));
+        assert_eq!(stats["width"], Value::from(64));
+        assert!(stats["keyFrameOutputs"].as_u64().unwrap_or(0) >= 2);
+        assert_eq!(stats["encodeFailures"], Value::from(0));
+    }
+
+    #[test]
+    fn resizing_and_reconfiguring_rebuilds_the_encoder() {
+        let mut encoder = SoftwareH264Encoder::new(quality(500_000, 2), 30);
+        encoder
+            .encode_rgba(&solid_rgba(64, 64, [0, 0, 0]), 64, 64)
+            .expect("first size");
+        let resized = encoder
+            .encode_rgba(&solid_rgba(96, 64, [0, 0, 0]), 96, 64)
+            .expect("second size")
+            .expect("resized keyframe is emitted");
+        assert!(resized.is_keyframe);
+        assert_eq!(encoder.stats()["reinitializations"], Value::from(1));
+
+        encoder.reconfigure(quality(4_000_000, 4), 60);
+        let reconfigured = encoder
+            .encode_rgba(&solid_rgba(96, 64, [0, 0, 0]), 96, 64)
+            .expect("reconfigured encode")
+            .expect("reconfigured keyframe is emitted");
+        assert!(reconfigured.is_keyframe);
+        assert_eq!(encoder.stats()["reinitializations"], Value::from(2));
+        assert_eq!(encoder.stats()["fps"], Value::from(60));
+    }
+}

--- a/packages/server/src/transport/webrtc.rs
+++ b/packages/server/src/transport/webrtc.rs
@@ -3063,7 +3063,9 @@ mod tests {
     use crate::metrics::counters::Metrics;
     use crate::transport::packet::FramePacket;
     use bytes::Bytes;
-    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+    #[cfg(target_os = "macos")]
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::{Arc, Mutex, RwLock};
     use std::time::Duration;
     use webrtc::rtcp::payload_feedbacks::full_intra_request::FullIntraRequest;
@@ -3272,8 +3274,12 @@ mod tests {
             frame_sequence: AtomicU64::new(0),
             quality: Mutex::new(crate::android::AndroidH264StreamQuality::default()),
             source_kind: RwLock::new("shared-video"),
+            #[cfg(target_os = "macos")]
             encoder_handle: AtomicUsize::new(0),
+            #[cfg(target_os = "macos")]
             callback_user_data: AtomicUsize::new(0),
+            #[cfg(not(target_os = "macos"))]
+            software_encoder: Mutex::new(super::SoftwareH264Encoder::new(Default::default(), 30)),
             shared_frames_read: AtomicU64::new(0),
             encode_submissions: AtomicU64::new(0),
             encode_failures: AtomicU64::new(0),

--- a/packages/server/src/transport/webrtc.rs
+++ b/packages/server/src/transport/webrtc.rs
@@ -206,6 +206,15 @@ pub async fn create_answer(
             "WebRTC payload must include type `offer`.",
         ));
     }
+    // Both the iOS simulator session and the Android emulator source encode
+    // through the macOS native bridge. Non-macOS builds link `native_stubs.c`,
+    // so fail here with the platform explanation instead of letting the stub
+    // encoder fail deeper in the pipeline.
+    if !crate::platform::live_video_supported() {
+        return Err(AppError::unsupported(
+            crate::platform::live_video_unsupported_message(),
+        ));
+    }
     let is_android = android::is_android_id(&udid);
     if payload.transport.is_some() {
         return Err(AppError::bad_request(

--- a/packages/server/src/transport/webrtc.rs
+++ b/packages/server/src/transport/webrtc.rs
@@ -3250,7 +3250,9 @@ mod tests {
 
         assert_eq!((width, height), (4, 2));
         let red_values = rgba
-            .chunks_exact(4)
+            .as_chunks::<4>()
+            .0
+            .iter()
             .map(|pixel| pixel[0])
             .collect::<Vec<_>>();
         assert_eq!(red_values, vec![1, 2, 3, 3, 4, 5, 6, 6]);

--- a/packages/server/src/transport/webrtc.rs
+++ b/packages/server/src/transport/webrtc.rs
@@ -10,17 +10,25 @@ use crate::api::routes::{
 };
 use crate::error::AppError;
 use crate::metrics::counters::ClientStreamStats;
+#[cfg(target_os = "macos")]
 use crate::native::ffi;
 use crate::transport::packet::{FramePacket, SharedFrame};
+#[cfg(not(target_os = "macos"))]
+use crate::transport::software_h264::{EncodedH264Frame, SoftwareH264Encoder};
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::{HashMap, VecDeque};
+#[cfg(target_os = "macos")]
 use std::ffi::{c_void, CStr, CString};
 use std::net::{SocketAddr, TcpStream};
+#[cfg(target_os = "macos")]
 use std::ptr;
+#[cfg(target_os = "macos")]
 use std::slice;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+#[cfg(target_os = "macos")]
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, RwLock, Weak};
 use std::thread;
 use std::time::Duration;
@@ -206,16 +214,16 @@ pub async fn create_answer(
             "WebRTC payload must include type `offer`.",
         ));
     }
-    // Both the iOS simulator session and the Android emulator source encode
-    // through the macOS native bridge. Non-macOS builds link `native_stubs.c`,
-    // so fail here with the platform explanation instead of letting the stub
-    // encoder fail deeper in the pipeline.
-    if !crate::platform::live_video_supported() {
+    let is_android = android::is_android_id(&udid);
+    // Android emulator frames encode in Rust on every platform. iOS simulator
+    // sessions need the macOS native bridge, which non-macOS builds replace
+    // with `native_stubs.c`, so answer with the platform explanation instead of
+    // letting the stubbed session fail deeper in the pipeline.
+    if !is_android && !crate::platform::ios_simulator_supported() {
         return Err(AppError::unsupported(
-            crate::platform::live_video_unsupported_message(),
+            crate::platform::ios_simulator_unsupported_message(),
         ));
     }
-    let is_android = android::is_android_id(&udid);
     if payload.transport.is_some() {
         return Err(AppError::bad_request(
             "Unsupported WebRTC transport. SimDeck streams WebRTC video over media tracks.",
@@ -1378,6 +1386,9 @@ fn ice_transport_policy() -> RTCIceTransportPolicy {
     }
 }
 
+#[cfg(not(target_os = "macos"))]
+type SoftwareEncodeResult = Result<Option<EncodedH264Frame>, AppError>;
+
 #[derive(Clone)]
 pub(crate) struct AndroidWebRtcSource {
     inner: Arc<AndroidWebRtcSourceInner>,
@@ -1393,8 +1404,12 @@ struct AndroidWebRtcSourceInner {
     frame_sequence: AtomicU64,
     quality: Mutex<android::AndroidH264StreamQuality>,
     source_kind: RwLock<&'static str>,
+    #[cfg(target_os = "macos")]
     encoder_handle: AtomicUsize,
+    #[cfg(target_os = "macos")]
     callback_user_data: AtomicUsize,
+    #[cfg(not(target_os = "macos"))]
+    software_encoder: Mutex<SoftwareH264Encoder>,
     shared_frames_read: AtomicU64,
     encode_submissions: AtomicU64,
     encode_failures: AtomicU64,
@@ -1450,8 +1465,15 @@ impl AndroidWebRtcSource {
             frame_sequence: AtomicU64::new(0),
             quality: Mutex::new(config.quality),
             source_kind: RwLock::new("shared-video"),
+            #[cfg(target_os = "macos")]
             encoder_handle: AtomicUsize::new(0),
+            #[cfg(target_os = "macos")]
             callback_user_data: AtomicUsize::new(0),
+            #[cfg(not(target_os = "macos"))]
+            software_encoder: Mutex::new(SoftwareH264Encoder::new(
+                config.quality,
+                android_h264_target_fps(config.quality),
+            )),
             shared_frames_read: AtomicU64::new(0),
             encode_submissions: AtomicU64::new(0),
             encode_failures: AtomicU64::new(0),
@@ -1469,6 +1491,7 @@ impl AndroidWebRtcSource {
         });
 
         let source = Self { inner };
+        #[cfg(target_os = "macos")]
         source.inner.create_native_encoder()?;
         sources.push(Arc::downgrade(&source.inner));
         drop(sources);
@@ -1849,6 +1872,14 @@ fn android_shutdown_requested(receiver: &mut broadcast::Receiver<()>) -> bool {
 impl Drop for AndroidWebRtcSourceInner {
     fn drop(&mut self) {
         let _ = self.shutdown_tx.send(());
+        #[cfg(target_os = "macos")]
+        self.release_native_encoder();
+    }
+}
+
+impl AndroidWebRtcSourceInner {
+    #[cfg(target_os = "macos")]
+    fn release_native_encoder(&mut self) {
         let handle = self.encoder_handle.swap(0, Ordering::AcqRel);
         if handle != 0 {
             unsafe {
@@ -1862,9 +1893,8 @@ impl Drop for AndroidWebRtcSourceInner {
             }
         }
     }
-}
 
-impl AndroidWebRtcSourceInner {
+    #[cfg(target_os = "macos")]
     fn create_native_encoder(self: &Arc<Self>) -> Result<(), AppError> {
         let weak = Arc::downgrade(self);
         let user_data = Weak::into_raw(weak) as *mut c_void;
@@ -1951,6 +1981,11 @@ impl AndroidWebRtcSourceInner {
             *self.latest_keyframe.write().unwrap() = None;
         }
         drop(current);
+        #[cfg(not(target_os = "macos"))]
+        self.software_encoder
+            .lock()
+            .unwrap()
+            .reconfigure(quality, android_h264_target_fps(quality));
         self.request_keyframe();
     }
 
@@ -1958,12 +1993,17 @@ impl AndroidWebRtcSourceInner {
         self.metrics
             .keyframe_requests
             .fetch_add(1, Ordering::Relaxed);
-        let handle = self.encoder_handle.load(Ordering::Acquire);
-        if handle != 0 {
-            unsafe {
-                ffi::xcw_native_h264_encoder_request_keyframe(handle as *mut c_void);
+        #[cfg(target_os = "macos")]
+        {
+            let handle = self.encoder_handle.load(Ordering::Acquire);
+            if handle != 0 {
+                unsafe {
+                    ffi::xcw_native_h264_encoder_request_keyframe(handle as *mut c_void);
+                }
             }
         }
+        #[cfg(not(target_os = "macos"))]
+        self.software_encoder.lock().unwrap().request_keyframe();
     }
 
     fn stats_snapshot(&self) -> Value {
@@ -2000,6 +2040,12 @@ impl AndroidWebRtcSourceInner {
         })
     }
 
+    #[cfg(not(target_os = "macos"))]
+    fn native_encoder_stats(&self) -> Value {
+        self.software_encoder.lock().unwrap().stats()
+    }
+
+    #[cfg(target_os = "macos")]
     fn native_encoder_stats(&self) -> Value {
         let handle = self.encoder_handle.load(Ordering::Acquire);
         if handle == 0 {
@@ -2017,6 +2063,70 @@ impl AndroidWebRtcSourceInner {
         }
     }
 
+    #[cfg(not(target_os = "macos"))]
+    fn encode_android_shared_video_frame(
+        &self,
+        frame: &android::AndroidSharedVideoFrame,
+    ) -> Result<(), AppError> {
+        self.encode_software_frame(frame.width, frame.height, frame.timestamp_us, |encoder| {
+            encoder.encode_bgra(&frame.bgra, frame.width, frame.height)
+        })
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    fn encode_android_rgba_frame(
+        &self,
+        rgba: &[u8],
+        width: u32,
+        height: u32,
+        timestamp_us: u64,
+    ) -> Result<(), AppError> {
+        self.encode_software_frame(width, height, timestamp_us, |encoder| {
+            encoder.encode_rgba(rgba, width, height)
+        })
+    }
+
+    /// Runs one frame through the OpenH264 encoder and publishes the result
+    /// the same way the macOS native callback does.
+    #[cfg(not(target_os = "macos"))]
+    fn encode_software_frame(
+        &self,
+        width: u32,
+        height: u32,
+        timestamp_us: u64,
+        encode: impl FnOnce(&mut SoftwareH264Encoder) -> SoftwareEncodeResult,
+    ) -> Result<(), AppError> {
+        let submit_started = Instant::now();
+        self.encode_submissions.fetch_add(1, Ordering::Relaxed);
+        let result = {
+            let mut encoder = self.software_encoder.lock().unwrap();
+            encode(&mut encoder)
+        };
+        self.latest_encode_submit_us
+            .store(duration_us(submit_started.elapsed()), Ordering::Relaxed);
+        match result {
+            Ok(Some(frame)) => {
+                self.publish_frame(FramePacket {
+                    frame_sequence: 0,
+                    timestamp_us,
+                    is_keyframe: frame.is_keyframe,
+                    width,
+                    height,
+                    codec: Some("h264".to_owned()),
+                    description: None,
+                    data: frame.data,
+                });
+                Ok(())
+            }
+            Ok(None) => Ok(()),
+            Err(error) => {
+                self.encode_failures.fetch_add(1, Ordering::Relaxed);
+                Err(error)
+            }
+        }
+    }
+
+    #[cfg(target_os = "macos")]
     fn encode_android_shared_video_frame(
         &self,
         frame: &android::AndroidSharedVideoFrame,
@@ -2050,6 +2160,7 @@ impl AndroidWebRtcSourceInner {
         Ok(())
     }
 
+    #[cfg(target_os = "macos")]
     fn encode_android_rgba_frame(
         &self,
         rgba: &[u8],
@@ -2086,15 +2197,15 @@ impl AndroidWebRtcSourceInner {
         Ok(())
     }
 
+    #[cfg(target_os = "macos")]
     fn handle_encoded_frame(&self, frame: &ffi::xcw_native_frame) {
         let Some(data) = (unsafe { copy_native_shared_bytes(frame.data) }) else {
             return;
         };
         let description = unsafe { copy_native_shared_bytes(frame.description) };
         let codec = unsafe { native_c_string(frame.codec) };
-        let frame_sequence = self.frame_sequence.fetch_add(1, Ordering::Relaxed) + 1;
-        let packet = Arc::new(FramePacket {
-            frame_sequence,
+        self.publish_frame(FramePacket {
+            frame_sequence: 0,
             timestamp_us: frame.timestamp_us,
             is_keyframe: frame.is_keyframe,
             width: frame.width,
@@ -2103,6 +2214,13 @@ impl AndroidWebRtcSourceInner {
             description,
             data,
         });
+    }
+
+    /// Assigns the next frame sequence number and fans the packet out to
+    /// WebRTC subscribers, remembering keyframes for late joiners.
+    fn publish_frame(&self, mut packet: FramePacket) {
+        packet.frame_sequence = self.frame_sequence.fetch_add(1, Ordering::Relaxed) + 1;
+        let packet = Arc::new(packet);
         self.metrics.frames_encoded.fetch_add(1, Ordering::Relaxed);
         if packet.is_keyframe {
             self.metrics
@@ -2114,6 +2232,7 @@ impl AndroidWebRtcSourceInner {
     }
 }
 
+#[cfg(target_os = "macos")]
 unsafe extern "C" fn android_h264_encoder_frame_callback(
     frame: *const ffi::xcw_native_frame,
     user_data: *mut c_void,
@@ -2129,6 +2248,7 @@ unsafe extern "C" fn android_h264_encoder_frame_callback(
     let _ = Weak::into_raw(weak);
 }
 
+#[cfg(target_os = "macos")]
 unsafe fn copy_native_shared_bytes(bytes: ffi::xcw_native_shared_bytes) -> Option<Bytes> {
     let copied = if bytes.data.is_null() || bytes.length == 0 {
         None
@@ -2142,6 +2262,7 @@ unsafe fn copy_native_shared_bytes(bytes: ffi::xcw_native_shared_bytes) -> Optio
     copied
 }
 
+#[cfg(target_os = "macos")]
 unsafe fn native_c_string(value: *const i8) -> Option<String> {
     if value.is_null() {
         return None;
@@ -2149,6 +2270,7 @@ unsafe fn native_c_string(value: *const i8) -> Option<String> {
     CStr::from_ptr(value).to_str().ok().map(ToOwned::to_owned)
 }
 
+#[cfg(target_os = "macos")]
 unsafe fn take_native_string(value: *mut i8) -> Option<String> {
     if value.is_null() {
         return None;
@@ -2158,6 +2280,7 @@ unsafe fn take_native_string(value: *mut i8) -> Option<String> {
     string
 }
 
+#[cfg(target_os = "macos")]
 unsafe fn take_native_error(error: *mut i8, fallback: &str) -> AppError {
     if error.is_null() {
         return AppError::native(fallback);

--- a/scripts/build-cli.mjs
+++ b/scripts/build-cli.mjs
@@ -6,10 +6,10 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
-  isWindowsGnuTarget,
-  mingwRuntimeImports,
+  isWindowsTarget,
   targetRustflagsEnvName,
-  windowsGnuRustflags,
+  windowsRuntimeImports,
+  windowsRustflags,
 } from "./windows-runtime.mjs";
 
 const rootDir = path.resolve(
@@ -43,11 +43,11 @@ const cargoArgs = ["build", "--release", "--manifest-path", manifestPath];
 if (target) {
   cargoArgs.push("--target", target);
 }
-if (isWindowsGnuTarget(target)) {
-  // Link the MinGW C++ runtime (OpenH264) statically so the shipped binary
-  // does not depend on libstdc++-6.dll, which plain Windows installs lack.
+if (isWindowsTarget(target)) {
+  // Link the C/C++ runtime (OpenH264 is C++) statically so the shipped
+  // binary does not depend on redistributable or MinGW DLLs.
   const envName = targetRustflagsEnvName(target);
-  process.env[envName] = windowsGnuRustflags(
+  process.env[envName] = windowsRustflags(
     process.env[envName] ?? process.env.RUSTFLAGS,
   );
   console.log(`${envName}=${process.env[envName]}`);
@@ -60,12 +60,12 @@ const serverBin = path.join(
   "release",
   `simdeck-server${targetExe(target) ?? hostExe}`,
 );
-if (isWindowsGnuTarget(target)) {
-  const runtimeImports = mingwRuntimeImports(fs.readFileSync(serverBin));
+if (isWindowsTarget(target)) {
+  const runtimeImports = windowsRuntimeImports(fs.readFileSync(serverBin));
   if (runtimeImports.length > 0) {
     console.error(
-      `${serverBin} imports the MinGW runtime (${runtimeImports.join(", ")}); ` +
-        "it would fail to start outside Git Bash. Check the +crt-static link flags.",
+      `${serverBin} imports toolchain runtime DLLs (${runtimeImports.join(", ")}); ` +
+        "it would fail to start on machines without them. Check the +crt-static link flags.",
     );
     process.exit(1);
   }

--- a/scripts/build-cli.mjs
+++ b/scripts/build-cli.mjs
@@ -5,6 +5,13 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import {
+  isWindowsGnuTarget,
+  mingwRuntimeImports,
+  targetRustflagsEnvName,
+  windowsGnuRustflags,
+} from "./windows-runtime.mjs";
+
 const rootDir = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "..",
@@ -36,6 +43,15 @@ const cargoArgs = ["build", "--release", "--manifest-path", manifestPath];
 if (target) {
   cargoArgs.push("--target", target);
 }
+if (isWindowsGnuTarget(target)) {
+  // Link the MinGW C++ runtime (OpenH264) statically so the shipped binary
+  // does not depend on libstdc++-6.dll, which plain Windows installs lack.
+  const envName = targetRustflagsEnvName(target);
+  process.env[envName] = windowsGnuRustflags(
+    process.env[envName] ?? process.env.RUSTFLAGS,
+  );
+  console.log(`${envName}=${process.env[envName]}`);
+}
 run("cargo", cargoArgs);
 
 const serverBin = path.join(
@@ -44,6 +60,16 @@ const serverBin = path.join(
   "release",
   `simdeck-server${targetExe(target) ?? hostExe}`,
 );
+if (isWindowsGnuTarget(target)) {
+  const runtimeImports = mingwRuntimeImports(fs.readFileSync(serverBin));
+  if (runtimeImports.length > 0) {
+    console.error(
+      `${serverBin} imports the MinGW runtime (${runtimeImports.join(", ")}); ` +
+        "it would fail to start outside Git Bash. Check the +crt-static link flags.",
+    );
+    process.exit(1);
+  }
+}
 const tmpOutputBin = `${outputBin}.tmp.${process.pid}`;
 fs.copyFileSync(serverBin, tmpOutputBin);
 if (process.platform !== "win32") {

--- a/scripts/github-actions.test.mjs
+++ b/scripts/github-actions.test.mjs
@@ -171,6 +171,25 @@ test("CI runs Android emulator integration on Linux and Windows", () => {
   assert.match(ciWorkflow, /test:integration:android/);
 });
 
+test("Windows Android CI builds the release's windows-gnu binary", () => {
+  // The release ships x86_64-pc-windows-gnu; the emulator job must exercise
+  // that exact binary from PowerShell so a MinGW runtime DLL dependency fails
+  // CI instead of the published package.
+  const windowsBuildStep = stepSlice(
+    ciWorkflow,
+    "Build Android integration artifacts (Windows, release target)",
+  );
+  assert.match(windowsBuildStep, /if:\s*runner\.os == 'Windows'/);
+  assert.match(
+    windowsBuildStep,
+    /SIMDECK_BUILD_TARGET:\s*x86_64-pc-windows-gnu/,
+  );
+  assert.match(windowsBuildStep, /rustup target add x86_64-pc-windows-gnu/);
+  assert.match(windowsBuildStep, /npm run build:cli/);
+  assert.match(releaseWorkflow, /SIMDECK_BUILD_TARGET=x86_64-pc-windows-gnu/);
+  assert.match(ciWorkflow, /npm run test:windows-runtime/);
+});
+
 test("Windows Android CI boot path is bounded and diagnostic", () => {
   const windowsBootStep = stepSlice(
     ciWorkflow,

--- a/scripts/github-actions.test.mjs
+++ b/scripts/github-actions.test.mjs
@@ -78,11 +78,89 @@ test("release workflow builds supported native CLI artifacts per platform", () =
   assert.match(releaseWorkflow, /simdeck-bin-linux-x64/);
   assert.match(releaseWorkflow, /actions\/download-artifact@v4/);
 
-  const verifyStep = releaseWorkflow.indexOf("Verify CLI artifacts are published");
+  const verifyStep = releaseWorkflow.indexOf(
+    "Verify CLI artifacts are published",
+  );
   const commitStep = releaseWorkflow.indexOf("Commit and push version bump");
   assert.ok(verifyStep !== -1, "artifact verification step should exist");
-  assert.ok(commitStep > verifyStep, "release commit should happen after artifact verification");
-  assert.match(releaseWorkflow, /test -f \\\"\$artifact\\\"/);
+  assert.ok(
+    commitStep > verifyStep,
+    "release commit should happen after artifact verification",
+  );
+  assert.match(releaseWorkflow, /test -f "\$artifact"/);
+});
+
+test("release workflow compiles native CLI artifacts from the bumped version", () => {
+  // The bug this guards against: native binaries were built before the release
+  // job bumped package.json/Cargo.toml, so simdeck@0.1.35 shipped a binary
+  // whose `--version` said 0.1.34.
+  assert.match(releaseWorkflow, /^  resolve-version:$/m);
+  assert.match(
+    releaseWorkflow,
+    /needs: \[resolve-version, build-native-artifacts\]/,
+  );
+  assert.match(releaseWorkflow, /needs\.resolve-version\.result == 'success'/);
+
+  const nativeJobStart = releaseWorkflow.indexOf("  build-native-artifacts:");
+  const releaseJobStart = releaseWorkflow.indexOf("  release:");
+  assert.ok(nativeJobStart !== -1 && releaseJobStart > nativeJobStart);
+  const nativeJob = releaseWorkflow.slice(nativeJobStart, releaseJobStart);
+
+  assert.match(nativeJob, /needs: resolve-version/);
+  assert.match(
+    nativeJob,
+    /NEW_VERSION: \$\{\{ needs\.resolve-version\.outputs\.version \}\}/,
+  );
+  assert.match(
+    nativeJob,
+    /cargo update --manifest-path packages\/server\/Cargo\.toml -p simdeck-server --precise "\$NEW_VERSION"/,
+  );
+
+  const syncStep = nativeJob.indexOf("- name: Sync Rust CLI version");
+  const buildStep = nativeJob.indexOf("- name: Build native artifact");
+  const checkStep = nativeJob.indexOf(
+    "- name: Verify native artifact reports the release version",
+  );
+  const uploadStep = nativeJob.indexOf("- name: Upload artifact");
+  assert.ok(syncStep !== -1, "native build should sync the crate version");
+  assert.ok(
+    buildStep > syncStep,
+    "crate version must be synced before compiling",
+  );
+  assert.ok(checkStep > buildStep, "built binary should be version-checked");
+  assert.ok(uploadStep > checkStep, "version check must pass before uploading");
+  assert.match(nativeJob, /"\$BINARY" --version/);
+  for (const binary of [
+    "build/simdeck-bin-darwin-arm64",
+    "build/simdeck-bin-darwin-x64",
+    "build/simdeck-bin-linux-x64",
+    "build/simdeck-bin-win32-x64.exe",
+  ]) {
+    assert.ok(
+      nativeJob.includes(`binary: ${binary}`),
+      `${binary} should be declared in the native build matrix`,
+    );
+  }
+
+  const releaseJob = releaseWorkflow.slice(releaseJobStart);
+  assert.match(
+    releaseJob,
+    /RESOLVED_VERSION: \$\{\{ needs\.resolve-version\.outputs\.version \}\}/,
+  );
+  assert.match(
+    releaseJob,
+    /npm version "\$version" --no-git-tag-version --allow-same-version/,
+  );
+  const verifyStep = releaseJob.indexOf(
+    "- name: Verify CLI artifacts are published",
+  );
+  const commitStep = releaseJob.indexOf("- name: Commit and push version bump");
+  const verifyBody = releaseJob.slice(verifyStep, commitStep);
+  assert.match(
+    verifyBody,
+    /for artifact in build\/simdeck-bin build\/simdeck-bin-darwin-arm64; do/,
+  );
+  assert.match(verifyBody, /"\$artifact" --version/);
 });
 
 test("CI runs Android emulator integration on Linux and Windows", () => {

--- a/scripts/github-actions.test.mjs
+++ b/scripts/github-actions.test.mjs
@@ -171,10 +171,10 @@ test("CI runs Android emulator integration on Linux and Windows", () => {
   assert.match(ciWorkflow, /test:integration:android/);
 });
 
-test("Windows Android CI builds the release's windows-gnu binary", () => {
-  // The release ships x86_64-pc-windows-gnu; the emulator job must exercise
-  // that exact binary from PowerShell so a MinGW runtime DLL dependency fails
-  // CI instead of the published package.
+test("Windows Android CI builds the release's windows-msvc binary", () => {
+  // The release ships x86_64-pc-windows-msvc with a static CRT; the emulator
+  // job must exercise that exact binary from PowerShell so a runtime DLL
+  // dependency fails CI instead of the published package.
   const windowsBuildStep = stepSlice(
     ciWorkflow,
     "Build Android integration artifacts (Windows, release target)",
@@ -182,11 +182,11 @@ test("Windows Android CI builds the release's windows-gnu binary", () => {
   assert.match(windowsBuildStep, /if:\s*runner\.os == 'Windows'/);
   assert.match(
     windowsBuildStep,
-    /SIMDECK_BUILD_TARGET:\s*x86_64-pc-windows-gnu/,
+    /SIMDECK_BUILD_TARGET:\s*x86_64-pc-windows-msvc/,
   );
-  assert.match(windowsBuildStep, /rustup target add x86_64-pc-windows-gnu/);
   assert.match(windowsBuildStep, /npm run build:cli/);
-  assert.match(releaseWorkflow, /SIMDECK_BUILD_TARGET=x86_64-pc-windows-gnu/);
+  assert.match(releaseWorkflow, /SIMDECK_BUILD_TARGET=x86_64-pc-windows-msvc/);
+  assert.doesNotMatch(releaseWorkflow, /windows-gnu|choco install mingw/);
   assert.match(ciWorkflow, /npm run test:windows-runtime/);
 });
 

--- a/scripts/windows-runtime.mjs
+++ b/scripts/windows-runtime.mjs
@@ -1,35 +1,46 @@
-// Helpers for shipping a self-contained Windows binary from the
-// `x86_64-pc-windows-gnu` target.
+// Helpers for shipping a self-contained Windows binary.
 //
-// The OpenH264 encoder is C++ compiled by the MinGW toolchain, which links
-// `libstdc++-6.dll` dynamically by default. That DLL only exists inside
-// MinGW/Git Bash installs, so a plain PowerShell or cmd launch of the binary
-// fails with STATUS_DLL_NOT_FOUND (0xC0000135) and a modal error dialog.
+// The OpenH264 encoder is C++. Built with the MinGW toolchain
+// (`x86_64-pc-windows-gnu`) it links `libstdc++-6.dll`, which only exists
+// inside MinGW/Git Bash installs; built with MSVC without a static CRT it
+// links `vcruntime140.dll`/`msvcp140.dll`, which not every machine has. Either
+// way a plain PowerShell or cmd launch fails with STATUS_DLL_NOT_FOUND
+// (0xC0000135) and a modal error dialog instead of the service URL. The
+// release therefore targets `x86_64-pc-windows-msvc` with `+crt-static`, and
+// the packaging step refuses any binary that still imports a runtime DLL.
 
-/** MinGW runtime DLLs that a shipped SimDeck binary must never import. */
-export const MINGW_RUNTIME_DLLS = [
+/** Toolchain runtime DLLs that a shipped SimDeck binary must never import. */
+export const WINDOWS_RUNTIME_DLLS = [
+  // MinGW
   "libstdc++-6.dll",
   "libgcc_s_seh-1.dll",
   "libgcc_s_dw2-1.dll",
   "libwinpthread-1.dll",
+  // MSVC redistributable
+  "vcruntime140.dll",
+  "vcruntime140_1.dll",
+  "msvcp140.dll",
+  "msvcp140_1.dll",
+  "msvcp140_2.dll",
+  "concrt140.dll",
 ];
 
 const CRT_STATIC_FLAG = "-C target-feature=+crt-static";
 
-export function isWindowsGnuTarget(target) {
-  return typeof target === "string" && /-windows-gnu(llvm)?$/.test(target);
+export function isWindowsTarget(target) {
+  return typeof target === "string" && /-windows-/.test(target);
 }
 
-/** Cargo's per-target RUSTFLAGS variable, e.g. CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS. */
+/** Cargo's per-target RUSTFLAGS variable, e.g. CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_RUSTFLAGS. */
 export function targetRustflagsEnvName(target) {
   return `CARGO_TARGET_${target.toUpperCase().replace(/-/g, "_")}_RUSTFLAGS`;
 }
 
 /**
- * Adds `+crt-static` to existing RUSTFLAGS so rustc links the executable with
- * `-static`, which resolves the MinGW C++ runtime from static archives.
+ * Adds `+crt-static` to existing RUSTFLAGS so rustc and the `cc` crate link
+ * the C/C++ runtime statically (`/MT` on MSVC).
  */
-export function windowsGnuRustflags(existing) {
+export function windowsRustflags(existing) {
   const current = existing?.trim() ?? "";
   if (current.includes("+crt-static")) {
     return current;
@@ -117,8 +128,8 @@ export function peImportedDlls(binary) {
   return names;
 }
 
-/** MinGW runtime DLLs imported by a PE binary, empty for a self-contained one. */
-export function mingwRuntimeImports(binary) {
+/** Toolchain runtime DLLs imported by a PE binary, empty for a self-contained one. */
+export function windowsRuntimeImports(binary) {
   const imported = new Set(peImportedDlls(binary));
-  return MINGW_RUNTIME_DLLS.filter((dll) => imported.has(dll));
+  return WINDOWS_RUNTIME_DLLS.filter((dll) => imported.has(dll));
 }

--- a/scripts/windows-runtime.mjs
+++ b/scripts/windows-runtime.mjs
@@ -1,0 +1,124 @@
+// Helpers for shipping a self-contained Windows binary from the
+// `x86_64-pc-windows-gnu` target.
+//
+// The OpenH264 encoder is C++ compiled by the MinGW toolchain, which links
+// `libstdc++-6.dll` dynamically by default. That DLL only exists inside
+// MinGW/Git Bash installs, so a plain PowerShell or cmd launch of the binary
+// fails with STATUS_DLL_NOT_FOUND (0xC0000135) and a modal error dialog.
+
+/** MinGW runtime DLLs that a shipped SimDeck binary must never import. */
+export const MINGW_RUNTIME_DLLS = [
+  "libstdc++-6.dll",
+  "libgcc_s_seh-1.dll",
+  "libgcc_s_dw2-1.dll",
+  "libwinpthread-1.dll",
+];
+
+const CRT_STATIC_FLAG = "-C target-feature=+crt-static";
+
+export function isWindowsGnuTarget(target) {
+  return typeof target === "string" && /-windows-gnu(llvm)?$/.test(target);
+}
+
+/** Cargo's per-target RUSTFLAGS variable, e.g. CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS. */
+export function targetRustflagsEnvName(target) {
+  return `CARGO_TARGET_${target.toUpperCase().replace(/-/g, "_")}_RUSTFLAGS`;
+}
+
+/**
+ * Adds `+crt-static` to existing RUSTFLAGS so rustc links the executable with
+ * `-static`, which resolves the MinGW C++ runtime from static archives.
+ */
+export function windowsGnuRustflags(existing) {
+  const current = existing?.trim() ?? "";
+  if (current.includes("+crt-static")) {
+    return current;
+  }
+  return current ? `${current} ${CRT_STATIC_FLAG}` : CRT_STATIC_FLAG;
+}
+
+/** Returns the lower-cased DLL names in a PE file's import directory. */
+export function peImportedDlls(binary) {
+  const view = Buffer.isBuffer(binary) ? binary : Buffer.from(binary);
+  if (view.length < 0x40 || view.readUInt16LE(0) !== 0x5a4d) {
+    throw new Error("Not a PE file: missing MZ header.");
+  }
+  const peOffset = view.readUInt32LE(0x3c);
+  if (view.readUInt32LE(peOffset) !== 0x00004550) {
+    throw new Error("Not a PE file: missing PE signature.");
+  }
+  const coffOffset = peOffset + 4;
+  const sectionCount = view.readUInt16LE(coffOffset + 2);
+  const optionalHeaderSize = view.readUInt16LE(coffOffset + 16);
+  const optionalOffset = coffOffset + 20;
+  const magic = view.readUInt16LE(optionalOffset);
+  const dataDirectoryOffset =
+    magic === 0x20b
+      ? optionalOffset + 112
+      : magic === 0x10b
+        ? optionalOffset + 96
+        : null;
+  if (dataDirectoryOffset === null) {
+    throw new Error(
+      `Unknown PE optional header magic 0x${magic.toString(16)}.`,
+    );
+  }
+  const importTableRva = view.readUInt32LE(dataDirectoryOffset + 8);
+  if (importTableRva === 0) {
+    return [];
+  }
+
+  const sections = [];
+  const sectionsOffset = optionalOffset + optionalHeaderSize;
+  for (let index = 0; index < sectionCount; index += 1) {
+    const offset = sectionsOffset + index * 40;
+    const virtualSize = view.readUInt32LE(offset + 8);
+    const virtualAddress = view.readUInt32LE(offset + 12);
+    const rawSize = view.readUInt32LE(offset + 16);
+    const rawOffset = view.readUInt32LE(offset + 20);
+    sections.push({
+      virtualAddress,
+      size: Math.max(virtualSize, rawSize),
+      rawOffset,
+    });
+  }
+  const rvaToOffset = (rva) => {
+    const section = sections.find(
+      (candidate) =>
+        rva >= candidate.virtualAddress &&
+        rva < candidate.virtualAddress + candidate.size,
+    );
+    if (!section) {
+      throw new Error(`PE RVA 0x${rva.toString(16)} is outside every section.`);
+    }
+    return rva - section.virtualAddress + section.rawOffset;
+  };
+  const readCString = (offset) => {
+    let end = offset;
+    while (end < view.length && view[end] !== 0) {
+      end += 1;
+    }
+    return view.toString("latin1", offset, end);
+  };
+
+  const names = [];
+  let descriptor = rvaToOffset(importTableRva);
+  while (descriptor + 20 <= view.length) {
+    const nameRva = view.readUInt32LE(descriptor + 12);
+    const firstThunk = view.readUInt32LE(descriptor + 16);
+    if (nameRva === 0 && firstThunk === 0) {
+      break;
+    }
+    if (nameRva !== 0) {
+      names.push(readCString(rvaToOffset(nameRva)).toLowerCase());
+    }
+    descriptor += 20;
+  }
+  return names;
+}
+
+/** MinGW runtime DLLs imported by a PE binary, empty for a self-contained one. */
+export function mingwRuntimeImports(binary) {
+  const imported = new Set(peImportedDlls(binary));
+  return MINGW_RUNTIME_DLLS.filter((dll) => imported.has(dll));
+}

--- a/scripts/windows-runtime.test.mjs
+++ b/scripts/windows-runtime.test.mjs
@@ -2,11 +2,11 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import {
-  isWindowsGnuTarget,
-  mingwRuntimeImports,
+  isWindowsTarget,
   peImportedDlls,
   targetRustflagsEnvName,
-  windowsGnuRustflags,
+  windowsRuntimeImports,
+  windowsRustflags,
 } from "./windows-runtime.mjs";
 
 /** Builds a minimal PE32+ image whose import directory names `dlls`. */
@@ -52,23 +52,24 @@ function buildPeWithImports(dlls) {
   return image;
 }
 
-test("windows-gnu targets get +crt-static in their target RUSTFLAGS", () => {
-  assert.equal(isWindowsGnuTarget("x86_64-pc-windows-gnu"), true);
-  assert.equal(isWindowsGnuTarget("x86_64-pc-windows-gnullvm"), true);
-  assert.equal(isWindowsGnuTarget("x86_64-pc-windows-msvc"), false);
-  assert.equal(isWindowsGnuTarget("x86_64-unknown-linux-gnu"), false);
-  assert.equal(isWindowsGnuTarget(undefined), false);
+test("Windows targets get +crt-static in their target RUSTFLAGS", () => {
+  assert.equal(isWindowsTarget("x86_64-pc-windows-msvc"), true);
+  assert.equal(isWindowsTarget("x86_64-pc-windows-gnu"), true);
+  assert.equal(isWindowsTarget("aarch64-pc-windows-msvc"), true);
+  assert.equal(isWindowsTarget("x86_64-unknown-linux-gnu"), false);
+  assert.equal(isWindowsTarget("aarch64-apple-darwin"), false);
+  assert.equal(isWindowsTarget(undefined), false);
   assert.equal(
-    targetRustflagsEnvName("x86_64-pc-windows-gnu"),
-    "CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS",
+    targetRustflagsEnvName("x86_64-pc-windows-msvc"),
+    "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_RUSTFLAGS",
   );
-  assert.equal(windowsGnuRustflags(undefined), "-C target-feature=+crt-static");
+  assert.equal(windowsRustflags(undefined), "-C target-feature=+crt-static");
   assert.equal(
-    windowsGnuRustflags("-C opt-level=3 "),
+    windowsRustflags("-C opt-level=3 "),
     "-C opt-level=3 -C target-feature=+crt-static",
   );
   assert.equal(
-    windowsGnuRustflags("-C target-feature=+crt-static"),
+    windowsRustflags("-C target-feature=+crt-static"),
     "-C target-feature=+crt-static",
   );
 });
@@ -86,9 +87,9 @@ test("PE import directory lists every imported DLL", () => {
   ]);
 });
 
-test("MinGW runtime imports are reported and a static binary passes", () => {
+test("toolchain runtime imports are reported and a static binary passes", () => {
   assert.deepEqual(
-    mingwRuntimeImports(
+    windowsRuntimeImports(
       buildPeWithImports([
         "kernel32.dll",
         "libwinpthread-1.dll",
@@ -98,7 +99,19 @@ test("MinGW runtime imports are reported and a static binary passes", () => {
     ["libstdc++-6.dll", "libwinpthread-1.dll"],
   );
   assert.deepEqual(
-    mingwRuntimeImports(buildPeWithImports(["kernel32.dll", "ws2_32.dll"])),
+    windowsRuntimeImports(
+      buildPeWithImports(["KERNEL32.dll", "VCRUNTIME140.dll", "MSVCP140.dll"]),
+    ),
+    ["vcruntime140.dll", "msvcp140.dll"],
+  );
+  assert.deepEqual(
+    windowsRuntimeImports(
+      buildPeWithImports([
+        "kernel32.dll",
+        "ws2_32.dll",
+        "api-ms-win-crt-runtime-l1-1-0.dll",
+      ]),
+    ),
     [],
   );
 });

--- a/scripts/windows-runtime.test.mjs
+++ b/scripts/windows-runtime.test.mjs
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  isWindowsGnuTarget,
+  mingwRuntimeImports,
+  peImportedDlls,
+  targetRustflagsEnvName,
+  windowsGnuRustflags,
+} from "./windows-runtime.mjs";
+
+/** Builds a minimal PE32+ image whose import directory names `dlls`. */
+function buildPeWithImports(dlls) {
+  const sectionRva = 0x1000;
+  const sectionRawOffset = 0x200;
+  const descriptorsSize = (dlls.length + 1) * 20;
+  const nameBlobs = dlls.map((dll) => Buffer.from(`${dll}\0`, "latin1"));
+  const namesSize = nameBlobs.reduce((total, blob) => total + blob.length, 0);
+  const section = Buffer.alloc(descriptorsSize + namesSize);
+  let nameRva = sectionRva + descriptorsSize;
+  let nameOffset = descriptorsSize;
+  dlls.forEach((_, index) => {
+    const descriptor = index * 20;
+    section.writeUInt32LE(nameRva, descriptor + 12);
+    section.writeUInt32LE(sectionRva + 0x800, descriptor + 16);
+    nameBlobs[index].copy(section, nameOffset);
+    nameRva += nameBlobs[index].length;
+    nameOffset += nameBlobs[index].length;
+  });
+
+  const peOffset = 0x40;
+  const optionalHeaderSize = 240;
+  const image = Buffer.alloc(sectionRawOffset + section.length);
+  image.writeUInt16LE(0x5a4d, 0);
+  image.writeUInt32LE(peOffset, 0x3c);
+  image.writeUInt32LE(0x00004550, peOffset);
+  const coffOffset = peOffset + 4;
+  image.writeUInt16LE(0x8664, coffOffset);
+  image.writeUInt16LE(1, coffOffset + 2);
+  image.writeUInt16LE(optionalHeaderSize, coffOffset + 16);
+  const optionalOffset = coffOffset + 20;
+  image.writeUInt16LE(0x20b, optionalOffset);
+  image.writeUInt32LE(sectionRva, optionalOffset + 112 + 8);
+  image.writeUInt32LE(section.length, optionalOffset + 112 + 12);
+  const sectionHeader = optionalOffset + optionalHeaderSize;
+  image.write(".idata", sectionHeader, "latin1");
+  image.writeUInt32LE(section.length, sectionHeader + 8);
+  image.writeUInt32LE(sectionRva, sectionHeader + 12);
+  image.writeUInt32LE(section.length, sectionHeader + 16);
+  image.writeUInt32LE(sectionRawOffset, sectionHeader + 20);
+  section.copy(image, sectionRawOffset);
+  return image;
+}
+
+test("windows-gnu targets get +crt-static in their target RUSTFLAGS", () => {
+  assert.equal(isWindowsGnuTarget("x86_64-pc-windows-gnu"), true);
+  assert.equal(isWindowsGnuTarget("x86_64-pc-windows-gnullvm"), true);
+  assert.equal(isWindowsGnuTarget("x86_64-pc-windows-msvc"), false);
+  assert.equal(isWindowsGnuTarget("x86_64-unknown-linux-gnu"), false);
+  assert.equal(isWindowsGnuTarget(undefined), false);
+  assert.equal(
+    targetRustflagsEnvName("x86_64-pc-windows-gnu"),
+    "CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS",
+  );
+  assert.equal(windowsGnuRustflags(undefined), "-C target-feature=+crt-static");
+  assert.equal(
+    windowsGnuRustflags("-C opt-level=3 "),
+    "-C opt-level=3 -C target-feature=+crt-static",
+  );
+  assert.equal(
+    windowsGnuRustflags("-C target-feature=+crt-static"),
+    "-C target-feature=+crt-static",
+  );
+});
+
+test("PE import directory lists every imported DLL", () => {
+  const image = buildPeWithImports([
+    "KERNEL32.dll",
+    "ws2_32.dll",
+    "libstdc++-6.dll",
+  ]);
+  assert.deepEqual(peImportedDlls(image), [
+    "kernel32.dll",
+    "ws2_32.dll",
+    "libstdc++-6.dll",
+  ]);
+});
+
+test("MinGW runtime imports are reported and a static binary passes", () => {
+  assert.deepEqual(
+    mingwRuntimeImports(
+      buildPeWithImports([
+        "kernel32.dll",
+        "libwinpthread-1.dll",
+        "libstdc++-6.dll",
+      ]),
+    ),
+    ["libstdc++-6.dll", "libwinpthread-1.dll"],
+  );
+  assert.deepEqual(
+    mingwRuntimeImports(buildPeWithImports(["kernel32.dll", "ws2_32.dll"])),
+    [],
+  );
+});
+
+test("non-PE input is rejected", () => {
+  assert.throws(() => peImportedDlls(Buffer.from("#!/bin/sh\n")), /MZ header/);
+});


### PR DESCRIPTION
## Summary

Android emulator live streaming now works on Windows and Linux. Those builds link `native_stubs.c` instead of the macOS simulator bridge, so the Android WebRTC source had no H.264 encoder and every stream failed with the stub error (rendered as raw JSON in the browser). Frame capture (emulator gRPC screenshots) and the WebRTC transport were already cross-platform Rust; only the encoder was missing.

### Encoder (non-macOS)
- New `packages/server/src/transport/software_h264.rs`: Cisco OpenH264 via the `openh264` crate, compiled from source (BSD, no system deps, supported on `x86_64-pc-windows-gnu`/`msvc` and Linux). Emits Annex B baseline H.264, which the existing packetizer and browsers already accept.
- Bitrate mirrors the macOS budget (bits per pixel with a minimum), keyframes honor RTCP PLI/FIR requests, the encoder rebuilds on size or quality changes, and stats surface under `androidEncoders[].encoder.native`.
- The Android WebRTC source is `cfg`-gated: macOS keeps the native VideoToolbox/x264 path behind the C ABI; other targets use the software encoder. Frame publishing is shared.

### Capability reporting and messaging
- `platform.rs` now describes iOS simulator support rather than "live video". `liveVideo` in `/api/health` and `/api/stream-quality` reports `supported: true`, `encoder` (`native` or `openh264`), `androidEmulator: true`, `iosSimulator` (macOS only) and `iosSimulatorReason` elsewhere.
- WebRTC offers for iOS simulators on non-macOS answer `501` with that reason (new `AppError::Unsupported`). Android offers proceed.
- The CLI prints a `Live video:` note on Windows/Linux; the browser unwraps JSON `error` bodies instead of showing raw JSON, and still pauses with a reason if a server ever reports `supported: false`.

### CI and docs
- New `rust-non-macos` job runs `cargo clippy -D warnings` and `cargo test` on Ubuntu and Windows, since the macOS job compiles out both the OpenH264 module and the native stubs.
- Per-platform encoder table in the video guide, install-guide platform support, health/REST field docs, troubleshooting entries, AGENTS pointer.

## Test plan
- [x] `npm run --prefix packages/client typecheck` and `npm run --prefix packages/client test` (104 tests)
- [x] CI: `rust` (macOS fmt/clippy/test) and the new `rust-non-macos` job (Ubuntu + Windows clippy/test, including the OpenH264 encoder tests) are green as of `7fb0e39`. Release run 34411749072 built all four native artifacts (macOS arm64/x64, Linux, Windows) with OpenH264.
- [ ] Windows: `simdeck` prints the `Live video:` note, `/api/health` reports `liveVideo.encoder: "openh264"`, boot an Android emulator and confirm the browser shows live video with touch input; `/api/metrics` shows `androidEncoders[].encoder.native.outputFrames` increasing.
- [ ] macOS: Android and iOS streams unchanged, `liveVideo.encoder: "native"`.
- [ ] `Cargo.lock` gains the `openh264` entries via the release version-bump commit (the workflow stages it).

Also fixed along the way: pre-existing lints that the new clippy 1.98 and the first non-macOS clippy run surfaced (`chunks_exact`, `needless_return`, unused imports, an unread `fd`, `result_large_err` in generated tonic code), and two `/bin/sh` log-stream tests are now Unix-only.

Follow-up worth considering: install `nasm` on the release runners for OpenH264's assembly paths (up to ~3x faster encoding); left out to keep the release build unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013K2GgwpF2vLSgz4otg8tmT
